### PR TITLE
Remove internal_dns_order

### DIFF
--- a/resources/language/Croatian/strings.po
+++ b/resources/language/Croatian/strings.po
@@ -2208,7 +2208,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/Croatian/strings.po
+++ b/resources/language/Croatian/strings.po
@@ -2207,10 +2207,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/Dutch/strings.po
+++ b/resources/language/Dutch/strings.po
@@ -2191,7 +2191,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/Dutch/strings.po
+++ b/resources/language/Dutch/strings.po
@@ -2190,10 +2190,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -2190,7 +2190,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -2189,10 +2189,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/Finnish/strings.po
+++ b/resources/language/Finnish/strings.po
@@ -2190,7 +2190,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/Finnish/strings.po
+++ b/resources/language/Finnish/strings.po
@@ -2189,10 +2189,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/French/strings.po
+++ b/resources/language/French/strings.po
@@ -2199,10 +2199,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/French/strings.po
+++ b/resources/language/French/strings.po
@@ -2200,7 +2200,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -2193,10 +2193,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -2194,7 +2194,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/Greek/strings.po
+++ b/resources/language/Greek/strings.po
@@ -2193,10 +2193,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/Greek/strings.po
+++ b/resources/language/Greek/strings.po
@@ -2194,7 +2194,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/Hebrew/strings.po
+++ b/resources/language/Hebrew/strings.po
@@ -2195,7 +2195,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/Hebrew/strings.po
+++ b/resources/language/Hebrew/strings.po
@@ -2194,10 +2194,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/Hungarian/strings.po
+++ b/resources/language/Hungarian/strings.po
@@ -2191,10 +2191,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/Hungarian/strings.po
+++ b/resources/language/Hungarian/strings.po
@@ -2192,7 +2192,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/Italian/strings.po
+++ b/resources/language/Italian/strings.po
@@ -2191,7 +2191,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/Italian/strings.po
+++ b/resources/language/Italian/strings.po
@@ -2190,10 +2190,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/Portuguese (Brazil)/strings.po
+++ b/resources/language/Portuguese (Brazil)/strings.po
@@ -2190,7 +2190,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/Portuguese (Brazil)/strings.po
+++ b/resources/language/Portuguese (Brazil)/strings.po
@@ -2189,10 +2189,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -2190,7 +2190,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -2189,10 +2189,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/Romanian/strings.po
+++ b/resources/language/Romanian/strings.po
@@ -2193,10 +2193,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/Romanian/strings.po
+++ b/resources/language/Romanian/strings.po
@@ -2194,7 +2194,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/Russian/strings.po
+++ b/resources/language/Russian/strings.po
@@ -2191,8 +2191,8 @@ msgid "Internal DNS client"
 msgstr "Встроенный DNS клиент"
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
-msgstr "Порядок использования сервисов DNS-over-HTTPS"
+msgid "DNS-over-HTTPS services to use"
+msgstr "Используемые DNS-over-HTTPS сервисы"
 
 msgctxt "#30691"
 msgid "Hide watched"

--- a/resources/language/Russian/strings.po
+++ b/resources/language/Russian/strings.po
@@ -2190,10 +2190,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr "Встроенный DNS клиент"
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr "Используемые DNS-over-HTTPS сервисы"
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr "Скрывать просмотренное"

--- a/resources/language/Slovak/strings.po
+++ b/resources/language/Slovak/strings.po
@@ -2191,7 +2191,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/Slovak/strings.po
+++ b/resources/language/Slovak/strings.po
@@ -2190,10 +2190,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/Spanish (Argentina)/strings.po
+++ b/resources/language/Spanish (Argentina)/strings.po
@@ -2191,7 +2191,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/Spanish (Argentina)/strings.po
+++ b/resources/language/Spanish (Argentina)/strings.po
@@ -2190,10 +2190,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/Spanish (Mexico)/strings.po
+++ b/resources/language/Spanish (Mexico)/strings.po
@@ -2190,7 +2190,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/Spanish (Mexico)/strings.po
+++ b/resources/language/Spanish (Mexico)/strings.po
@@ -2189,10 +2189,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -2191,7 +2191,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -2190,10 +2190,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/Swedish/strings.po
+++ b/resources/language/Swedish/strings.po
@@ -2193,10 +2193,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/Swedish/strings.po
+++ b/resources/language/Swedish/strings.po
@@ -2194,7 +2194,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/Ukrainian/strings.po
+++ b/resources/language/Ukrainian/strings.po
@@ -2191,7 +2191,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/language/Ukrainian/strings.po
+++ b/resources/language/Ukrainian/strings.po
@@ -2190,10 +2190,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/messages.pot
+++ b/resources/language/messages.pot
@@ -2201,10 +2201,6 @@ msgctxt "#30689"
 msgid "Internal DNS client"
 msgstr ""
 
-msgctxt "#30690"
-msgid "DNS-over-HTTPS services to use"
-msgstr ""
-
 msgctxt "#30691"
 msgid "Hide watched"
 msgstr ""

--- a/resources/language/messages.pot
+++ b/resources/language/messages.pot
@@ -2202,7 +2202,7 @@ msgid "Internal DNS client"
 msgstr ""
 
 msgctxt "#30690"
-msgid "Order of DNS-over-HTTPS services to use"
+msgid "DNS-over-HTTPS services to use"
 msgstr ""
 
 msgctxt "#30691"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -336,7 +336,7 @@
         <setting id="internal_dns_enabled" label="30495" type="bool" default="false" />
         <setting id="internal_dns_help" label="30496" type="text" enable="false" />
         <setting id="internal_dns_skip_ipv6" label="30536" type="bool" default="true" enable="eq(-2,true)" />
-        <setting id="internal_dns_order" label="30690" type="enum" values="Quad9 > Google > Cloudflare|Google > Cloudflare > Quad9|Cloudflare > Quad9 > Google" default="0" enable="eq(-3,true)" />
+        <setting id="internal_dns_order" label="30690" type="enum" values="Google + Cloudflare + Quad9|Quad9" default="0" enable="eq(-3,true)" />
         <setting id="internal_dns_opennic" label="30671" type="text" default="54.36.111.116, 192.3.165.37, 80.78.132.79" enable="eq(-4,true)" />
 
         <!-- Internal proxy -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->
because of 
https://github.com/likexian/doh/blob/0805781d5c924c4d6b63fee15eddb05df4d52670/doh.go#L103-L106

it does not make sense to have different orders, but it makes sense to make quad9 a separate option to unblock sites like TMDB.

for https://github.com/elgatito/elementum/pull/126 **thus should me merged after it.**

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
