### PR TITLE
Fix Kodi methods deprecations as of 04.2025

### DIFF
--- a/resources/site-packages/elementum/navigation.py
+++ b/resources/site-packages/elementum/navigation.py
@@ -227,6 +227,8 @@ def _json(url):
                     label2=_infoLabels["label2"],
                     thumbnailImage=_infoLabels["thumbnail"]
                 )
+            if PLATFORM['kodi'] >= 20:
+                video_info_tag = item.getVideoInfoTag()
 
             item.setArt({
                 "thumb": _infoLabels["artthumb"],
@@ -241,7 +243,18 @@ def _json(url):
             })
 
             if 'castmembers' in _infoLabels:
-                if PLATFORM['kodi'] >= 17:
+                if PLATFORM['kodi'] >= 20:
+                    actors = []
+                    for castmember in _infoLabels['castmembers']:
+                        if 'order' in castmember:
+                            castmember['order'] = int(castmember['order'])
+                        actor = xbmc.Actor(name=castmember.get('name', ''),
+                                           role=castmember.get('role', ''),
+                                           thumbnail=castmember.get('thumbnail', ''),
+                                           order=castmember.get('order', -1))
+                        actors.append(actor)
+                    video_info_tag.setCast(actors)
+                elif PLATFORM['kodi'] >= 17:
                     item.setCast(_infoLabels['castmembers'])
                 del _infoLabels['castmembers']
 
@@ -463,19 +476,62 @@ def run(url_suffix="", retry=0):
                 iconImage=item["icon"],
                 thumbnailImage=item["thumbnail"]
             )
+        if PLATFORM['kodi'] >= 20:
+            video_info_tag = listItem.getVideoInfoTag()
 
         try:
-            if item.get("castmembers") and PLATFORM['kodi'] >= 17:
-                listItem.setCast(item.get("castmembers"))
+            if item.get("castmembers"):
+                if PLATFORM['kodi'] >= 20:
+                    actors = []
+                    for castmember in item['castmembers']:
+                        actor = xbmc.Actor(name=castmember.get('name', ''),
+                                           role=castmember.get('role', ''),
+                                           thumbnail=castmember.get('thumbnail', ''),
+                                           order=castmember.get('order', -1))
+                        actors.append(actor)
+                    video_info_tag.setCast(actors)
+                elif PLATFORM['kodi'] >= 17:
+                    listItem.setCast(item["castmembers"])
             if item.get("info"):
                 item["info"] = normalizeLabels(item["info"])
                 remove_dbtype_from_list(item["info"])
                 listItem.setInfo("video", item["info"])
             if item.get("stream_info"):
-                for type_, values in item["stream_info"].items():
-                    listItem.addStreamInfo(type_, values)
+                if PLATFORM['kodi'] >= 20:
+                    for type_, values in item["stream_info"].items():
+                        if type_ == "video":
+                            video_stream_detail = xbmc.VideoStreamDetail(
+                                width=values.get('width', 0),
+                                height=values.get('height', 0),
+                                aspect=values.get('aspect', 0),
+                                duration=values.get('duration', 0),
+                                codec=values.get('codec', ''),
+                                language=values.get('language', ''),
+                                )
+                            video_info_tag.addVideoStream(video_stream_detail)
+                        elif type_ == "audio":
+                            audio_stream_detail = xbmc.AudioStreamDetail(
+                                language=values.get('language', ''),
+                                codec=values.get('codec', ''),
+                                channels=values.get('channels', -1),
+                                )
+                            video_info_tag.addAudioStream(audio_stream_detail)
+                        elif type_ == "subtitle":
+                            subtitle_stream_detail = xbmc.SubtitleStreamDetail(
+                                language=values.get('language', ''),
+                                )
+                            video_info_tag.addSubtitleStream(subtitle_stream_detail)
+                else:
+                    for type_, values in item["stream_info"].items():
+                        listItem.addStreamInfo(type_, values)
             if item.get("uniqueids"):
-                listItem.setUniqueIDs(item["uniqueids"])
+                # values for setUniqueIDs() must be str
+                if "Kodi" in item["uniqueids"]:
+                    item["uniqueids"]["Kodi"] = str(item["uniqueids"]["Kodi"])
+                if PLATFORM['kodi'] >= 20:
+                    video_info_tag.setUniqueIDs(item["uniqueids"])
+                else:
+                    listItem.setUniqueIDs(item["uniqueids"])
             if item.get("art"):
                 if "fanarts" in item.get("art") and item.get("art")["fanarts"]:
                     try:
