### PR TITLE
Add TMDB images quality (tmdb_images_quality) option.

### DIFF
--- a/resources/language/Croatian/strings.po
+++ b/resources/language/Croatian/strings.po
@@ -2222,3 +2222,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/Dutch/strings.po
+++ b/resources/language/Dutch/strings.po
@@ -2205,3 +2205,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -2204,3 +2204,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/Finnish/strings.po
+++ b/resources/language/Finnish/strings.po
@@ -2204,3 +2204,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/French/strings.po
+++ b/resources/language/French/strings.po
@@ -2214,3 +2214,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -2208,3 +2208,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/Greek/strings.po
+++ b/resources/language/Greek/strings.po
@@ -2208,3 +2208,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/Hebrew/strings.po
+++ b/resources/language/Hebrew/strings.po
@@ -2209,3 +2209,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/Hungarian/strings.po
+++ b/resources/language/Hungarian/strings.po
@@ -2206,3 +2206,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/Italian/strings.po
+++ b/resources/language/Italian/strings.po
@@ -2205,3 +2205,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/Portuguese (Brazil)/strings.po
+++ b/resources/language/Portuguese (Brazil)/strings.po
@@ -2204,3 +2204,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -2204,3 +2204,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/Romanian/strings.po
+++ b/resources/language/Romanian/strings.po
@@ -2208,3 +2208,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/Russian/strings.po
+++ b/resources/language/Russian/strings.po
@@ -2205,3 +2205,23 @@ msgstr "Порядок использования сервисов DNS-over-HTTP
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr "Скрывать просмотренное"
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr "Качество изображений TMDB (влияет на производительность Kodi)"
+
+msgctxt "#30693"
+msgid "Original"
+msgstr "Исходное"
+
+msgctxt "#30694"
+msgid "High"
+msgstr "Высокое"
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr "Среднее"
+
+msgctxt "#30696"
+msgid "Low"
+msgstr "Низкое"

--- a/resources/language/Slovak/strings.po
+++ b/resources/language/Slovak/strings.po
@@ -2205,3 +2205,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/Spanish (Argentina)/strings.po
+++ b/resources/language/Spanish (Argentina)/strings.po
@@ -2205,3 +2205,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/Spanish (Mexico)/strings.po
+++ b/resources/language/Spanish (Mexico)/strings.po
@@ -2204,3 +2204,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -2205,3 +2205,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/Swedish/strings.po
+++ b/resources/language/Swedish/strings.po
@@ -2208,3 +2208,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/Ukrainian/strings.po
+++ b/resources/language/Ukrainian/strings.po
@@ -2205,3 +2205,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/language/messages.pot
+++ b/resources/language/messages.pot
@@ -2216,3 +2216,23 @@ msgstr ""
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""
+
+msgctxt "#30692"
+msgid "TMDB images quality (affects Kodi performance)"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Original"
+msgstr ""
+
+msgctxt "#30694"
+msgid "High"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Low"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -125,6 +125,7 @@
         <setting id="results_per_page" label="30021" type="slider" option="int" range="3,1,50" default="9" />
         <setting id="default_fanart" label="30092" type="bool" default="true" />
         <setting id="use_fanart_tv" label="30491" type="bool" default="false" />
+        <setting id="tmdb_images_quality" label="30692" type="enum" lvalues="30693|30694|30695|30696" default="1" />
         <setting id="seasons_all" label="30567" type="bool" default="true" />
         <setting id="seasons_order" label="30568" type="enum" lvalues="30569|30570" default="0" />
         <setting id="seasons_specials" label="30639" type="bool" default="true" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->
UI changes for new "TMDB images quality" `tmdb_images_quality` option.
depends on https://github.com/elgatito/elementum/pull/111

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
