### PR TITLE
60secondsassassin patch 1

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -137,6 +137,9 @@
         <setting id="tmdb_show_use_prod_company_as_studio" label="30417" type="bool" default="false" />
         <setting id="show_unwatched_episodes_number" label="30418" type="bool" default="true" />
 
+        <setting id="viewmode_global_enabled" type="bool" label="Enable Global View Mode" default="false" />
+        <setting id="viewmode_global_id" type="number" label="Global View ID (e.g. 51)" default="50" enable="eq(-1,true)" />
+
         <setting id="viewmode_movies" label="30034" type="number" default="" />
         <setting id="viewmode_tvshows" label="30035" type="number" default="" />
         <setting id="viewmode_seasons" label="30036" type="number" default="" />

--- a/resources/site-packages/elementum/navigation.py
+++ b/resources/site-packages/elementum/navigation.py
@@ -595,7 +595,8 @@ def run(url_suffix="", retry=0):
         listitems[i] = (item["path"], listItem, not item["is_playable"])
 
     xbmcplugin.addDirectoryItems(HANDLE, listitems, totalItems=len(listitems))
-
+    
+    # Set ViewMode
     # 1. Finalize the directory FIRST. 
     # Kodi needs the list to be "closed" before it can apply a view style.
     xbmcplugin.endOfDirectory(HANDLE, succeeded=True, updateListing=False, cacheToDisc=True)

--- a/resources/site-packages/elementum/navigation.py
+++ b/resources/site-packages/elementum/navigation.py
@@ -596,13 +596,26 @@ def run(url_suffix="", retry=0):
 
     xbmcplugin.addDirectoryItems(HANDLE, listitems, totalItems=len(listitems))
 
-    # Set ViewMode
-    if data["content_type"]:
-        viewMode = ADDON.getSetting("viewmode_%s" % data["content_type"])
-        if viewMode and viewMode != "0":
-            try:
-                xbmc.executebuiltin('Container.SetViewMode(%s)' % viewMode)
-            except Exception as e:
-                log.warning("Unable to SetViewMode(%s): %s" % (viewMode, repr(e)))
+    # 1. Finalize the directory FIRST. 
+    # Kodi needs the list to be "closed" before it can apply a view style.
+    xbmcplugin.endOfDirectory(HANDLE, succeeded=True, updateListing=False, cacheToDisc=True)
 
-    xbmcplugin.endOfDirectory(HANDLE, succeeded=True, updateListing=False, cacheToDisc=True)
+    # 2. Apply ViewMode with Global Logic and Timing Fix
+    if data["content_type"]:
+        # Check if Global Mode is enabled (assumes you added this to settings.xml)
+        if ADDON.getSetting("viewmode_global_enabled") == "true":
+            viewMode = ADDON.getSetting("viewmode_global_id")
+            log.debug("Elementum: Using Global View Mode: %s" % viewMode)
+        else:
+            # Fallback to granular settings
+            viewMode = ADDON.getSetting("viewmode_%s" % data["content_type"])
+            log.debug("Elementum: Using Granular View Mode: %s for %s" % (viewMode, data["content_type"]))
+
+        if viewMode and viewMode != "0":
+            try:
+                # The Timing Fix: 
+                # Wait 400ms to let the skin "catch up" and render the items.
+                xbmc.sleep(400) 
+                xbmc.executebuiltin('Container.SetViewMode(%s)' % viewMode)
+            except Exception as e:
+                log.warning("Unable to SetViewMode(%s): %s" % (viewMode, repr(e)))

--- a/resources/site-packages/elementum/navigation.py
+++ b/resources/site-packages/elementum/navigation.py
@@ -448,6 +448,18 @@ def run(url_suffix="", retry=0):
 
     listitems = list(range(len(data["items"])))
     for i, item in enumerate(data["items"]):
+    
+        # --- ROBUST PATH TRANSLATION ---
+        if item.get("icon") and "resources" in item["icon"]:
+            # Extract just the filename (e.g., movies.png)
+            icon_name = os.path.basename(item["icon"])
+            # Force Kodi to look in the local addon's image folder
+            item["icon"] = "special://home/addons/plugin.video.elementum/resources/img/%s" % icon_name
+
+        if item.get("thumbnail") and "resources" in item["thumbnail"]:
+            thumb_name = os.path.basename(item["thumbnail"])
+            item["thumbnail"] = "special://home/addons/plugin.video.elementum/resources/img/%s" % thumb_name
+
         # Translate labels
         if "LOCALIZE" in item["label"]:
             if item["label"][0:8] == "LOCALIZE":


### PR DESCRIPTION
# Fix: Inconsistent ViewMode application + local icons when in remote server mode

## Description

This PR fixes the issue where Elementum fails to apply the configured View ID (Posters, List, etc.) when navigating through directories.

The fix involves:

1. **Reordering execution**: Ensuring `xbmcplugin.endOfDirectory` is called before attempting to set the view.
2. **Timing Buffer**: Introducing a 400ms sleep to allow the Kodi skin to render the container before the `SetViewMode` command is sent.
3. **Global View Support**: Adding a new setting to allow users to force a single View ID across all categories.

## Related Issue

Fixes inconsistent UI behavior on Kodi 20/21, especially on low-end hardware where the UI thread is slower than the Python execution.

## Motivation and Context

Currently, the `Container.SetViewMode` command often fires while the directory is still "loading," causing Kodi to ignore it and fall back to the skin's default view. By finalizing the directory first and adding a slight delay, we ensure the command is received when the UI is ready to process it.

## How Has This Been Tested?

* **Environment**: Kodi 21.3 on OpenSUSE and tvOS.
* **Test Case 1**: Set "Movies" to View 51 (Posters) in Estuary. Result: Consistently applies the view on every entry.
* **Test Case 2**: Enabled "Global View Mode" and set it to 50 (List). Result: All directories (Movies, Shows, Search) now correctly use the List view.
* **Hardware**: Tested on high-end PC and lower-end hardware to verify that 400ms is a sufficient buffer.

## Screenshots (if appropriate):

*(Optionnel : tu peux ajouter ici une capture d'écran de l'affichage correct des Posters)*

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Translation

## Checklist:

* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation (Settings).
* [ ] I have updated the documentation accordingly.
* [ ] I have read the **CONTRIBUTING** document.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
