### PR TITLE
Complete Spanish translation and fix two inverted strings

### DIFF
--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -1860,7 +1860,7 @@ msgstr "Mostrar estado de visionado para archivos torrents"
 
 msgctxt "#30607"
 msgid "Use earliest release date as basic for searching"
-msgstr "Usar fecha de lanzamiento más reciente para buscar"
+msgstr "Usar la fecha de lanzamiento más antigua como base para la búsqueda"
 
 msgctxt "#30608"
 msgid "Match found in your active torrents, play it?[CR]%s"
@@ -2224,7 +2224,7 @@ msgstr "Idioma de Kodi"
 
 msgctxt "#30699"
 msgid "Use earliest release date for progress and calendars"
-msgstr "Usar versión más reciente para progreso y calendarios"
+msgstr "Usar la fecha de lanzamiento más antigua para progreso y calendarios"
 
 msgctxt "#30700"
 msgid "Interface fallback language"

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -1460,7 +1460,7 @@ msgstr "Desactivar si usas direcciones Tor, o deseas[CR]utilizar la configuraci�
 
 msgctxt "#30497"
 msgid "Use Antizapret proxy (only for Russia)"
-msgstr ""
+msgstr "Usar proxy Antizapret (solo para Rusia)"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"
@@ -2232,7 +2232,7 @@ msgstr "Idioma secundario de la interfaz"
 
 msgctxt "#30701"
 msgid "English | en"
-msgstr ""
+msgstr "Inglés | en"
 
 msgctxt "#30702"
 msgid "Reached daily limit for subtitles downloads"
@@ -2276,28 +2276,28 @@ msgstr "¿Deseas eliminar el torrent '%s'?"
 
 msgctxt "#30712"
 msgid "Force to always use proxy, can break download in some cases"
-msgstr ""
+msgstr "Forzar el uso del proxy siempre, puede hacer que falle la descarga en algunos casos"
 
 msgctxt "#30713"
 msgid "Disable NATPMP"
-msgstr "Disable NATPMP"
+msgstr "Desactivar NATPMP"
 
 msgctxt "#30714"
 msgid "Re-check torrent's data"
-msgstr ""
+msgstr "Volver a comprobar los datos del torrent"
 
 msgctxt "#30715"
 msgid "Antizapret PAC file URL"
-msgstr ""
+msgstr "URL del archivo PAC de Antizapret"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "Servidor DNS sobre HTTPS"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "Servidor DNS sobre HTTPS personalizado"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "Usar servidores DNS de OpenNIC"


### PR DESCRIPTION
Spanish was at 563/571 strings. This completes it, and fixes two existing strings that say the opposite of the original.

## Filling the gaps

Eight strings had an empty `msgstr`, so they fell back to English in the UI:

| ID | Original |
|---|---|
| 30497 | Use Antizapret proxy (only for Russia) |
| 30701 | English \| en |
| 30712 | Force to always use proxy, can break download in some cases |
| 30714 | Re-check torrent's data |
| 30715 | Antizapret PAC file URL |
| 30716 | DNS over HTTPS Server |
| 30717 | Custom DNS over HTTPS Server |
| 30718 | Use OpenNIC DNS Servers |

I also fixed **30713** (`Disable NATPMP`), which had the English text copied verbatim into `msgstr` rather than being translated.

## The two inverted strings

`30607` and `30699` are the only strings in the file containing "earliest", and both were translated as **"más reciente"** — most recent, the opposite of what the setting does:

```
30607  Use earliest release date as basic for searching
       was: Usar fecha de lanzamiento más reciente para buscar
30699  Use earliest release date for progress and calendars
       was: Usar versión más reciente para progreso y calendarios
```

The setting is `trakt_use_lowest_release_date`, and `Episode.GetLowestAirDate` keeps the Trakt date only when it is `Before` the TMDB one, so it takes the earlier of the two. Both now read **"más antigua"**. 30699 also called it a *versión* rather than a *fecha*.

## Notes on the choices

- Provider and protocol names are left untranslated (`Antizapret`, `NATPMP`, `OpenNIC`, `PAC`), matching what the Russian file does.
- `DNS over HTTPS` is rendered as `DNS sobre HTTPS`, the established form in Spanish, rather than leaving a half-translated hybrid.
- `Disable NATPMP` follows the existing `Desactivar UPNP` wording.

Only `resources/language/Spanish/strings.po` is touched. I hit 30716-30718 myself while setting up the built-in DoH resolver, which is what prompted this.

While here I noticed five strings in this file whose Kodi markup does not match the English source: `[I]` added in 30681 and 30684, an extra `[CR]` in 30349 and 30586, and a missing `[CR]` in 30703. I have left them alone to keep this PR to filling gaps and fixing meaning — happy to send them separately if you want them.
