### PR TITLE
Make get_setting() work as it used to under Python2

### DIFF
--- a/resources/site-packages/elementum/provider.py
+++ b/resources/site-packages/elementum/provider.py
@@ -130,7 +130,12 @@ def extract_magnets(data):
 def get_setting(key, converter=str, choices=None):
     value = ADDON.getSetting(id=key)
     if converter is str:
-        return py2_decode(value)
+        if six.PY3:
+            return py2_decode(value)
+        else:
+            return value
+    elif converter is unicode and six.PY2:
+        return value.decode('utf-8')
     elif converter is bool:
         return value == 'true'
     elif converter is int:
@@ -138,9 +143,14 @@ def get_setting(key, converter=str, choices=None):
     elif isinstance(choices, (list, tuple)):
         return choices[int(value)]
     else:
-        raise TypeError('Acceptable converters are str, unicode, bool and '
-                        'int. Acceptable choices are instances of list '
-                        ' or tuple.')
+        if six.PY3:
+            raise TypeError('Acceptable converters are str, bool and '
+                            'int. Acceptable choices are instances of list '
+                            ' or tuple.')
+        else:
+            raise TypeError('Acceptable converters are str, unicode, bool and '
+                            'int. Acceptable choices are instances of list '
+                            ' or tuple.')
 
 
 def set_setting(key, val):


### PR DESCRIPTION
In particular make it compatible with Burst in its current state (Kodi
18 + Python 2).

<!--- Provide a general summary of your changes in the Title above -->

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
