### PR TITLE
Use shutil.copy instead of shutil.copytree to avoid failure while setting file's metadata

### DIFF
--- a/resources/site-packages/elementum/daemon.py
+++ b/resources/site-packages/elementum/daemon.py
@@ -214,20 +214,42 @@ def get_elementum_binary():
             system_information()
             return False, False
 
-    if not os.path.exists(dest_binary_path) or not os.path.exists(binary_path) or get_elementumd_checksum(dest_binary_path) != get_elementumd_checksum(binary_path) or not filecmp.cmp(dest_binary_path, binary_path, shallow=True):
-        log.info("Updating elementum daemon from %s (%s checksum => %s) => %s ... (%s checksum => %s)" % (binary_dir, binary_path, get_elementumd_checksum(binary_path), dest_binary_dir, dest_binary_path, get_elementumd_checksum(dest_binary_path)))
-        try:
-            os.makedirs(dest_binary_dir)
-        except OSError:
-            pass
+    if (
+        not os.path.exists(dest_binary_path)
+        or not os.path.exists(binary_path)
+        or get_elementumd_checksum(dest_binary_path) != get_elementumd_checksum(binary_path)
+        or not filecmp.cmp(dest_binary_path, binary_path, shallow=True)
+    ):
+        log.info(
+            "Updating elementum daemon from %s (%s checksum => %s) to %s (%s checksum => %s)"
+            % (
+                binary_dir,
+                binary_path,
+                get_elementumd_checksum(binary_path),
+                dest_binary_dir,
+                dest_binary_path,
+                get_elementumd_checksum(dest_binary_path),
+            )
+        )
         try:
             shutil.rmtree(dest_binary_dir)
         except Exception as e:
             log.error("Unable to remove destination path for update: %s" % e)
-            system_information()
             pass
         try:
-            shutil.copytree(binary_dir, dest_binary_dir)
+            os.makedirs(dest_binary_dir)
+        except OSError as e:
+            log.error("Unable to create destination path for update: %s" % e)
+            pass
+        if not os.path.exists(dest_binary_dir):
+            log.error("Destination path for update does not exist: %s" % dest_binary_dir)
+            system_information()
+            return False, False
+        try:
+            for file in os.listdir(binary_dir):
+                shutil.copy(
+                    os.path.join(binary_dir, file), os.path.join(dest_binary_dir, file)
+                )
         except Exception as e:
             log.error("Unable to copy to destination path for update: %s" % e)
             system_information()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->
shutil.copytree fails on kodi 21 and android tv 10 (see https://github.com/elgatito/plugin.video.elementum/issues/1012).

now the logic is:
1. remove destination directory (failure is ignored, because we can live with old directory)
2. create destination directory (failure is ignored, because maybe previous step failed so dir still exists and we can't create it obviously)
3. check if destination directory exists (failure is not ignored since we need dir)
4. copy files to destination directory (failure is not ignored since we need files)

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes https://github.com/elgatito/plugin.video.elementum/issues/1012

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested on:
kodi 21 and android tv 10
kodi 20 and android tv 9
kodi 20 and linux x64

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
