### PR TITLE
Add explicit bool to int conversion for Dialog return value.

### DIFF
--- a/resources/site-packages/elementum/rpc.py
+++ b/resources/site-packages/elementum/rpc.py
@@ -94,7 +94,7 @@ class ElementumRPCServer(BaseHandler):
 
     def Dialog(self, title, message):
         dialog = xbmcgui.Dialog()
-        return dialog.ok(getLocalizedLabel(title), getLocalizedLabel(message))
+        return int(dialog.ok(getLocalizedLabel(title), getLocalizedLabel(message)))
 
     def Dialog_Browse_Single(self, type, heading, shares, mask, useThumbs, treatAsFolder, defaultt):
         fn = six.ensure_text(xbmcgui.Dialog().browseSingle(type, getLocalizedLabel(heading), shares, mask, useThumbs, treatAsFolder, defaultt), errors='ignore')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->
for bug found in https://github.com/elgatito/plugin.video.elementum/issues/1075 :

>When authorizing Trakt after entering the code, Elementum notifies that Trakt has been successfully authorized, however the authorization screen does not go away after authorizing. If you hit OK or back a message comes up saying Trakt authorization cancelled. But after opening it seems it is authorized.

we returned wrong value in python thus we always showed error in golang.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
