### PR TITLE
Return None in beginning of start_elementumd like in other returns

### DIFF
--- a/resources/site-packages/elementum/daemon.py
+++ b/resources/site-packages/elementum/daemon.py
@@ -294,7 +294,7 @@ def start_elementumd(monitor, **kwargs):
             time.sleep(5)
             if not jsonrpc_enabled(notify=True):
                 log.error("Unable to reach Kodi's JSON-RPC service, aborting...")
-                return False
+                return None
             else:
                 break
         time.sleep(3)
@@ -304,7 +304,7 @@ def start_elementumd(monitor, **kwargs):
 
     log.info("Binary dir: %s, item: %s " % (elementum_dir, elementum_binary))
     if elementum_dir is False or elementum_binary is False:
-        return False
+        return None
 
     lockfile = os.path.join(ADDON_PATH, ".lockfile")
     if os.path.exists(lockfile):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->
to fix
```
error <general>:   File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.elementum/resources/site-packages/elementum/daemon.py", line 532, in elementumd_thread
error <general>: fd = proc.stdout.fileno()
error <general>: AttributeError
error <general>: 'bool' object has no attribute 'stdout'
```

we should return None, like it other returns in that function, b/c we check for None later:
```
            proc = start_elementumd(monitor, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
            if proc is None:
                break
```

found while tried to run elementum on kodi 21 with android tv.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
