### PR TITLE
Do not fail on empty System.BuildVersion label.

### DIFF
--- a/resources/site-packages/elementum/osarch.py
+++ b/resources/site-packages/elementum/osarch.py
@@ -20,7 +20,7 @@ def get_platform():
         pass
 
     build = xbmc.getInfoLabel("System.BuildVersion")
-    kodi_version = int(build.split()[0][:2])
+    kodi_version = int(build.split()[0][:2]) if build else 0
 
     if binary_platform and "auto" not in binary_platform.lower():
         custom = binary_platform.split('_')
@@ -73,7 +73,7 @@ def get_platform_legacy():
         pass
 
     build = xbmc.getInfoLabel("System.BuildVersion")
-    kodi_version = int(build.split()[0][:2])
+    kodi_version = int(build.split()[0][:2]) if build else 0
 
     if binary_platform and "auto" not in binary_platform.lower():
         custom = binary_platform.split('_')


### PR DESCRIPTION
So test scripts that are run outside of kodi will not fail on elementum.provider.log which inderectly uses osarch.py.

<!--- Provide a general summary of your changes in the Title above -->

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->
for https://github.com/elgatito/script.elementum.burst/pull/472

fixes
```
    kodi_version = int(build.split()[0][:2])
IndexError: list index out of range
```

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
