### PR TITLE
Fix Android 14 W^X permission reset on binary after sleep.

### DIFF
--- a/resources/site-packages/elementum/daemon.py
+++ b/resources/site-packages/elementum/daemon.py
@@ -410,6 +410,7 @@ def start_elementumd(monitor, **kwargs):
     proc = None
     if force_library != u"true":
         try:
+            ensure_exec_perms(elementum_binary)
             proc = subprocess.Popen(args, **kwargs)
         except Exception as e:
             log.error("Unable to start binary: %s" % (e))


### PR DESCRIPTION
## Description
Call `ensure_exec_perms()` immediately before `subprocess.Popen()` in `start_elementumd()` to restore execute permissions on the Elementum binary before each playback attempt.

## Related Issue
No existing issue — this PR introduces the fix directly.

## Motivation and Context
On Android 14, the W^X (Write XOR Execute) security policy resets execute permissions on binaries stored in the app's internal cache directory (`/data/user/0/`) after the device enters sleep mode. When the device wakes and the user tries to play media, Elementum attempts to spawn a new binary process for playback. The binary exists but has lost its execute permission, causing a `Permission denied` error. The `.so` library fallback then also fails, resulting in a `std::bad_alloc` exception that crashes Kodi completely.

The fix calls the already existing `ensure_exec_perms()` function right before `subprocess.Popen()` so the execute bit is restored on every playback attempt, regardless of what happened during sleep.

## How Has This Been Tested?
Tested on a Homatics R 4K (Android 14, ARM 32-bit) with Kodi 21 and Elementum 0.1.113. Device was put to sleep for 15+ minutes, woken, and playback was initiated successfully. Same also tested with 1+ hour timeframe. Previously this would consistently crash Kodi.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.