### PR TITLE
Complete Argentinian Spanish, Polish and Swedish translations

### DIFF
--- a/resources/language/Polish/strings.po
+++ b/resources/language/Polish/strings.po
@@ -2291,12 +2291,12 @@ msgstr "URL pliku PAC Antizapret"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "Serwer DNS over HTTPS"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "Własny serwer DNS over HTTPS"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "Użyj serwerów DNS OpenNIC"

--- a/resources/language/Spanish (Argentina)/strings.po
+++ b/resources/language/Spanish (Argentina)/strings.po
@@ -2224,7 +2224,7 @@ msgstr "Idioma de Kodi"
 
 msgctxt "#30699"
 msgid "Use earliest release date for progress and calendars"
-msgstr "Usar la fecha de estreno más temprana para progreso y calendarios"
+msgstr "Usar la fecha de lanzamiento más antigua para progreso y calendarios"
 
 msgctxt "#30700"
 msgid "Interface fallback language"

--- a/resources/language/Spanish (Argentina)/strings.po
+++ b/resources/language/Spanish (Argentina)/strings.po
@@ -410,11 +410,11 @@ msgstr "Scrapeando trackers..."
 
 msgctxt "#30119"
 msgid "ID of selected userlist for movies"
-msgstr ""
+msgstr "ID de la lista de usuario seleccionada para películas"
 
 msgctxt "#30120"
 msgid "ID of selected userlist for shows"
-msgstr ""
+msgstr "ID de la lista de usuario seleccionada para series"
 
 msgctxt "#30141"
 msgid "Please support Elementum development by visiting[CR]https://elementum.surge.sh/donate/ or https://elementumorg.github.io/donate/"
@@ -1460,7 +1460,7 @@ msgstr "Desactive si usa direcciones Tor o si desea delegar resolución de nombr
 
 msgctxt "#30497"
 msgid "Use Antizapret proxy (only for Russia)"
-msgstr ""
+msgstr "Usar proxy Antizapret (solo para Rusia)"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"
@@ -2144,139 +2144,139 @@ msgstr "Contraseña de host remoto"
 
 msgctxt "#30678"
 msgid "Remove from Kodi library, when movie is deleted from Trakt"
-msgstr ""
+msgstr "Quitar de la biblioteca de Kodi cuando la película se elimine de Trakt"
 
 msgctxt "#30679"
 msgid "Remove from Kodi library, when show is deleted from Trakt"
-msgstr ""
+msgstr "Quitar de la biblioteca de Kodi cuando la serie se elimine de Trakt"
 
 msgctxt "#30680"
 msgid "Remove Elementum duplicates from library"
-msgstr ""
+msgstr "Quitar duplicados de Elementum de la biblioteca"
 
 msgctxt "#30681"
 msgid "[B]Found duplicates in Kodi library:[/B][CR]Movies: [B]%s[/B], Shows: [B]%s[/B], Episodes: [B]%s[/B][CR]Proceed?"
-msgstr ""
+msgstr "[B]Duplicados encontrados en la biblioteca de Kodi:[/B][CR]Películas: [B]%s[/B], Series: [B]%s[/B], Episodios: [B]%s[/B][CR]¿Continuar?"
 
 msgctxt "#30682"
 msgid "No duplicates were found in Kodi library"
-msgstr ""
+msgstr "No se encontraron duplicados en la biblioteca de Kodi"
 
 msgctxt "#30683"
 msgid "Starting library duplicates removal"
-msgstr ""
+msgstr "Iniciando la eliminación de duplicados de la biblioteca"
 
 msgctxt "#30684"
 msgid "Removed Movies: %s, Shows: %s, Episodes: %s"
-msgstr ""
+msgstr "Eliminados. Películas: %s, Series: %s, Episodios: %s"
 
 msgctxt "#30685"
 msgid "Remove movies from Elementum database"
-msgstr ""
+msgstr "Quitar películas de la base de datos de Elementum"
 
 msgctxt "#30686"
 msgid "Remove shows from Elementum database"
-msgstr ""
+msgstr "Quitar series de la base de datos de Elementum"
 
 msgctxt "#30687"
 msgid "In Elementum library"
-msgstr ""
+msgstr "En la biblioteca de Elementum"
 
 msgctxt "#30688"
 msgid "Skip searching for installed Elementum repository"
-msgstr ""
+msgstr "Omitir la búsqueda del repositorio de Elementum instalado"
 
 msgctxt "#30689"
 msgid "Internal DNS client"
-msgstr ""
+msgstr "Cliente DNS interno"
 
 msgctxt "#30691"
 msgid "Hide watched"
-msgstr ""
+msgstr "Ocultar vistos"
 
 msgctxt "#30692"
 msgid "TMDB images quality (affects Kodi performance)"
-msgstr ""
+msgstr "Calidad de las imágenes de TMDB (afecta al rendimiento de Kodi)"
 
 msgctxt "#30693"
 msgid "Original"
-msgstr ""
+msgstr "Original"
 
 msgctxt "#30694"
 msgid "High"
-msgstr ""
+msgstr "Alta"
 
 msgctxt "#30695"
 msgid "Medium"
-msgstr ""
+msgstr "Media"
 
 msgctxt "#30696"
 msgid "Low"
-msgstr ""
+msgstr "Baja"
 
 msgctxt "#30697"
 msgid "Interface language"
