### PR TITLE
Flatpak : fix lockfile path, and remove danging file

### DIFF
--- a/resources/site-packages/elementum/daemon.py
+++ b/resources/site-packages/elementum/daemon.py
@@ -326,6 +326,10 @@ def start_elementumd(monitor, **kwargs):
         return None
 
     lockfile = os.path.join(get_addon_profile_dir(), ".lockfile")
+    if binary_platform["os"] == "linux" and os.getenv("container", "") == "flatpak":
+        log.warning("Running within Flatpak")
+        os.unlink(lockfile)
+
     if os.path.exists(lockfile):
         log.warning("Existing process found from lockfile, killing...")
         try:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
It's a fix for running elementum within Flatpak 

lockfile path was resolved to addons/plugin.video.elementum/.lockfile whereas on disk it's userdata/addon_data/plugin.video.elementum/.lockfile

in the case of Flatpak, there's no dangling process : they are killed at the end, so it's safe to remove the file completely at start

(https://github.com/elgatito/plugin.video.elementum/issues/1058)

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
