### PR TITLE
Fix for force view mode

### DIFF
--- a/resources/site-packages/elementum/navigation.py
+++ b/resources/site-packages/elementum/navigation.py
@@ -483,7 +483,7 @@ def run(url_suffix="", retry=0):
     # Set ViewMode
     if data["content_type"]:
         viewMode = ADDON.getSetting("viewmode_%s" % data["content_type"])
-        if viewMode != "0":
+        if viewMode and viewMode != "0":
             try:
                 xbmc.executebuiltin('Container.SetViewMode(%s)' % viewMode)
             except Exception as e:

--- a/resources/site-packages/elementum/navigation.py
+++ b/resources/site-packages/elementum/navigation.py
@@ -483,7 +483,7 @@ def run(url_suffix="", retry=0):
     # Set ViewMode
     if data["content_type"]:
         viewMode = ADDON.getSetting("viewmode_%s" % data["content_type"])
-        if viewMode:
+        if viewMode != "0":
             try:
                 xbmc.executebuiltin('Container.SetViewMode(%s)' % viewMode)
             except Exception as e:


### PR DESCRIPTION
## Motivation and Context
- Since the default view mode value for all the view types in the Elementum settings are equal to "0",
Each navigation to any place in the addon force the view mode to be changed to "List" view (In my skin).
*** Probably activate "Container.SetViewMode()" with "0" value in Kodi 19.2 forces it to be changed to "List" view mode as default since there is no view mode id of "0" in my skin (And I guess in others too)
- I also have another issue regarding to this:
One of the Lists in Elementum is used as a widget in my skin. 
So on each refreshing of the widget (Kodi startup/Reload skin etc...) actually runs Elemetum which activate the force view mode changing.
It cause that after each widget refreshing the first window in kodi that you navigate to it, its view mode will be changed according to what set in Elementum.

## The fix descrioption:
It's so simple.
If the view mode is equal to "0" (Which is the defaul value), don't do any view mode changing.
Else, change it according to the Elementum settings.
In this case,  every change of the view modes inside Elementum by the skin context menu, the view mode is kept in Kodi/Skin/Addon cache or something (So at least I don't need this "Force" view mode changing). If for others these view mode changes are not kept in memory, they will need these options of "Force" changing and use it as always.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## How Has This Been Tested?
As describe in the fix description.
It was tested and works well.

Thanks.