-msgstr ""
+msgstr "Idioma de la interfaz"
 
 msgctxt "#30698"
 msgid "Kodi language"
-msgstr ""
+msgstr "Idioma de Kodi"
 
 msgctxt "#30699"
 msgid "Use earliest release date for progress and calendars"
-msgstr ""
+msgstr "Usar la fecha de estreno más temprana para progreso y calendarios"
 
 msgctxt "#30700"
 msgid "Interface fallback language"
-msgstr ""
+msgstr "Idioma alternativo de la interfaz"
 
 msgctxt "#30701"
 msgid "English | en"
-msgstr ""
+msgstr "Inglés | en"
 
 msgctxt "#30702"
 msgid "Reached daily limit for subtitles downloads"
-msgstr ""
+msgstr "Se alcanzó el límite diario de descargas de subtítulos"
 
 msgctxt "#30703"
 msgid "Can be used by search providers or [CR]for debugging"
-msgstr ""
+msgstr "Puede ser usado por los proveedores de búsqueda o[CR]para depuración"
 
 msgctxt "#30704"
 msgid "TMDB API Key check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Falló la comprobación de la clave de API de TMDB, no se puede usar el servicio TMDB"
 
 msgctxt "#30705"
 msgid "TMDB API accessibility check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Falló la comprobación de accesibilidad de la API de TMDB, no se puede usar el servicio TMDB"
 
 msgctxt "#30706"
 msgid "Transmission 4.05"
-msgstr ""
+msgstr "Transmission 4.05"
 
 msgctxt "#30707"
 msgid "qBittorrent 3.3.9"
-msgstr ""
+msgstr "qBittorrent 3.3.9"
 
 msgctxt "#30708"
 msgid "qBittorrent 4.6.4"
-msgstr ""
+msgstr "qBittorrent 4.6.4"
 
 msgctxt "#30709"
 msgid "Open [B]%s[/B]"
-msgstr ""
+msgstr "Abrir [B]%s[/B]"
 
 msgctxt "#30710"
 msgid "BitTorrent ports"
-msgstr ""
+msgstr "Puertos de BitTorrent"
 
 msgctxt "#30711"
 msgid "Delete torrent '%s'?"
-msgstr ""
+msgstr "¿Eliminar el torrent '%s'?"
 
 msgctxt "#30712"
 msgid "Force to always use proxy, can break download in some cases"
-msgstr ""
+msgstr "Forzar el uso del proxy siempre, puede hacer que falle la descarga en algunos casos"
 
 msgctxt "#30713"
 msgid "Disable NATPMP"
@@ -2284,20 +2284,20 @@ msgstr "Desactivar NATPMP"
 
 msgctxt "#30714"
 msgid "Re-check torrent's data"
-msgstr ""
+msgstr "Volver a verificar los datos del torrent"
 
 msgctxt "#30715"
 msgid "Antizapret PAC file URL"
-msgstr ""
+msgstr "URL del archivo PAC de Antizapret"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "Servidor DNS sobre HTTPS"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "Servidor DNS sobre HTTPS personalizado"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "Usar servidores DNS de OpenNIC"

--- a/resources/language/Swedish/strings.po
+++ b/resources/language/Swedish/strings.po
@@ -1463,7 +1463,7 @@ msgstr "Stäng av om du använder TOR-adresser, eller du vill använda DNS-inst�
 
 msgctxt "#30497"
 msgid "Use Antizapret proxy (only for Russia)"
-msgstr ""
+msgstr "Använd Antizapret-proxy (endast för Ryssland)"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"
@@ -2291,16 +2291,16 @@ msgstr "Kontrollera torrentens data igen"
 
 msgctxt "#30715"
 msgid "Antizapret PAC file URL"
-msgstr ""
+msgstr "URL till Antizapret PAC-fil"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "DNS over HTTPS-server"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "Anpassad DNS over HTTPS-server"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "Använd OpenNIC DNS-servrar"


### PR DESCRIPTION
Follow-up to #1194, kept separate so it can be reviewed on its own.

Three more language files had empty `msgstr` entries, which fall back to English in the UI. This fills in every remaining one:

| Language | Strings | Now |
|---|---|---|
| Spanish (Argentina) | 42 | 571/571 |
| Polish | 3 | 571/571 |
| Swedish | 5 | 571/571 |

**Spanish (Argentina)** is the bulk of it: `30678`-`30718` plus `30119`, `30120` and `30497`. It is based on the Spanish file, adjusted where the regional wording differs, and it keeps the file's existing infinitive register so it does not have to pick a side on tuteo vs voseo in dialogs.

**Polish** and **Swedish** only needed the recent proxy and DNS settings. Each follows its own file's established conventions (`Użyj ...` / `Wyłącz ...`, `Använd ...` / `Inaktivera ...`).

Format placeholders and Kodi markup (`%s`, `[CR]`, `[B]`) were checked against the English source for every string touched.

One caveat worth stating plainly: **I am a Spanish speaker, not a Polish or Swedish one.** Those eight strings are short and mostly proper nouns (`Antizapret`, `OpenNIC`, `PAC`, `DNS over HTTPS`), but they would benefit from a native speaker glancing at them before this is merged. Happy to drop either file from this PR if you would rather wait for one.

For reference, the languages still furthest from complete are Slovak (511), Spanish (Mexico) (511), German (457), Portuguese (424) and Romanian (424).
