### PR TITLE
Fix missing text on episodes view with Estuary skin

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -284,7 +284,7 @@
         <setting id="trakt_progress_hide_unaired" type="bool" label="30428" default="true" />
         <setting id="trakt_use_lowest_release_date" type="bool" label="30699" default="true" />
         <setting id="trakt_progress_color_date" label="30425" type="text" default="yellow" />
-        <setting id="trakt_progress_color_show" label="30426" type="text" default="none" />
+        <setting id="trakt_progress_color_show" label="30426" type="text" default="gainsboro" />
         <setting id="trakt_progress_color_episode" label="30427" type="text" default="skyblue" />
         <setting id="trakt_progress_color_unaired" label="30440" type="text" default="deeppink" />
         <setting id="trakt_progress_date_format" label="30434" type="text" default="yyyy-mm-dd" />
@@ -292,7 +292,7 @@
         <setting label="30290" type="lsep" />
         <setting id="trakt_calendars_hide_watched" type="bool" label="30691" default="false" />
         <setting id="trakt_calendars_color_date" label="30425" type="text" default="yellow" />
-        <setting id="trakt_calendars_color_show" label="30426" type="text" default="none" />
+        <setting id="trakt_calendars_color_show" label="30426" type="text" default="gainsboro" />
         <setting id="trakt_calendars_color_episode" label="30427" type="text" default="skyblue" />
         <setting id="trakt_calendars_color_unaired" label="30440" type="text" default="deeppink" />
         <setting id="trakt_calendars_date_format" label="30434" type="text" default="yyyy-mm-dd" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->
with default skin Estuary on episodes view we have no text because of `color none`:
![progress with none color on estuary skin](https://github.com/elgatito/plugin.video.elementum/assets/17964763/0111bbc8-b121-4d92-bf89-c9b3889e1881)

I used gainsboro color since it looks like a neutral color:
![progress with gainsboro color on estuary skin](https://github.com/elgatito/plugin.video.elementum/assets/17964763/64851057-e835-4887-8140-5de9bdc7baaa)

list of colors with examples - https://forum.kodi.tv/showthread.php?tid=210837

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
