### PR TITLE
Fix profile path for android - use non-temporary directory

### DIFF
--- a/resources/site-packages/elementum/daemon.py
+++ b/resources/site-packages/elementum/daemon.py
@@ -101,8 +101,6 @@ def get_elementum_binary():
             xbmc_data_path = translatePath("special://masterprofile/")
 
         dest_binary_dir = os.path.join(xbmc_data_path, "files", ADDON_ID, "bin", "%(os)s_%(arch)s" % binary_platform)
-        custom_path = os.path.join(xbmc_data_path, "files", ADDON_ID)
-        log_path = os.path.join(custom_path, "elementum.log")
     else:
         try:
             dest_binary_dir = os.path.join(translatePath(ADDON.getAddonInfo("profile")).decode('utf-8'), "bin", "%(os)s_%(arch)s" % binary_platform)

--- a/resources/site-packages/elementum/daemon.py
+++ b/resources/site-packages/elementum/daemon.py
@@ -113,7 +113,9 @@ def get_elementum_binary():
         else:
             custom_path = os.path.join(xbmc_data_path, "files", ADDON_ID)
 
-        log_path = os.path.join(custom_path, "elementum.log")
+        log_dir = translatePath("special://temp/")
+        if not os.path.exists(log_dir) or not is_writable(log_dir):
+            log_path = os.path.join(custom_path, "elementum.log")
     else:
         dest_binary_dir = os.path.join(addon_profile_dir, "bin", "%(os)s_%(arch)s" % binary_platform)
 

--- a/resources/site-packages/elementum/daemon.py
+++ b/resources/site-packages/elementum/daemon.py
@@ -81,6 +81,11 @@ def get_elementum_binary():
     binary = "elementum" + (binary_platform["os"] == "windows" and ".exe" or "")
     binary_dir = os.path.join(ADDON_PATH, "resources", "bin", "%(os)s_%(arch)s" % binary_platform)
 
+    try:
+        addon_profile_dir = translatePath(ADDON.getAddonInfo("profile")).decode('utf-8')
+    except Exception:
+        addon_profile_dir = translatePath(ADDON.getAddonInfo("profile"))
+
     if binary_platform["os"] == "android":
         log.info("Detected binary folder: %s" % binary_dir)
         binary_dir_legacy = binary_dir.replace("/storage/emulated/0", "/storage/emulated/legacy")
@@ -96,16 +101,21 @@ def get_elementum_binary():
             log.info("%s path does not exist, so using %s as xbmc_data_path" % (xbmc_data_path, os.path.join("/data", "data", app_id)))
             xbmc_data_path = os.path.join("/data", "data", app_id)
 
-        if not os.path.exists(xbmc_data_path):
+        if not os.path.exists(xbmc_data_path) or not is_writable(xbmc_data_path):
             log.info("%s path does not exist, so using %s as xbmc_data_path" % (xbmc_data_path, translatePath("special://masterprofile/")))
             xbmc_data_path = translatePath("special://masterprofile/")
 
         dest_binary_dir = os.path.join(xbmc_data_path, "files", ADDON_ID, "bin", "%(os)s_%(arch)s" % binary_platform)
+
+        # profile directory for shared library version
+        if os.path.exists(addon_profile_dir) and is_writable(addon_profile_dir):
+            custom_path = addon_profile_dir # if possible - use same directory as for binary version
+        else:
+            custom_path = os.path.join(xbmc_data_path, "files", ADDON_ID)
+
+        log_path = os.path.join(custom_path, "elementum.log")
     else:
-        try:
-            dest_binary_dir = os.path.join(translatePath(ADDON.getAddonInfo("profile")).decode('utf-8'), "bin", "%(os)s_%(arch)s" % binary_platform)
-        except Exception:
-            dest_binary_dir = os.path.join(translatePath(ADDON.getAddonInfo("profile")), "bin", "%(os)s_%(arch)s" % binary_platform)
+        dest_binary_dir = os.path.join(addon_profile_dir, "bin", "%(os)s_%(arch)s" % binary_platform)
 
     binary_path = os.path.join(binary_dir, binary)
     dest_binary_path = os.path.join(dest_binary_dir, binary)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->
After this https://github.com/elgatito/plugin.video.elementum/commit/c4869e6455330cbabb668c650e889d4042b491e1#diff-71ebf61bf8dc7b8a527700b3aaf2c64e628b2074cd503d890e1c005a311776b5R99-R100
elementum started to store internal databases inside kodi's apk dir - `/data/user/0/org.xbmc.kodi/cache/apk/assets/` and after kodi update this dir is erased thus elementum's data like history, cache and etc is gone.

also, there is not way to edit `libtorrent.config` since that dir is not accessible by user.
the same for `elementum.log` - user can not read it.

before
```
[plugin.video.elementum]     Profile: "/data/user/0/org.xbmc.kodi/cache/apk/assets/files/plugin.video.elementum",

[plugin.video.elementum] INFO  config       ▶ Reload           [0mSetting custom profile path to: /data/user/0/org.xbmc.kodi/cache/apk/assets/files/plugin.video.elementum
[plugin.video.elementum] INFO  config       ▶ Reload           [0mCreating libtorrent.config to further usage at: /data/user/0/org.xbmc.kodi/cache/apk/assets/files/plugin.video.elementum/libtorrent.config

[plugin.video.elementum] INFO  database     ▶ func1            [0mDatabase backup saved at: /data/user/0/org.xbmc.kodi/cache/apk/assets/files/plugin.video.elementum/cache-backup.db
[plugin.video.elementum] INFO  database     ▶ func1            [0mDatabase backup saved at: /data/user/0/org.xbmc.kodi/cache/apk/assets/files/plugin.video.elementum/storm-backup.db
```
after:
```
[plugin.video.elementum]     Profile: "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/userdata/addon_data/plugin.video.elementum/",
```

all data is browseable and readable now.

also log file was inaccessible. 
```
$ adb shell
KM6:/ $ cat /data/user/0/org.xbmc.kodi/cache/apk/assets/files/plugin.video.elementum/elementum.log
cat: /data/user/0/org.xbmc.kodi/cache/apk/assets/files/plugin.video.elementum/elementum.log: Permission denied
```


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes #979

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
