### PR TITLE
Fix internal_dns_help label

### DIFF
--- a/resources/language/Croatian/strings.po
+++ b/resources/language/Croatian/strings.po
@@ -1442,12 +1442,12 @@ msgid "Use Proxy for torrent downloading"
 msgstr "Koristi proxy za preuzimanje torrenta"
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
-msgstr "Koristi unutrašnjeg DNS razrješitelja"
+msgid "Use internal DNS resolver (enable for Tor)"
+msgstr "Koristi unutrašnjeg DNS razrješitelja (omogućiti za Tor)"
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
-msgstr "Isključite ako koristite Tor adrese, ili želite proslijediti rješenje na postavke lokalne mreže"
+msgid "Turn off if you want to pass resolve to local network settings"
+msgstr "Isključite ako želite proslijediti rješenje na postavke lokalne mreže"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"

--- a/resources/language/Dutch/strings.po
+++ b/resources/language/Dutch/strings.po
@@ -1439,11 +1439,11 @@ msgid "Use Proxy for torrent downloading"
 msgstr ""
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
+msgid "Use internal DNS resolver (enable for Tor)"
 msgstr ""
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
+msgid "Turn off if you want to pass resolve to local network settings"
 msgstr ""
 
 msgctxt "#30498"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -1438,11 +1438,11 @@ msgid "Use Proxy for torrent downloading"
 msgstr ""
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
+msgid "Use internal DNS resolver (enable for Tor)"
 msgstr ""
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
+msgid "Turn off if you want to pass resolve to local network settings"
 msgstr ""
 
 msgctxt "#30498"

--- a/resources/language/Finnish/strings.po
+++ b/resources/language/Finnish/strings.po
@@ -1438,11 +1438,11 @@ msgid "Use Proxy for torrent downloading"
 msgstr ""
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
+msgid "Use internal DNS resolver (enable for Tor)"
 msgstr ""
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
+msgid "Turn off if you want to pass resolve to local network settings"
 msgstr ""
 
 msgctxt "#30498"

--- a/resources/language/French/strings.po
+++ b/resources/language/French/strings.po
@@ -1448,11 +1448,11 @@ msgid "Use Proxy for torrent downloading"
 msgstr ""
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
+msgid "Use internal DNS resolver (enable for Tor)"
 msgstr ""
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
+msgid "Turn off if you want to pass resolve to local network settings"
 msgstr ""
 
 msgctxt "#30498"

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -1442,11 +1442,11 @@ msgid "Use Proxy for torrent downloading"
 msgstr ""
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
+msgid "Use internal DNS resolver (enable for Tor)"
 msgstr ""
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
+msgid "Turn off if you want to pass resolve to local network settings"
 msgstr ""
 
 msgctxt "#30498"

--- a/resources/language/Greek/strings.po
+++ b/resources/language/Greek/strings.po
@@ -1442,12 +1442,12 @@ msgid "Use Proxy for torrent downloading"
 msgstr "Χρήση του proxy για λήψεις μεσω torrent"
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
-msgstr "Χρήση του ενσωματωμενου DNS resover"
+msgid "Use internal DNS resolver (enable for Tor)"
+msgstr "Χρήση του ενσωματωμενου DNS resover (ενεργοποίηση για Tor)"
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
-msgstr "Απενεργοποιήστε το αυτο αν χρησιμοποιειτε διευθύνσεις Tor"
+msgid "Turn off if you want to pass resolve to local network settings"
+msgstr "Απενεργοποιήστε εάν θέλετε να χρησιμοποιήσετε τις ρυθμίσεις τοπικού δικτύου για επίλυση ονόματος κεντρικού υπολογιστή"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"

--- a/resources/language/Hebrew/strings.po
+++ b/resources/language/Hebrew/strings.po
@@ -1443,11 +1443,11 @@ msgid "Use Proxy for torrent downloading"
 msgstr ""
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
+msgid "Use internal DNS resolver (enable for Tor)"
 msgstr ""
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
+msgid "Turn off if you want to pass resolve to local network settings"
 msgstr ""
 
 msgctxt "#30498"

--- a/resources/language/Hungarian/strings.po
+++ b/resources/language/Hungarian/strings.po
@@ -1440,11 +1440,11 @@ msgid "Use Proxy for torrent downloading"
 msgstr ""
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
+msgid "Use internal DNS resolver (enable for Tor)"
 msgstr ""
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
+msgid "Turn off if you want to pass resolve to local network settings"
 msgstr ""
 
 msgctxt "#30498"

--- a/resources/language/Italian/strings.po
+++ b/resources/language/Italian/strings.po
@@ -1439,12 +1439,12 @@ msgid "Use Proxy for torrent downloading"
 msgstr "Usa il Proxy per il download dei torrent"
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
+msgid "Use internal DNS resolver (enable for Tor)"
 msgstr "Usa il DNS interno per le rosoluzioni"
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
-msgstr "Disattivare se si utilizzano gli indirizzi Tor, o si desidera passare la risoluzione alle impostazioni della rete locale"
+msgid "Turn off if you want to pass resolve to local network settings"
+msgstr "Disattivare si desidera passare la risoluzione alle impostazioni della rete locale"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"

