### PR TITLE
Delete available_artworks key even if it is empty to avoid error in setArt

### DIFF
--- a/resources/site-packages/elementum/navigation.py
+++ b/resources/site-packages/elementum/navigation.py
@@ -488,15 +488,16 @@ def run(url_suffix="", retry=0):
                         pass
                     del item.get("art")["fanarts"]
 
-                if "available_artworks" in item.get("art") and item.get("art")["available_artworks"]:
-                    if PLATFORM['kodi'] >= 18:
-                        try:
-                            for artwork_type, artworks in item.get("art")["available_artworks"].items():
-                                for artwork in artworks:
-                                    listItem.addAvailableArtwork(artwork, artwork_type)
-                        except Exception as e:
-                            log.warning("Could not initialize ListItem.Art (%s): %s" % (repr(item.get("art")), repr(e)))
-                            pass
+                if "available_artworks" in item.get("art"):
+                    if item.get("art")["available_artworks"]:
+                        if PLATFORM['kodi'] >= 18:
+                            try:
+                                for artwork_type, artworks in item.get("art")["available_artworks"].items():
+                                    for artwork in artworks:
+                                        listItem.addAvailableArtwork(artwork, artwork_type)
+                            except Exception as e:
+                                log.warning("Could not initialize ListItem.Art (%s): %s" % (repr(item.get("art")), repr(e)))
+                                pass
                     del item.get("art")["available_artworks"]
 
                 listItem.setArt(item["art"])


### PR DESCRIPTION
we should delete available_artworks key even if it is empty to avoid error in setArt:
```
[plugin.video.elementum] item["art"]: {'poster': 'https://image.tmdb.org/t/p/w780/8Z4n4wDCV2EdW9AT0H81gGOKBg1.jpg', 'available_artworks': {}}
EXCEPTION: argument "value" for method "setArt" must be unicode or str
```

search in movies for "flash", some movies do not have any art or have only 1 poster, thus available_artworks was empty.