### PR TITLE
Move trakt_sync_removed_X_back to make more sense

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -248,15 +248,15 @@
         <setting id="trakt_sync_added_shows_list_name"     type="text" label="30446" default="" enable="false" />
         <setting id="trakt_sync_added_shows_list"          type="number" label="30120" default="" enable="false" />
 
-        <setting id="trakt_sync_removed_movies"            type="bool" label="30449" default="true" />
         <setting id="trakt_sync_removed_movies_back"       type="bool" label="30678" default="true" />
+        <setting id="trakt_sync_removed_movies"            type="bool" label="30449" default="true" />
         <setting id="trakt_sync_removed_movies_location"   type="enum" label="30442" lvalues="30257|30254|30436" default="0" enable="eq(-2,true)" />
         <setting                                           type="action" label="30441" action="RunPlugin(plugin://plugin.video.elementum/trakt/select_list/removed/movies)" enable="eq(-2,2)" />
         <setting id="trakt_sync_removed_movies_list_name"  type="text" label="30443" default="" enable="false" />
         <setting id="trakt_sync_removed_movies_list"       type="number" label="30119" default="" enable="false" />
 
-        <setting id="trakt_sync_removed_shows"             type="bool" label="30450" default="true" />
         <setting id="trakt_sync_removed_shows_back"        type="bool" label="30679" default="true" />
+        <setting id="trakt_sync_removed_shows"             type="bool" label="30450" default="true" />
         <setting id="trakt_sync_removed_shows_location"    type="enum" label="30445" lvalues="30257|30254|30436" default="0" enable="eq(-2,true)" />
         <setting                                           type="action" label="30444" action="RunPlugin(plugin://plugin.video.elementum/trakt/select_list/removed/shows)" enable="eq(-2,2)" />
         <setting id="trakt_sync_removed_shows_list_name"   type="text" label="30446" default="" enable="false" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->
Right now `trakt_sync_removed_X_back` is between `trakt_sync_removed_X` and settings of `trakt_sync_removed_X` - which is confusing. We need to move `_back` up.

trakt_sync_removed_X is disabled 
![Screenshot_20240123_140841](https://github.com/elgatito/plugin.video.elementum/assets/17964763/24193399-4c89-4a73-b429-333ed34d40ed)

trakt_sync_removed_X is enabled
![Screenshot_20240123_140854](https://github.com/elgatito/plugin.video.elementum/assets/17964763/a71ffb3f-1f8a-4184-a3c4-9d435474af8c)




## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