--- a/resources/language/Portuguese (Brazil)/strings.po
+++ b/resources/language/Portuguese (Brazil)/strings.po
@@ -1438,11 +1438,11 @@ msgid "Use Proxy for torrent downloading"
 msgstr ""
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
+msgid "Use internal DNS resolver (enable for Tor)"
 msgstr ""
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
+msgid "Turn off if you want to pass resolve to local network settings"
 msgstr ""
 
 msgctxt "#30498"

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -1438,11 +1438,11 @@ msgid "Use Proxy for torrent downloading"
 msgstr ""
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
+msgid "Use internal DNS resolver (enable for Tor)"
 msgstr ""
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
+msgid "Turn off if you want to pass resolve to local network settings"
 msgstr ""
 
 msgctxt "#30498"

--- a/resources/language/Romanian/strings.po
+++ b/resources/language/Romanian/strings.po
@@ -1442,11 +1442,11 @@ msgid "Use Proxy for torrent downloading"
 msgstr ""
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
+msgid "Use internal DNS resolver (enable for Tor)"
 msgstr ""
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
+msgid "Turn off if you want to pass resolve to local network settings"
 msgstr ""
 
 msgctxt "#30498"

--- a/resources/language/Russian/strings.po
+++ b/resources/language/Russian/strings.po
@@ -1439,12 +1439,12 @@ msgid "Use Proxy for torrent downloading"
 msgstr "Использовать прокси для скачивания торрентов"
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
-msgstr "Использовать встроенный DNS клиент"
+msgid "Use internal DNS resolver (enable for Tor)"
+msgstr "Использовать встроенный DNS клиент (вкл для Tor)"
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
-msgstr "Отключите, если используете адреса Tor, или хотите оставить DNS настройки сети"
+msgid "Turn off if you want to pass resolve to local network settings"
+msgstr "Отключите, если хотите оставить DNS настройки сети"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"

--- a/resources/language/Slovak/strings.po
+++ b/resources/language/Slovak/strings.po
@@ -1439,11 +1439,11 @@ msgid "Use Proxy for torrent downloading"
 msgstr ""
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
+msgid "Use internal DNS resolver (enable for Tor)"
 msgstr ""
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
+msgid "Turn off if you want to pass resolve to local network settings"
 msgstr ""
 
 msgctxt "#30498"

--- a/resources/language/Spanish (Argentina)/strings.po
+++ b/resources/language/Spanish (Argentina)/strings.po
@@ -1439,12 +1439,12 @@ msgid "Use Proxy for torrent downloading"
 msgstr "Usar proxy para descarga de torrents"
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
-msgstr "Usar resolver DNS interno"
+msgid "Use internal DNS resolver (enable for Tor)"
+msgstr "Usar resolver DNS interno (habilitar para Tor)"
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
-msgstr "Desactive si usa direcciones Tor o si desea delegar resolución de nombre a red local"
+msgid "Turn off if you want to pass resolve to local network settings"
+msgstr "Desactive si desea delegar resolución de nombre a red local"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"

--- a/resources/language/Spanish (Mexico)/strings.po
+++ b/resources/language/Spanish (Mexico)/strings.po
@@ -1438,11 +1438,11 @@ msgid "Use Proxy for torrent downloading"
 msgstr ""
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
+msgid "Use internal DNS resolver (enable for Tor)"
 msgstr ""
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
+msgid "Turn off if you want to pass resolve to local network settings"
 msgstr ""
 
 msgctxt "#30498"

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -1439,12 +1439,12 @@ msgid "Use Proxy for torrent downloading"
 msgstr "Usar Proxy para la descarga torrent"
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
-msgstr "Usar resolución DNS interna"
+msgid "Use internal DNS resolver (enable for Tor)"
+msgstr "Usar resolución DNS interna (habilitar para Tor)"
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
-msgstr "Desactivar si usa direcciones Tor, o si quiere pasar la resolución a la configuración de red local"
+msgid "Turn off if you want to pass resolve to local network settings"
+msgstr "Desactivar si quiere pasar la resolución a la configuración de red local"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"

--- a/resources/language/Swedish/strings.po
+++ b/resources/language/Swedish/strings.po
@@ -1442,12 +1442,12 @@ msgid "Use Proxy for torrent downloading"
 msgstr "Använd proxy för hämtning av torrent"
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
-msgstr "Använd intern DNS-resolver"
+msgid "Use internal DNS resolver (enable for Tor)"
+msgstr "Använd intern DNS-resolver (aktivera för Tor)"
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
-msgstr "Stäng av om du använder Tor-adresser, eller om du vill skicka lösning till lokala nätverksinställningar"
+msgid "Turn off if you want to pass resolve to local network settings"
+msgstr "Stäng av om du vill skicka lösning till lokala nätverksinställningar"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"

--- a/resources/language/Ukrainian/strings.po
+++ b/resources/language/Ukrainian/strings.po
@@ -1439,11 +1439,11 @@ msgid "Use Proxy for torrent downloading"
 msgstr ""
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
+msgid "Use internal DNS resolver (enable for Tor)"
 msgstr ""
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
+msgid "Turn off if you want to pass resolve to local network settings"
 msgstr ""
 
 msgctxt "#30498"

--- a/resources/language/messages.pot
+++ b/resources/language/messages.pot
@@ -1450,11 +1450,11 @@ msgid "Use Proxy for torrent downloading"
 msgstr ""
 
 msgctxt "#30495"
-msgid "Use internal DNS resolver"
+msgid "Use internal DNS resolver (enable for Tor)"
 msgstr ""
 
 msgctxt "#30496"
-msgid "Turn off if you use Tor addresses, or you want to pass resolve to local network settings"
+msgid "Turn off if you want to pass resolve to local network settings"
 msgstr ""
 
 msgctxt "#30498"


### PR DESCRIPTION
You actually need to enable internal_dns_enabled to resolve via proxy
it is clear even from setting name (internal, e.g. system independent)