### PR TITLE
Add login & password startup args to elementum daemon

### DIFF
--- a/resources/site-packages/elementum/daemon.py
+++ b/resources/site-packages/elementum/daemon.py
@@ -367,6 +367,12 @@ def start_elementumd(monitor, **kwargs):
     if ADDON.getSetting("remote_port") != "":
         args.append("-localPort=" + ADDON.getSetting("remote_port"))
         shared_args += " -localPort=" + ADDON.getSetting("remote_port")
+    if ADDON.getSetting("remote_login") != "":
+        args.append("-localLogin=" + ADDON.getSetting("remote_login"))
+        shared_args += " -localLogin=" + ADDON.getSetting("remote_login")
+    if ADDON.getSetting("remote_password") != "":
+        args.append("-localPassword=" + ADDON.getSetting("remote_password"))
+        shared_args += " -localPassword=" + ADDON.getSetting("remote_password")
     force_library = ADDON.getSetting("local_force_library")
     kwargs["cwd"] = elementum_dir
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->
Add login & password startup args to elementum daemon so local daemon will be launched with those args and they will be used.
Previously they were not passed to daemon and i guess it was expected that authentication will be used only for manually launched daemon.
## Related Issue
fixes https://github.com/elgatito/plugin.video.elementum/issues/1124
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
