### PR TITLE
Extend maximum results per page to 50, and use viewmode for episodes "WideList" instead of "InfoWall" as default.

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -69,7 +69,7 @@
     <category label="30033">
         <!-- Appearance -->
         <setting label="30033" type="lsep" />
-        <setting id="results_per_page" label="30021" type="slider" option="int" range="3,1,30" default="9" />
+        <setting id="results_per_page" label="30021" type="slider" option="int" range="3,1,50" default="9" />
         <setting id="default_fanart" label="30092" type="bool" default="true" />
         <setting id="use_fanart_tv" label="30491" type="bool" default="false" />
         <setting id="do_not_disturb" label="30093" type="bool" default="false" />
@@ -79,7 +79,7 @@
         <setting id="viewmode_movies" label="30034" type="number" default="" />
         <setting id="viewmode_tvshows" label="30035" type="number" default="" />
         <setting id="viewmode_seasons" label="30036" type="number" default="" />
-        <setting id="viewmode_episodes" label="30037" type="number" default="" />
+        <setting id="viewmode_episodes" label="30037" type="number" default="55" />
         <setting id="viewmode_menus_movies" label="30142" type="number" default="" />
         <setting id="viewmode_menus_tvshows" label="30143" type="number" default="" />
         <setting id="viewmode_menus_movies_genres" label="30144" type="number" default="" />


### PR DESCRIPTION
Extend maximum results per page from 30 to 50, and use viewmode for episodes "WideList" instead of "InfoWall" as default.

