### PR TITLE
 Fix typo in spanish translation: Proovedores -> Proveedores 

### DIFF
--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -337,7 +337,7 @@ msgstr "Episodios Recientes"
 
 msgctxt "#30239"
 msgid "Providers"
-msgstr "Proovedores"
+msgstr "Proveedores"
 
 msgctxt "#30240"
 msgid "Enable"

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -353,11 +353,11 @@ msgstr "Chequear"
 
 msgctxt "#30243"
 msgid "Provider failures"
-msgstr "Fallas de Proovedor"
+msgstr "Fallas de Proveedor"
 
 msgctxt "#30244"
 msgid "Provider settings"
-msgstr "Configuracion de Proovedores"
+msgstr "Configuracion de Proveedores"
 
 msgctxt "#30245"
 msgid "Popular on Trakt"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed a typo in the Spanish translation.
`Proovedores` is wrong, `Proveedores` is right

https://es.wiktionary.org/wiki/proveedor
