### PR TITLE
Windows: fix UnicodeDecodeError while logging libtorrent logs

### DIFF
--- a/resources/site-packages/elementum/daemon.py
+++ b/resources/site-packages/elementum/daemon.py
@@ -541,7 +541,12 @@ def elementumd_thread(monitor):
                 else:
                     if binary_platform["os"] == "windows":
                         while proc.poll() is None:
-                            log.info(toUtf8(proc.stdout.readline().rstrip()))
+                            try:
+                                log.info(toUtf8(proc.stdout.readline().rstrip()))
+                            except UnicodeDecodeError:
+                                pass
+                            except TypeError:
+                                pass
                     else:
                         # Kodi hangs on some Android (sigh...) systems when doing a blocking
                         # read. We count on the fact that Elementum daemon flushes its log

--- a/resources/site-packages/elementum/util.py
+++ b/resources/site-packages/elementum/util.py
@@ -81,7 +81,7 @@ def getElementumLocalizedString(stringId):
 
 def toUtf8(string):
     if isinstance(string, bytes):
-        string = string.decode("utf-8")
+        string = string.decode('utf-8', 'ignore')
     return py2_encode(string)
 
 def system_information():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->
Windows: fix UnicodeDecodeError while logging libtorrent logs

## Related Issue
fixes https://github.com/elgatito/plugin.video.elementum/issues/1068
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
