### PR TITLE
Fix plugin use with System proxy enabled

### DIFF
--- a/resources/site-packages/elementum/navigation.py
+++ b/resources/site-packages/elementum/navigation.py
@@ -337,6 +337,8 @@ def run(url_suffix="", retry=0):
         ]
 
     urllib_request.install_opener(opener)
+    # Make requests to the ElementumD service bypass System proxy settings
+    os.environ['no_proxy'] = "localhost,%s" % ADDON.getSetting("remote_host")
 
     # Pause currently playing Elementum file to avoid doubling requests
     try:


### PR DESCRIPTION




<!--- Provide a general summary of your changes in the Title above -->

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description

When `network.usehttpproxy` settings is set, python environment makes all urllib.request.urlopen() calls through that `network.httpproxyserver`. Interface part of plugin couldn't access service API through that proxy.  So to make API call to go directly 'no_proxy' environment should be set.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes elgatito/plugin.video.elementum#1139

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes elgatito/plugin.video.elementum#1139

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Addon interface timeouts without the patch and System proxy set in Kodi settings, and works as expected when the patch applied.

* Version used:
  Elementum 0.1.111
* Environment name and version:
  Kodi 21.2 Omega
* Operating System and version:
  Windows 10

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