@@ -483,7 +539,8 @@ def run(url_suffix="", retry=0):
                         fanart_list = []
                         for fa in item.get("art")["fanarts"]:
                             start += 1
-                            item.get("art")["fanart{}".format(start)] = fa
+                            if PLATFORM['kodi'] < 18:
+                                item.get("art")["fanart{}".format(start)] = fa
                             fanart_list.append({'image': fa})
 
                         if PLATFORM['kodi'] >= 18:
@@ -499,12 +556,14 @@ def run(url_suffix="", retry=0):
                             try:
                                 for artwork_type, artworks in item.get("art")["available_artworks"].items():
                                     for artwork in artworks:
-                                        listItem.addAvailableArtwork(artwork, artwork_type)
+                                        if PLATFORM['kodi'] >= 20:
+                                            video_info_tag.addAvailableArtwork(artwork, artwork_type)
+                                        else:
+                                            listItem.addAvailableArtwork(artwork, artwork_type)
                             except Exception as e:
                                 log.warning("Could not initialize ListItem.Art (%s): %s" % (repr(item.get("art")), repr(e)))
                                 pass
                     del item.get("art")["available_artworks"]
-
                 listItem.setArt(item["art"])
             elif ADDON.getSetting('default_fanart') == 'true' and item["label"] != six.ensure_text(getLocalizedString(30218), 'utf-8'):
                 fanart = os.path.join(ADDON_PATH, "fanart.jpg")
@@ -519,6 +578,14 @@ def run(url_suffix="", retry=0):
                 listItem.addContextMenuItems(item["context_menu"])
             listItem.setProperty("isPlayable", item["is_playable"] and "true" or "false")
             if item.get("properties"):
+                if PLATFORM['kodi'] >= 20:
+                    if "resumetime" in item["properties"] and "totaltime" in item["properties"]:
+                        video_info_tag.setResumePoint(
+                            float(item["properties"]["resumetime"]),
+                            float(item["properties"]["totaltime"]),
+                            )
+                        del(item["properties"]["resumetime"])
+                        del(item["properties"]["totaltime"])
                 for k, v in item["properties"].items():
                     listItem.setProperty(k, v)
         except Exception as e:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->
setCast()
old https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d8/d29/group__python__xbmcgui__listitem.html#gade274b8e60b844a38c4192fb7ccd3619
new https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d9/dc2/group__python___info_tag_video.html#ga5e2d10eb77e82c720a6dd8ef5958a5f1

addStreamInfo()
old https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d8/d29/group__python__xbmcgui__listitem.html#gaf0c020ba8bc205d61e786dfec9111cdc
new
addVideoStream https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d9/dc2/group__python___info_tag_video.html#gaeaade4ab3cf17d9293cc46da1dc09536
addAudioStream https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d9/dc2/group__python___info_tag_video.html#gacc7de28085cef89b848b7d082e9c45bc
addSubtitleStream https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d9/dc2/group__python___info_tag_video.html#ga1684e17fac70df5e9c3e00ef88ed659d

setUniqueIDs()
old https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d8/d29/group__python__xbmcgui__listitem.html#ga7fc2ecd77b8d0032cc68eee6b4c9d6a2
new https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d9/dc2/group__python___info_tag_video.html#gac8d26ac69d9b20ca66ca45e532028f57

addAvailableArtwork()
old https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d8/d29/group__python__xbmcgui__listitem.html#ga029e2e45023ed17a8f5305249959a149
new https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d9/dc2/group__python___info_tag_video.html#gac6ce82a4fcd0cb447585af5305f9d031

setProperty() ResumeTime and TotalTime
old https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d8/d29/group__python__xbmcgui__listitem.html#gaf3890e39353d2e8f46928653667e7d81
new setResumePoint() https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d9/dc2/group__python___info_tag_video.html#gac4af7bb610e112d28f5df8acf639d1f0

setInfo() i have not replaced
https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d8/d29/group__python__xbmcgui__listitem.html#ga0b71166869bda87ad744942888fb5f14
since we need to replace it with a lot of separate methods like setYear()
https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d9/dc2/group__python___info_tag_video.html#ga2213ad601b90b7438fad9040957e3ba9
and setInfo() is only "Partially deprecated" at the moment.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/elgatito/plugin.video.elementum/issues/913

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
