### PR TITLE
fix-navigation.py for kodi<18

### DIFF
--- a/resources/site-packages/elementum/navigation.py
+++ b/resources/site-packages/elementum/navigation.py
@@ -447,8 +447,8 @@ def run(url_suffix="", retry=0):
                         pass
                     del item.get("art")["fanarts"]
 
-                if PLATFORM['kodi'] >= 18:
-                    if "available_artworks" in item.get("art") and item.get("art")["available_artworks"]:
+                if "available_artworks" in item.get("art") and item.get("art")["available_artworks"]:
+                    if PLATFORM['kodi'] >= 18:
                         try:
                             for artwork_type, artworks in item.get("art")["available_artworks"].items():
                                 for artwork in artworks:
@@ -456,7 +456,7 @@ def run(url_suffix="", retry=0):
                         except Exception as e:
                             log.warning("Could not initialize ListItem.Art (%s): %s" % (repr(item.get("art")), repr(e)))
                             pass
-                        del item.get("art")["available_artworks"]
+                    del item.get("art")["available_artworks"]
 
                 listItem.setArt(item["art"])
             elif ADDON.getSetting('default_fanart') == 'true' and item["label"] != six.ensure_text(getLocalizedString(30218), 'utf-8'):


### PR DESCRIPTION
## Description
Currently  if used Kodi17 Krypton we have a error - 
'ERROR: EXCEPTION: argument "value" for method "setArt" must be unicode or str'
Also because of this, posters and fanart are not loaded in the movie card.
This happens due to the fact when we call listItem.setArt(item["art"]) , item['art']['available_artworks'] is not a string, but an dictionary.
We must delete this key from item["art"] before call listItem.setArt(item["art"]).
This change code fix this for kodi<18 version.
