### PR TITLE
Fill in the remaining untranslated strings in 16 languages

### DIFF
--- a/resources/language/Croatian/strings.po
+++ b/resources/language/Croatian/strings.po
@@ -428,11 +428,11 @@ msgstr "Sakupljanje pratitelja..."
 
 msgctxt "#30119"
 msgid "ID of selected userlist for movies"
-msgstr ""
+msgstr "ID odabranog korisničkog popisa za filmove"
 
 msgctxt "#30120"
 msgid "ID of selected userlist for shows"
-msgstr ""
+msgstr "ID odabranog korisničkog popisa za serije"
 
 msgctxt "#30141"
 msgid "Please support Elementum development by visiting[CR]https://elementum.surge.sh/donate/ or https://elementumorg.github.io/donate/"
@@ -1477,7 +1477,7 @@ msgstr "Isključite ako koristite Tor adrese, ili želite proslijediti rješenje
 
 msgctxt "#30497"
 msgid "Use Antizapret proxy (only for Russia)"
-msgstr ""
+msgstr "Koristi Antizapret proxy (samo za Rusiju)"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"
@@ -2137,163 +2137,163 @@ msgstr "Popis Opennic DNS IP adresa"
 
 msgctxt "#30672"
 msgid "Compact database"
-msgstr ""
+msgstr "Sažmi bazu podataka"
 
 msgctxt "#30673"
 msgid "Compact cache database"
-msgstr ""
+msgstr "Sažmi bazu podataka predmemorije"
 
 msgctxt "#30674"
 msgid "Database was compacted"
-msgstr ""
+msgstr "Baza podataka je sažeta"
 
 msgctxt "#30675"
 msgid "Remote host login"
-msgstr ""
+msgstr "Korisničko ime udaljenog poslužitelja"
 
 msgctxt "#30676"
 msgid "Remote host password"
-msgstr ""
+msgstr "Lozinka udaljenog poslužitelja"
 
 msgctxt "#30677"
 msgid "Force start as a library"
-msgstr ""
+msgstr "Prisili pokretanje kao zbirka"
 
 msgctxt "#30678"
 msgid "Remove from Kodi library, when movie is deleted from Trakt"
-msgstr ""
+msgstr "Ukloni iz Kodi zbirke kada se film obriše s Trakta"
 
 msgctxt "#30679"
 msgid "Remove from Kodi library, when show is deleted from Trakt"
-msgstr ""
+msgstr "Ukloni iz Kodi zbirke kada se serija obriše s Trakta"
 
 msgctxt "#30680"
 msgid "Remove Elementum duplicates from library"
-msgstr ""
+msgstr "Ukloni Elementum duplikate iz zbirke"
 
 msgctxt "#30681"
 msgid "[B]Found duplicates in Kodi library:[/B][CR]Movies: [B]%s[/B], Shows: [B]%s[/B], Episodes: [B]%s[/B][CR]Proceed?"
-msgstr ""
+msgstr "[B]Pronađeni duplikati u Kodi zbirci:[/B][CR]Filmovi: [B]%s[/B], Serije: [B]%s[/B], Epizode: [B]%s[/B][CR]Nastaviti?"
 
 msgctxt "#30682"
 msgid "No duplicates were found in Kodi library"
-msgstr ""
+msgstr "Nisu pronađeni duplikati u Kodi zbirci"
 
 msgctxt "#30683"
 msgid "Starting library duplicates removal"
-msgstr ""
+msgstr "Pokretanje uklanjanja duplikata iz zbirke"
 
 msgctxt "#30684"
 msgid "Removed Movies: %s, Shows: %s, Episodes: %s"
-msgstr ""
+msgstr "Uklonjeno filmova: %s, serija: %s, epizoda: %s"
 
 msgctxt "#30685"
 msgid "Remove movies from Elementum database"
-msgstr ""
+msgstr "Ukloni filmove iz Elementum baze podataka"
 
 msgctxt "#30686"
 msgid "Remove shows from Elementum database"
-msgstr ""
+msgstr "Ukloni serije iz Elementum baze podataka"
 
 msgctxt "#30687"
 msgid "In Elementum library"
-msgstr ""
+msgstr "U Elementum zbirci"
 
 msgctxt "#30688"
 msgid "Skip searching for installed Elementum repository"
-msgstr ""
+msgstr "Preskoči traženje instaliranog Elementum repozitorija"
 
 msgctxt "#30689"
 msgid "Internal DNS client"
-msgstr ""
+msgstr "Interni DNS klijent"
 
 msgctxt "#30691"
 msgid "Hide watched"
-msgstr ""
+msgstr "Sakrij pogledano"
 
 msgctxt "#30692"
 msgid "TMDB images quality (affects Kodi performance)"
-msgstr ""
+msgstr "Kvaliteta TMDB slika (utječe na performanse Kodija)"
 
 msgctxt "#30693"
 msgid "Original"
-msgstr ""
+msgstr "Izvorna"
 
 msgctxt "#30694"
 msgid "High"
-msgstr ""
+msgstr "Visoka"
 
 msgctxt "#30695"
 msgid "Medium"
-msgstr ""
+msgstr "Srednja"
 
 msgctxt "#30696"
 msgid "Low"
-msgstr ""
+msgstr "Niska"
 
 msgctxt "#30697"
 msgid "Interface language"
-msgstr ""
+msgstr "Jezik sučelja"
 
 msgctxt "#30698"
 msgid "Kodi language"
-msgstr ""
+msgstr "Jezik Kodija"
 
 msgctxt "#30699"
 msgid "Use earliest release date for progress and calendars"
-msgstr ""
+msgstr "Koristi najraniji datum izlaska za napredak i kalendare"
 
 msgctxt "#30700"
 msgid "Interface fallback language"
-msgstr ""
+msgstr "Zamjenski jezik sučelja"
 
 msgctxt "#30701"
 msgid "English | en"
-msgstr ""
+msgstr "Engleski | en"
 
 msgctxt "#30702"
 msgid "Reached daily limit for subtitles downloads"
-msgstr ""
+msgstr "Dosegnuto dnevno ograničenje preuzimanja podnaslova"
 
 msgctxt "#30703"
 msgid "Can be used by search providers or [CR]for debugging"
-msgstr ""
+msgstr "Mogu ga koristiti pružatelji pretraživanja ili[CR]za otklanjanje pogrešaka"
 
 msgctxt "#30704"
 msgid "TMDB API Key check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Provjera TMDB API ključa nije uspjela, nije moguće koristiti TMDB uslugu"
 
 msgctxt "#30705"
 msgid "TMDB API accessibility check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Provjera dostupnosti TMDB API-ja nije uspjela, nije moguće koristiti TMDB uslugu"
 
 msgctxt "#30706"
 msgid "Transmission 4.05"
-msgstr ""
+msgstr "Transmission 4.05"
 
 msgctxt "#30707"
 msgid "qBittorrent 3.3.9"
-msgstr ""
+msgstr "qBittorrent 3.3.9"
 
 msgctxt "#30708"
 msgid "qBittorrent 4.6.4"
-msgstr ""
+msgstr "qBittorrent 4.6.4"
 
 msgctxt "#30709"
 msgid "Open [B]%s[/B]"
-msgstr ""
+msgstr "Otvori [B]%s[/B]"
 
 msgctxt "#30710"
 msgid "BitTorrent ports"
-msgstr ""
+msgstr "BitTorrent portovi"
 
 msgctxt "#30711"
 msgid "Delete torrent '%s'?"
-msgstr ""
+msgstr "Obrisati torrent '%s'?"
 
 msgctxt "#30712"
 msgid "Force to always use proxy, can break download in some cases"
-msgstr ""
+msgstr "Prisili uvijek korištenje proxyja, u nekim slučajevima može prekinuti preuzimanje"
 
 msgctxt "#30713"
 msgid "Disable NATPMP"
@@ -2301,20 +2301,20 @@ msgstr "Onemogući NATPMP"
 
 msgctxt "#30714"
 msgid "Re-check torrent's data"
-msgstr ""
+msgstr "Ponovno provjeri podatke torrenta"
 
 msgctxt "#30715"
 msgid "Antizapret PAC file URL"
-msgstr ""
+msgstr "URL Antizapret PAC datoteke"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "DNS over HTTPS poslužitelj"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "Prilagođeni DNS over HTTPS poslužitelj"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "Koristi OpenNIC DNS poslužitelje"

--- a/resources/language/Dutch/strings.po
+++ b/resources/language/Dutch/strings.po
@@ -22,7 +22,7 @@ msgstr "Algemeen"
 
 msgctxt "#30001"
 msgid "Download path"
-msgstr ""
+msgstr "Downloadpad"
 
 msgctxt "#30004"
 msgid "Max upload rate, kB/s"
@@ -98,7 +98,7 @@ msgstr "Kies stream automatisch"
 
 msgctxt "#30025"
 msgid "Limit rates after initial buffering only"
-msgstr ""
+msgstr "Snelheden pas na het initiële bufferen beperken"
 
 msgctxt "#30026"
 msgid "Library path"
@@ -110,7 +110,7 @@ msgstr "Maximaal aantal verbindingen"
 
 msgctxt "#30028"
 msgid "Download after play was stopped"
-msgstr ""
+msgstr "Blijven downloaden nadat het afspelen is gestopt"
 
 msgctxt "#30029"
 msgid "Session saving frequency, seconds"
@@ -234,7 +234,7 @@ msgstr "Bibliotheek update frequentie (uren)"
 
 msgctxt "#30063"
 msgid "Disable UPNP"
-msgstr ""
+msgstr "UPNP uitschakelen"
 
 msgctxt "#30064"
 msgid "Encryption policy"
@@ -274,7 +274,7 @@ msgstr "Spoof user agent (niet aanbevolen)"
 
 msgctxt "#30075"
 msgid "Default advisable (acceptable)"
-msgstr ""
+msgstr "Standaard aanbevolen (aanvaardbaar)"
 
 msgctxt "#30076"
 msgid "libtorrent (Rasterbar) 1.1.0"
@@ -338,11 +338,11 @@ msgstr "Gebruik standaard fanart"
 
 msgctxt "#30093"
 msgid "Disable notification sound"
-msgstr ""
+msgstr "Meldingsgeluid uitschakelen"
 
 msgctxt "#30094"
 msgid "Disable background progress dialog"
-msgstr ""
+msgstr "Voortgangsvenster op de achtergrond uitschakelen"
 
 # Interface
 msgctxt "#30100"
@@ -355,7 +355,7 @@ msgstr "Deze add-on kan alleen gebruikt worden door Elementum"
 
 msgctxt "#30103"
 msgid "Unable to find Elementum binary[CR]Required platform:"
-msgstr ""
+msgstr "Kan het Elementum-binaire bestand niet vinden[CR]Vereist platform:"
 
 msgctxt "#30104"
 msgid "Insert file or URL"
@@ -411,11 +411,11 @@ msgstr "Scraping trackers..."
 
 msgctxt "#30119"
 msgid "ID of selected userlist for movies"
-msgstr ""
+msgstr "ID van de geselecteerde gebruikerslijst voor films"
 
 msgctxt "#30120"
 msgid "ID of selected userlist for shows"
-msgstr ""
+msgstr "ID van de geselecteerde gebruikerslijst voor series"
 
 msgctxt "#30141"
 msgid "Please support Elementum development by visiting[CR]https://elementum.surge.sh/donate/ or https://elementumorg.github.io/donate/"
@@ -439,23 +439,23 @@ msgstr "Standaard weergave voor serie genres"
 
 msgctxt "#30146"
 msgid "Keep downloading '%s'?"
-msgstr ""
+msgstr "'%s' blijven downloaden?"
 
 msgctxt "#30147"
 msgid "Caches are still warming up, give it a minute or two..."
-msgstr ""
+msgstr "De caches worden nog opgebouwd, geef ze een minuut of twee..."
 
 msgctxt "#30148"
 msgid "Caches warmed up"
-msgstr ""
+msgstr "Caches zijn klaar"
 
 msgctxt "#30149"
 msgid "Trakt username not set, check your settings"
-msgstr ""
+msgstr "Trakt-gebruikersnaam niet ingesteld, controleer je instellingen"
 
 msgctxt "#30199"
 msgid "No available JSON-RPC connection to Kodi.[CR]Enable both Application control options in Service settings / Control and restart Kodi."
-msgstr ""
+msgstr "Geen JSON-RPC-verbinding met Kodi beschikbaar.[CR]Schakel beide opties voor applicatiebediening in bij Service-instellingen / Bediening en herstart Kodi."
 
 # Elementum daemon
 msgctxt "#30200"
@@ -712,7 +712,7 @@ msgstr "%s verwijderd van bibliotheek, wilt u nu opnieuw scannen?[CR] U kunt ook
 
 msgctxt "#30279"
 msgid "Video %s was previously removed from library.[CR]Force adding?"
-msgstr ""
+msgstr "Video %s is eerder uit de bibliotheek verwijderd.[CR]Toevoegen forceren?"
 
 msgctxt "#30282"
 msgid "Nothing left to remove from Elementum"
@@ -792,1512 +792,1512 @@ msgstr "Alle Premieres"
 
 msgctxt "#30301"
 msgid "Move finished downloads to separate folders"
-msgstr ""
+msgstr "Voltooide downloads naar aparte mappen verplaatsen"
 
 msgctxt "#30302"
 msgid "Files will only be moved after seeding is finished (see[CR]- BitTorrent settings), and will wait if currently playing"
-msgstr ""
+msgstr "Bestanden worden pas verplaatst nadat het seeden is voltooid (zie[CR]- BitTorrent-instellingen), en wachten als er wordt afgespeeld"
 
 msgctxt "#30303"
 msgid "RAR archive detected. Download will need to be completed before playback can start and will require around twice the amount of space, continue?"
-msgstr ""
+msgstr "RAR-archief gedetecteerd. De download moet voltooid zijn voordat het afspelen kan beginnen en vereist ongeveer twee keer zoveel ruimte. Doorgaan?"
 
 msgctxt "#30304"
 msgid "Error creating output pipe for 'unrar' command"
-msgstr ""
+msgstr "Fout bij het aanmaken van de uitvoerpipe voor de opdracht 'unrar'"
 
 msgctxt "#30305"
 msgid "Error starting 'unrar' command"
-msgstr ""
+msgstr "Fout bij het starten van de opdracht 'unrar'"
 
 msgctxt "#30306"
 msgid "Error waiting for 'unrar' command"
-msgstr ""
+msgstr "Fout bij het wachten op de opdracht 'unrar'"
 
 msgctxt "#30307"
 msgid "Error reading from destination folder"
-msgstr ""
+msgstr "Fout bij het lezen uit de doelmap"
 
 msgctxt "#30308"
 msgid "Move completed"
-msgstr ""
+msgstr "Verplaatsen voltooid"
 
 msgctxt "#30309"
 msgid "Keep"
-msgstr ""
+msgstr "Behouden"
 
 msgctxt "#30310"
 msgid "Ask to delete"
-msgstr ""
+msgstr "Vragen om te verwijderen"
 
 msgctxt "#30311"
 msgid "Delete"
-msgstr ""
+msgstr "Verwijderen"
 
 msgctxt "#30312"
 msgid "Keep files for not finished video"
-msgstr ""
+msgstr "Bestanden van niet-voltooide video's behouden"
 
 msgctxt "#30313"
 msgid "Keep files for watched/downloaded video"
-msgstr ""
+msgstr "Bestanden van bekeken/gedownloade video's behouden"
 
 msgctxt "#30314"
 msgid "Settings were not initialized.[CR]Save addon settings, then restart Kodi."
-msgstr ""
+msgstr "De instellingen zijn niet geïnitialiseerd.[CR]Sla de add-on-instellingen op en herstart Kodi."
 
 msgctxt "#30315"
 msgid "Download storage type"
-msgstr ""
+msgstr "Opslagtype voor downloads"
 
 msgctxt "#30316"
 msgid "Use files"
-msgstr ""
+msgstr "Bestanden gebruiken"
 
 msgctxt "#30317"
 msgid "Use memory"
-msgstr ""
+msgstr "Geheugen gebruiken"
 
 msgctxt "#30318"
 msgid "Memory size to use for each torrent, Mb"
-msgstr ""
+msgstr "Te gebruiken geheugen per torrent, MB"
 
 msgctxt "#30319"
 msgid "Continue"
-msgstr ""
+msgstr "Doorgaan"
 
 msgctxt "#30320"
 msgid "Ask to stop"
-msgstr ""
+msgstr "Vragen om te stoppen"
 
 msgctxt "#30321"
 msgid "Stop"
-msgstr ""
+msgstr "Stoppen"
 
 msgctxt "#30323"
 msgid "New search"
-msgstr ""
+msgstr "Nieuwe zoekopdracht"
 
 msgctxt "#30324"
 msgid "Force stream auto-selection from settings"
-msgstr ""
+msgstr "Automatische streamselectie uit de instellingen forceren"
 
 msgctxt "#30325"
 msgid "Download"
-msgstr ""
+msgstr "Download"
 
 msgctxt "#30326"
 msgid "Kodi library"
-msgstr ""
+msgstr "Kodi-bibliotheek"
 
 msgctxt "#30327"
 msgid "Storage"
-msgstr ""
+msgstr "Opslag"
 
 msgctxt "#30328"
 msgid "Disable TCP"
-msgstr ""
+msgstr "TCP uitschakelen"
 
 msgctxt "#30329"
 msgid "Disable UTP"
-msgstr ""
+msgstr "UTP uitschakelen"
 
 msgctxt "#30330"
 msgid "Update Trakt"
-msgstr ""
+msgstr "Trakt bijwerken"
 
 msgctxt "#30332"
 msgid "Reloading configuration..."
-msgstr ""
+msgstr "Configuratie wordt opnieuw geladen..."
 
 msgctxt "#30333"
 msgid "Try to find other episodes in the torrent"
-msgstr ""
+msgstr "Proberen andere afleveringen in de torrent te vinden"
 
 msgctxt "#30347"
 msgid "Could not find binary for architecture '%s'![CR]Try to uninstall this addon, re-download and re-install it from the biggest zip."
-msgstr ""
+msgstr "Kon geen binair bestand vinden voor architectuur '%s'![CR]Probeer deze add-on te verwijderen, opnieuw te downloaden en te installeren vanaf de grootste zip."
 
 msgctxt "#30348"
 msgid "Create usual files on the file system and write to them.[CR]Needs selected file's full size to be available on the disk!"
-msgstr ""
+msgstr "Maakt gewone bestanden aan op het bestandssysteem en schrijft daarnaar.[CR]De volledige grootte van het geselecteerde bestand moet beschikbaar zijn op de schijf!"
 
 msgctxt "#30349"
 msgid "Using device's memory to download parts of the torrent.[CR]Disk is used only to download and save .torrent file,"
-msgstr ""
+msgstr "Gebruikt het geheugen van het apparaat om delen van de torrent te downloaden.[CR]De schijf wordt alleen gebruikt om het .torrent-bestand te downloaden en op te slaan,"
 
 msgctxt "#30350"
 msgid "so can be any storage. For 1gb memory devices[CR]100mb is enough for memory storage, 200-250mb for bigger devices."
-msgstr ""
+msgstr "dus dat kan elke opslag zijn. Voor apparaten met 1 GB geheugen[CR]is 100 MB genoeg, 200-250 MB voor grotere apparaten."
 
 msgctxt "#30351"
 msgid "Same as for usual file storage, but splits file into many small files.[CR]Should be used on FAT-32 file-systems."
-msgstr ""
+msgstr "Zoals de gewone bestandsopslag, maar splitst het bestand in veel kleine bestanden.[CR]Te gebruiken op FAT-32-bestandssystemen."
 
 msgctxt "#30352"
 msgid "Same as for usual file storage, but using memory[CR]to lower filesystem operations. Experimental storage!"
-msgstr ""
+msgstr "Zoals de gewone bestandsopslag, maar gebruikt het geheugen[CR]om bestandssysteembewerkingen te beperken. Experimentele opslag!"
 
 msgctxt "#30355"
 msgid "Changelog"
-msgstr ""
+msgstr "Wijzigingslogboek"
 
 msgctxt "#30357"
 msgid "Use Trakt information in Trakt lists"
-msgstr ""
+msgstr "Trakt-informatie gebruiken in Trakt-lijsten"
 
 msgctxt "#30358"
 msgid "Trakt update started"
-msgstr ""
+msgstr "Trakt-update gestart"
 
 msgctxt "#30359"
 msgid "Do not ask questions before playback"
-msgstr ""
+msgstr "Geen vragen stellen voor het afspelen"
 
 msgctxt "#30360"
 msgid "My Progress"
-msgstr ""
+msgstr "Mijn voortgang"
 
 msgctxt "#30361"
 msgid "My History"
-msgstr ""
+msgstr "Mijn geschiedenis"
 
 msgctxt "#30362"
 msgid "Synchronization"
-msgstr ""
+msgstr "Synchronisatie"
 
 msgctxt "#30363"
 msgid "Sync items from collections into Kodi library"
-msgstr ""
+msgstr "Items uit collecties synchroniseren naar de Kodi-bibliotheek"
 
 msgctxt "#30364"
 msgid "Sync items from watchlist into Kodi library"
-msgstr ""
+msgstr "Items van de volglijst synchroniseren naar de Kodi-bibliotheek"
 
 msgctxt "#30365"
 msgid "Sync items from user lists into Kodi library"
-msgstr ""
+msgstr "Items uit gebruikerslijsten synchroniseren naar de Kodi-bibliotheek"
 
 msgctxt "#30366"
 msgid "Sync watched states from Trakt into Kodi library"
-msgstr ""
+msgstr "Bekeken-status van Trakt synchroniseren naar de Kodi-bibliotheek"
 
 msgctxt "#30367"
 msgid "Sync back Kodi watched states into Trakt"
-msgstr ""
+msgstr "Bekeken-status van Kodi terugsynchroniseren naar Trakt"
 
 msgctxt "#30369"
 msgid "Disable Upload"
-msgstr ""
+msgstr "Uploaden uitschakelen"
 
 msgctxt "#30370"
 msgid "Auto-assign network IP"
-msgstr ""
+msgstr "Netwerk-IP automatisch toewijzen"
 
 msgctxt "#30371"
 msgid "Auto-assign network ports"
-msgstr ""
+msgstr "Netwerkpoorten automatisch toewijzen"
 
 msgctxt "#30373"
 msgid "Languages"
-msgstr ""
+msgstr "Talen"
 
 msgctxt "#30374"
 msgid "Countries"
-msgstr ""
+msgstr "Landen"
 
 msgctxt "#30375"
 msgid "By size"
-msgstr ""
+msgstr "Op grootte"
 
 msgctxt "#30376"
 msgid "Choose memory size automatically"
-msgstr ""
+msgstr "Geheugengrootte automatisch kiezen"
 
 msgctxt "#30377"
 msgid "Size is chosen automatically, based on[CR]physical amount of memory"
-msgstr ""
+msgstr "De grootte wordt automatisch gekozen op basis van[CR]de fysiek beschikbare hoeveelheid geheugen"
 
 msgctxt "#30378"
 msgid "Allow memory usage"
-msgstr ""
+msgstr "Geheugengebruik toestaan"
 
 msgctxt "#30379"
 msgid "Minimum - 40MB, Default - 8%, Maximum - 15%"
-msgstr ""
+msgstr "Minimum - 40 MB, Standaard - 8%, Maximum - 15%"
 
 msgctxt "#30380"
 msgid "Minimum"
-msgstr ""
+msgstr "Minimum"
 
 msgctxt "#30381"
 msgid "Default"
-msgstr ""
+msgstr "Standaard"
 
 msgctxt "#30382"
 msgid "Maximum"
-msgstr ""
+msgstr "Maximum"
 
 msgctxt "#30383"
 msgid "Use Kodi language for subtitles search"
-msgstr ""
+msgstr "Kodi-taal gebruiken voor het zoeken naar ondertitels"
 
 msgctxt "#30384"
 msgid "Language code for subtitles (example: en, it, es)"
-msgstr ""
+msgstr "Taalcode voor ondertitels (voorbeeld: en, it, es)"
 
 msgctxt "#30386"
 msgid "Disable background progress dialog on playback"
-msgstr ""
+msgstr "Voortgangsvenster op de achtergrond tijdens afspelen uitschakelen"
 
 msgctxt "#30387"
 msgid "Caching"
-msgstr ""
+msgstr "Caching"
 
 msgctxt "#30388"
 msgid "Cache stream selection"
-msgstr ""
+msgstr "Streamselectie cachen"
 
 msgctxt "#30389"
 msgid "Cache stream search results"
-msgstr ""
+msgstr "Zoekresultaten van streams cachen"
 
 msgctxt "#30390"
 msgid "Cache search results duration, seconds"
-msgstr ""
+msgstr "Bewaarduur van gecachete zoekresultaten, seconden"
 
 msgctxt "#30393"
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 msgctxt "#30394"
 msgid "Version"
-msgstr ""
+msgstr "Versie"
 
 msgctxt "#30395"
 msgid "IP address"
-msgstr ""
+msgstr "IP-adres"
 
 msgctxt "#30396"
 msgid "Port"
-msgstr ""
+msgstr "Poort"
 
 msgctxt "#30397"
 msgid "Web UI"
-msgstr ""
+msgstr "Webinterface"
 
 msgctxt "#30398"
 msgid "Debug information (with kodi.log)"
-msgstr ""
+msgstr "Foutopsporingsinformatie (met kodi.log)"
 
 msgctxt "#30399"
 msgid "Addresses"
-msgstr ""
+msgstr "Adressen"
 
 msgctxt "#30400"
 msgid "Statistics"
-msgstr ""
+msgstr "Statistieken"
 
 msgctxt "#30401"
 msgid "Torrent library status"
-msgstr ""
+msgstr "Status van de torrentbibliotheek"
 
 msgctxt "#30402"
 msgid "Size of cache.db"
-msgstr ""
+msgstr "Grootte van cache.db"
 
 msgctxt "#30403"
 msgid "Size of app.db"
-msgstr ""
+msgstr "Grootte van app.db"
 
 msgctxt "#30404"
 msgid "Assigned torrent files"
-msgstr ""
+msgstr "Toegewezen torrentbestanden"
 
 msgctxt "#30405"
 msgid "Search queries"
-msgstr ""
+msgstr "Zoekopdrachten"
 
 msgctxt "#30406"
 msgid "Remove from history"
-msgstr ""
+msgstr "Uit de geschiedenis verwijderen"
 
 msgctxt "#30408"
 msgid "Addon Connectivity"
-msgstr ""
+msgstr "Add-on-verbinding"
 
 msgctxt "#30409"
 msgid "Local port"
-msgstr ""
+msgstr "Lokale poort"
 
 msgctxt "#30410"
 msgid "Remote port"
-msgstr ""
+msgstr "Externe poort"
 
 msgctxt "#30411"
 msgid "Remote host"
-msgstr ""
+msgstr "Externe host"
 
 msgctxt "#30412"
 msgid "Do not start binary (client mode)"
-msgstr ""
+msgstr "Binair bestand niet starten (clientmodus)"
 
 msgctxt "#30413"
 msgid "Yes"
-msgstr ""
+msgstr "Ja"
 
 msgctxt "#30414"
 msgid "No"
-msgstr ""
+msgstr "Nee"
 
 msgctxt "#30415"
 msgid "Next page (%s)"
-msgstr ""
+msgstr "Volgende pagina (%s)"
 
 msgctxt "#30416"
 msgid "Percents of playback to mark as watched"
-msgstr ""
+msgstr "Percentage van het afspelen om als bekeken te markeren"
 
 msgctxt "#30417"
 msgid "Use name of production company as Studio for shows"
-msgstr ""
+msgstr "Naam van de productiemaatschappij als Studio gebruiken voor series"
 
 msgctxt "#30418"
 msgid "Calculate number of unwatched episodes in Shows/Seasons"
-msgstr ""
+msgstr "Aantal onbekeken afleveringen in Series/Seizoenen berekenen"
 
 msgctxt "#30421"
 msgid "Load torrents from torrents folder on startup"
-msgstr ""
+msgstr "Torrents bij het opstarten laden uit de torrentmap"
 
 msgctxt "#30422"
 msgid "Popular lists"
-msgstr ""
+msgstr "Populaire lijsten"
 
 msgctxt "#30423"
 msgid "Recommendations"
-msgstr ""
+msgstr "Aanbevelingen"
 
 msgctxt "#30424"
 msgid "Progress"
-msgstr ""
+msgstr "Voortgang"
 
 msgctxt "#30425"
 msgid "Color of an air date"
-msgstr ""
+msgstr "Kleur van de uitzenddatum"
 
 msgctxt "#30426"
 msgid "Color of a show name"
-msgstr ""
+msgstr "Kleur van de serienaam"
 
 msgctxt "#30427"
 msgid "Color of an episode name"
-msgstr ""
+msgstr "Kleur van de afleveringsnaam"
 
 msgctxt "#30428"
 msgid "Hide unaired episodes"
-msgstr ""
+msgstr "Niet-uitgezonden afleveringen verbergen"
 
 msgctxt "#30429"
 msgid "Sort shows in the list"
-msgstr ""
+msgstr "Series in de lijst sorteren"
 
 msgctxt "#30430"
 msgid "By latest watched"
-msgstr ""
+msgstr "Op laatst bekeken"
 
 msgctxt "#30431"
 msgid "By show name"
-msgstr ""
+msgstr "Op serienaam"
 
 msgctxt "#30432"
 msgid "By air date (newer)"
-msgstr ""
+msgstr "Op uitzenddatum (nieuwer)"
 
 msgctxt "#30433"
 msgid "By air date (older)"
-msgstr ""
+msgstr "Op uitzenddatum (ouder)"
 
 msgctxt "#30434"
 msgid "Date format"
-msgstr ""
+msgstr "Datumnotatie"
 
 msgctxt "#30436"
 msgid "Userlist"
-msgstr ""
+msgstr "Gebruikerslijst"
 
 msgctxt "#30438"
 msgid "Userlists"
-msgstr ""
+msgstr "Gebruikerslijsten"
 
 msgctxt "#30439"
 msgid "Debug information (without kodi.log)"
-msgstr ""
+msgstr "Foutopsporingsinformatie (zonder kodi.log)"
 
 msgctxt "#30440"
 msgid "Color of an unaired episode name"
-msgstr ""
+msgstr "Kleur van de naam van een niet-uitgezonden aflevering"
 
 msgctxt "#30441"
 msgid "Select userlist for movies"
-msgstr ""
+msgstr "Gebruikerslijst voor films selecteren"
 
 msgctxt "#30442"
 msgid "Userlist for movies"
-msgstr ""
+msgstr "Gebruikerslijst voor films"
 
 msgctxt "#30443"
 msgid "Selected userlist for movies"
-msgstr ""
+msgstr "Geselecteerde gebruikerslijst voor films"
 
 msgctxt "#30444"
 msgid "Select userlist for shows"
-msgstr ""
+msgstr "Gebruikerslijst voor series selecteren"
 
 msgctxt "#30445"
 msgid "Userlist for shows"
-msgstr ""
+msgstr "Gebruikerslijst voor series"
 
 msgctxt "#30446"
 msgid "Selected userlist for shows"
-msgstr ""
+msgstr "Geselecteerde gebruikerslijst voor series"
 
 msgctxt "#30447"
 msgid "Add to Trakt, when movie is added to Kodi library"
-msgstr ""
+msgstr "Toevoegen aan Trakt wanneer een film aan de Kodi-bibliotheek wordt toegevoegd"
 
 msgctxt "#30448"
 msgid "Add to Trakt, when show is added to Kodi library"
-msgstr ""
+msgstr "Toevoegen aan Trakt wanneer een serie aan de Kodi-bibliotheek wordt toegevoegd"
 
 msgctxt "#30449"
 msgid "Remove from Trakt, when movie is deleted from Kodi library"
-msgstr ""
+msgstr "Verwijderen uit Trakt wanneer een film uit de Kodi-bibliotheek wordt verwijderd"
 
 msgctxt "#30450"
 msgid "Remove from Trakt, when show is deleted from Kodi library"
-msgstr ""
+msgstr "Verwijderen uit Trakt wanneer een serie uit de Kodi-bibliotheek wordt verwijderd"
 
 msgctxt "#30451"
 msgid "Torrent files path"
-msgstr ""
+msgstr "Pad voor torrentbestanden"
 
 msgctxt "#30452"
 msgid "Reset all paths"
-msgstr ""
+msgstr "Alle paden herstellen"
 
 msgctxt "#30453"
 msgid "Upload /debug/bundle (with kodi.log) to pastebin"
-msgstr ""
+msgstr "/debug/bundle (met kodi.log) uploaden naar pastebin"
 
 msgctxt "#30454"
 msgid "Paste url:[CR]%s"
-msgstr ""
+msgstr "Paste-URL:[CR]%s"
 
 msgctxt "#30455"
 msgid "Logging"
-msgstr ""
+msgstr "Logboekregistratie"
 
 msgctxt "#30456"
 msgid "Upload /debug/all (no kodi.log) to pastebin"
-msgstr ""
+msgstr "/debug/all (zonder kodi.log) uploaden naar pastebin"
 
 msgctxt "#30457"
 msgid "Uploading file to pastebin"
-msgstr ""
+msgstr "Bestand wordt geüpload naar pastebin"
 
 msgctxt "#30458"
 msgid "Deleted movies"
-msgstr ""
+msgstr "Verwijderde films"
 
 msgctxt "#30459"
 msgid "Deleted shows"
-msgstr ""
+msgstr "Verwijderde series"
 
 msgctxt "#30460"
 msgid "Database"
-msgstr ""
+msgstr "Database"
 
 msgctxt "#30461"
 msgid "Show information"
-msgstr ""
+msgstr "Informatie tonen"
 
 msgctxt "#30462"
 msgid "Clear deleted movies"
-msgstr ""
+msgstr "Verwijderde films opschonen"
 
 msgctxt "#30463"
 msgid "Clear deleted shows"
-msgstr ""
+msgstr "Verwijderde series opschonen"
 
 msgctxt "#30464"
 msgid "Clear torrents history"
-msgstr ""
+msgstr "Torrentgeschiedenis wissen"
 
 msgctxt "#30465"
 msgid "Clear search history"
-msgstr ""
+msgstr "Zoekgeschiedenis wissen"
 
 msgctxt "#30466"
 msgid "Clear the database"
-msgstr ""
+msgstr "De database wissen"
 
 msgctxt "#30467"
 msgid "Cache"
-msgstr ""
+msgstr "Cache"
 
 msgctxt "#30468"
 msgid "Clear TMDB cache"
-msgstr ""
+msgstr "TMDB-cache wissen"
 
 msgctxt "#30469"
 msgid "Clear Trakt cache"
-msgstr ""
+msgstr "Trakt-cache wissen"
 
 msgctxt "#30470"
 msgid "Clear the cache"
-msgstr ""
+msgstr "De cache wissen"
 
 msgctxt "#30471"
 msgid "Are you sure you want to do it?"
-msgstr ""
+msgstr "Weet je zeker dat je dit wilt doen?"
 
 msgctxt "#30472"
 msgid "Database cleared"
-msgstr ""
+msgstr "Database gewist"
 
 msgctxt "#30473"
 msgid "Select network interface"
-msgstr ""
+msgstr "Netwerkinterface selecteren"
 
 msgctxt "#30474"
 msgid "Network interfaces"
-msgstr ""
+msgstr "Netwerkinterfaces"
 
 msgctxt "#30475"
 msgid "Strm files language"
-msgstr ""
+msgstr "Taal van strm-bestanden"
 
 msgctxt "#30476"
 msgid "Select language"
-msgstr ""
+msgstr "Taal selecteren"
 
 msgctxt "#30477"
 msgid "Original language"
-msgstr ""
+msgstr "Oorspronkelijke taal"
 
 msgctxt "#30478"
 msgid "Searching"
-msgstr ""
+msgstr "Bezig met zoeken"
 
 msgctxt "#30480"
 msgid "Run Kodi library update after add/delete"
-msgstr ""
+msgstr "Kodi-bibliotheekupdate uitvoeren na toevoegen/verwijderen"
 
 msgctxt "#30481"
 msgid "Automatically"
-msgstr ""
+msgstr "Automatisch"
 
 msgctxt "#30482"
 msgid "Ask"
-msgstr ""
+msgstr "Vragen"
 
 msgctxt "#30483"
 msgid "Create NFO files for Movie scrapers"
-msgstr ""
+msgstr "NFO-bestanden aanmaken voor filmscrapers"
 
 msgctxt "#30484"
 msgid "Create NFO files for TV Show scrapers"
-msgstr ""
+msgstr "NFO-bestanden aanmaken voor seriescrapers"
 
 msgctxt "#30485"
 msgid "Concurrent connections limit per second"
-msgstr ""
+msgstr "Limiet gelijktijdige verbindingen per seconde"
 
 msgctxt "#30486"
 msgid "Automatic concurrent connections limit per second"
-msgstr ""
+msgstr "Automatische limiet gelijktijdige verbindingen per seconde"
 
 msgctxt "#30487"
 msgid "Enable built-in HTTP proxy"
-msgstr ""
+msgstr "Ingebouwde HTTP-proxy inschakelen"
 
 msgctxt "#30488"
 msgid "Internal Proxy Port"
-msgstr ""
+msgstr "Poort van de interne proxy"
 
 msgctxt "#30489"
 msgid "Log Internal proxy requests"
-msgstr ""
+msgstr "Verzoeken van de interne proxy loggen"
 
 msgctxt "#30490"
 msgid "Internal HTTP proxy"
-msgstr ""
+msgstr "Interne HTTP-proxy"
 
 msgctxt "#30491"
 msgid "Use Fanart.tv for posters/images"
-msgstr ""
+msgstr "Fanart.tv gebruiken voor posters/afbeeldingen"
 
 msgctxt "#30492"
 msgid "Use Proxy for downloading .torrent files"
-msgstr ""
+msgstr "Proxy gebruiken voor het downloaden van .torrent-bestanden"
 
 msgctxt "#30493"
 msgid "Use Proxy for trackers"
-msgstr ""
+msgstr "Proxy gebruiken voor trackers"
 
 msgctxt "#30494"
 msgid "Use Proxy for torrent downloading"
-msgstr ""
+msgstr "Proxy gebruiken voor het downloaden van torrents"
 
 msgctxt "#30495"
 msgid "Use built-in DNS resolver"
-msgstr ""
+msgstr "Ingebouwde DNS-resolver gebruiken"
 
 msgctxt "#30496"
 msgid "Turn off if you use Tor addresses, or you want [CR]to use DNS settings from OS"
-msgstr ""
+msgstr "Uitschakelen als je Tor-adressen gebruikt, of als je [CR]de DNS-instellingen van het besturingssysteem wilt gebruiken"
 
 msgctxt "#30497"
 msgid "Use Antizapret proxy (only for Russia)"
-msgstr ""
+msgstr "Antizapret-proxy gebruiken (alleen voor Rusland)"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"
-msgstr ""
+msgstr "Dit pad terugzetten naar '/'"
 
 msgctxt "#30499"
 msgid "Automatically adjust memory size[CR]for heavy torrents, if possible"
-msgstr ""
+msgstr "Geheugengrootte automatisch aanpassen[CR]voor zware torrents, indien mogelijk"
 
 msgctxt "#30500"
 msgid "Automatically adjust buffer size[CR]for heavy torrents"
-msgstr ""
+msgstr "Buffergrootte automatisch aanpassen[CR]voor zware torrents"
 
 msgctxt "#30502"
 msgid "Adjust buffer according to Kodi advancedsettings.xml, if set"
-msgstr ""
+msgstr "Buffer aanpassen volgens Kodi advancedsettings.xml, indien ingesteld"
 
 msgctxt "#30503"
 msgid "Use libtorrent.config to override torrent engine settings"
-msgstr ""
+msgstr "libtorrent.config gebruiken om de instellingen van de torrent-engine te overschrijven"
 
 msgctxt "#30504"
 msgid "Located at USERDATA/plugin.video.elementum/libtorrent.config file[CR]Settings apply automatically. Visit https://libtorrent.org for info."
-msgstr ""
+msgstr "Te vinden in het bestand USERDATA/plugin.video.elementum/libtorrent.config[CR]De instellingen worden automatisch toegepast. Zie https://libtorrent.org voor info."
 
 msgctxt "#30505"
 msgid "Add episode number to the title"
-msgstr ""
+msgstr "Afleveringsnummer aan de titel toevoegen"
 
 msgctxt "#30506"
 msgid "Enable libtorrent logging"
-msgstr ""
+msgstr "libtorrent-logboekregistratie inschakelen"
 
 msgctxt "#30511"
 msgid "Libtorrent settings profile"
-msgstr ""
+msgstr "Instellingenprofiel van libtorrent"
 
 msgctxt "#30512"
 msgid "Default"
-msgstr ""
+msgstr "Standaard"
 
 msgctxt "#30513"
 msgid "Minimal memory"
-msgstr ""
+msgstr "Minimaal geheugen"
 
 msgctxt "#30514"
 msgid "High speed"
-msgstr ""
+msgstr "Hoge snelheid"
 
 msgctxt "#30515"
 msgid "Load torrents from torrents folder paused"
-msgstr ""
+msgstr "Torrents gepauzeerd laden uit de torrentmap"
 
 msgctxt "#30516"
 msgid "... resume N seconds earlier"
-msgstr ""
+msgstr "... N seconden eerder hervatten"
 
 msgctxt "#30517"
 msgid "In Kodi library"
-msgstr ""
+msgstr "In de Kodi-bibliotheek"
 
 msgctxt "#30518"
 msgid "Use libtorrent deadlines"
-msgstr ""
+msgstr "libtorrent-deadlines gebruiken"
 
 msgctxt "#30519"
 msgid "Use libtorrent pause/resume trick for added torrents"
-msgstr ""
+msgstr "libtorrent-pauzeer/hervat-truc gebruiken voor toegevoegde torrents"
 
 msgctxt "#30520"
 msgid "Add item to start menu"
-msgstr ""
+msgstr "Item aan het startmenu toevoegen"
 
 msgctxt "#30521"
 msgid "Delete item from start menu"
-msgstr ""
+msgstr "Item uit het startmenu verwijderen"
 
 msgctxt "#30522"
 msgid "Minimum file size"
-msgstr ""
+msgstr "Minimale bestandsgrootte"
 
 msgctxt "#30523"
 msgid "Minimum file size for Movies, MB"
-msgstr ""
+msgstr "Minimale bestandsgrootte voor films, MB"
 
 msgctxt "#30524"
 msgid "Minimum file size for Shows, MB per minute"
-msgstr ""
+msgstr "Minimale bestandsgrootte voor series, MB per minuut"
 
 msgctxt "#30525"
 msgid "Automatically start downloading next episode"
-msgstr ""
+msgstr "Volgende aflevering automatisch beginnen te downloaden"
 
 msgctxt "#30527"
 msgid "Donate"
-msgstr ""
+msgstr "Doneren"
 
 msgctxt "#30528"
 msgid "Automatically load first found subtitles"
-msgstr ""
+msgstr "Eerst gevonden ondertitels automatisch laden"
 
 msgctxt "#30529"
 msgid "Number of subtitles to load automatically"
-msgstr ""
+msgstr "Aantal automatisch te laden ondertitels"
 
 msgctxt "#30530"
 msgid "Delete autoloaded subtitles on player stop"
-msgstr ""
+msgstr "Automatisch geladen ondertitels verwijderen bij het stoppen van de speler"
 
 msgctxt "#30531"
 msgid "Download all files from torrent"
-msgstr ""
+msgstr "Alle bestanden uit de torrent downloaden"
 
 msgctxt "#30532"
 msgid "Stop Downloading all files"
-msgstr ""
+msgstr "Het downloaden van alle bestanden stoppen"
 
 msgctxt "#30535"
 msgid "Continue playback from [B]%s[/B]?"
-msgstr ""
+msgstr "Afspelen hervatten vanaf [B]%s[/B]?"
 
 msgctxt "#30536"
 msgid "Skip IPv6 addresses resolving"
-msgstr ""
+msgstr "Het opzoeken van IPv6-adressen overslaan"
 
 msgctxt "#30537"
 msgid "Torrents history"
-msgstr ""
+msgstr "Torrentgeschiedenis"
 
 msgctxt "#30538"
 msgid "Use torrents history?"
-msgstr ""
+msgstr "Torrentgeschiedenis gebruiken?"
 
 msgctxt "#30539"
 msgid "Store N torrents in history"
-msgstr ""
+msgstr "N torrents in de geschiedenis bewaren"
 
 msgctxt "#30540"
 msgid "Subtitles"
-msgstr ""
+msgstr "Ondertitels"
 
 msgctxt "#30541"
 msgid "Automatic Subtitles Search"
-msgstr ""
+msgstr "Automatisch zoeken naar ondertitels"
 
 msgctxt "#30542"
 msgid "Disable if subtitles are available in player"
-msgstr ""
+msgstr "Uitschakelen als er ondertitels beschikbaar zijn in de speler"
 
 msgctxt "#30543"
 msgid "Subtitles included in torrent"
-msgstr ""
+msgstr "Ondertitels in de torrent"
 
 msgctxt "#30544"
 msgid "Automatic Scrape"
-msgstr ""
+msgstr "Automatisch scrapen"
 
 msgctxt "#30545"
 msgid "Automatic scraping allows to scrape connected providers[CR]to find new movies, if there are results,"
-msgstr ""
+msgstr "Automatisch scrapen doorzoekt de verbonden providers[CR]op nieuwe films. Als er resultaten zijn"
 
 msgctxt "#30546"
 msgid "Strategy"
-msgstr ""
+msgstr "Strategie"
 
 msgctxt "#30547"
 msgid "Find in each provider"
-msgstr ""
+msgstr "Zoeken bij elke provider"
 
 msgctxt "#30548"
 msgid "Find in overall"
-msgstr ""
+msgstr "In het geheel zoeken"
 
 msgctxt "#30549"
 msgid "Search is successful when found N results"
-msgstr ""
+msgstr "Het zoeken is geslaagd bij N gevonden resultaten"
 
 msgctxt "#30550"
 msgid "What to search"
-msgstr ""
+msgstr "Waarnaar wordt gezocht"
 
 msgctxt "#30551"
 msgid "How to search"
-msgstr ""
+msgstr "Hoe er wordt gezocht"
 
 msgctxt "#30552"
 msgid "Search each N hours"
-msgstr ""
+msgstr "Elke N uur zoeken"
 
 msgctxt "#30553"
 msgid "Find 4K resolution"
-msgstr ""
+msgstr "4K-resolutie vinden"
 
 msgctxt "#30554"
 msgid "Find 1080p resolution"
-msgstr ""
+msgstr "1080p-resolutie vinden"
 
 msgctxt "#30555"
 msgid "and movie passes checks for number of results[CR]movie can be added to the library."
-msgstr ""
+msgstr "en de film voldoet aan de controle van het aantal resultaten,[CR]dan kan die aan de bibliotheek worden toegevoegd."
 
 msgctxt "#30556"
 msgid "Add to the library"
-msgstr ""
+msgstr "Aan de bibliotheek toevoegen"
 
 msgctxt "#30557"
 msgid "Number of popular movies to search"
-msgstr ""
+msgstr "Aantal populaire films om te doorzoeken"
 
 msgctxt "#30558"
 msgid "Latest available movies"
-msgstr ""
+msgstr "Nieuwste beschikbare films"
 
 msgctxt "#30559"
 msgid "Skip searching for installed providers"
-msgstr ""
+msgstr "Zoeken naar geïnstalleerde providers overslaan"
 
 msgctxt "#30560"
 msgid "Files: %s"
-msgstr ""
+msgstr "Bestanden: %s"
 
 msgctxt "#30561"
 msgid "Interval between requests, seconds"
-msgstr ""
+msgstr "Interval tussen verzoeken, seconden"
 
 msgctxt "#30562"
 msgid "Open directory with Kodi file browser"
-msgstr ""
+msgstr "Map openen met de Kodi-bestandsbrowser"
 
 msgctxt "#30563"
 msgid "Synchronize frequency of Trakt, minutes"
-msgstr ""
+msgstr "Frequentie van Trakt-synchronisatie, minuten"
 
 msgctxt "#30564"
 msgid "Sync hidden items"
-msgstr ""
+msgstr "Verborgen items synchroniseren"
 
 msgctxt "#30565"
 msgid "Sync playback progress into Kodi library"
-msgstr ""
+msgstr "Afspeelvoortgang synchroniseren naar de Kodi-bibliotheek"
 
 msgctxt "#30566"
 msgid "Lists"
-msgstr ""
+msgstr "Lijsten"
 
 msgctxt "#30567"
 msgid "Show \"All seasons\" in shows"
-msgstr ""
+msgstr "\"Alle seizoenen\" tonen bij series"
 
 msgctxt "#30568"
 msgid "Seasons order"
-msgstr ""
+msgstr "Volgorde van seizoenen"
 
 msgctxt "#30569"
 msgid "Ascending"
-msgstr ""
+msgstr "Oplopend"
 
 msgctxt "#30570"
 msgid "Descending"
-msgstr ""
+msgstr "Aflopend"
 
 msgctxt "#30571"
 msgid "* All seasons"
-msgstr ""
+msgstr "* Alle seizoenen"
 
 msgctxt "#30572"
 msgid "Log server's response body"
-msgstr ""
+msgstr "Antwoordinhoud van de server loggen"
 
 msgctxt "#30573"
 msgid "Select file to play"
-msgstr ""
+msgstr "Bestand selecteren om af te spelen"
 
 msgctxt "#30574"
 msgid "Automatically answer Yes after timeout"
-msgstr ""
+msgstr "Na de time-out automatisch Ja antwoorden"
 
 msgctxt "#30575"
 msgid "Timeout, seconds"
-msgstr ""
+msgstr "Time-out, seconden"
 
 msgctxt "#30576"
 msgid "Trakt authentication needs to be updated!"
-msgstr ""
+msgstr "De Trakt-authenticatie moet bijgewerkt worden!"
 
 msgctxt "#30577"
 msgid "End of file Buffer size, MB"
-msgstr ""
+msgstr "Buffergrootte aan het einde van het bestand, MB"
 
 msgctxt "#30578"
 msgid "Beginning of file Buffer size, MB"
-msgstr ""
+msgstr "Buffergrootte aan het begin van het bestand, MB"
 
 msgctxt "#30579"
 msgid "Settings"
-msgstr ""
+msgstr "Instellingen"
 
 msgctxt "#30580"
 msgid "Custom Trakt API Client ID"
-msgstr ""
+msgstr "Eigen client-ID voor de Trakt-API"
 
 msgctxt "#30581"
 msgid "Custom Trakt API Client Secret"
-msgstr ""
+msgstr "Eigen client secret voor de Trakt-API"
 
 msgctxt "#30582"
 msgid "Settings for %s provider"
-msgstr ""
+msgstr "Instellingen voor provider %s"
 
 msgctxt "#30583"
 msgid "Resolving magnet link"
-msgstr ""
+msgstr "Magnetlink wordt opgezocht"
 
 msgctxt "#30585"
 msgid "Enable library integration with Kodi"
-msgstr ""
+msgstr "Bibliotheekintegratie met Kodi inschakelen"
 
 msgctxt "#30586"
 msgid "If disabled - Elementum will not get/insert items to Kodi library [CR]and skip watched management with Kodi."
-msgstr ""
+msgstr "Indien uitgeschakeld haalt en plaatst Elementum geen items in de Kodi-bibliotheek [CR]en slaat het beheer van de bekeken-status met Kodi over."
 
 msgctxt "#30587"
 msgid "Show welcome message on start"
-msgstr ""
+msgstr "Welkomstbericht tonen bij het opstarten"
 
 msgctxt "#30588"
 msgid "Pre-Play Buffering"
-msgstr ""
+msgstr "Bufferen voor het afspelen"
 
 msgctxt "#30589"
 msgid "Speed limiting"
-msgstr ""
+msgstr "Snelheidsbeperking"
 
 msgctxt "#30590"
 msgid "Torrents autoload on addon startup"
-msgstr ""
+msgstr "Torrents automatisch laden bij het opstarten van de add-on"
 
 msgctxt "#30591"
 msgid "Limits for connections"
-msgstr ""
+msgstr "Limieten voor verbindingen"
 
 msgctxt "#30592"
 msgid "Seeding"
-msgstr ""
+msgstr "Seeden"
 
 msgctxt "#30593"
 msgid "Seed forever"
-msgstr ""
+msgstr "Voor altijd seeden"
 
 msgctxt "#30594"
 msgid "Network"
-msgstr ""
+msgstr "Netwerk"
 
 msgctxt "#30595"
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Diversen"
 
 msgctxt "#30597"
 msgid "Cache size, MB"
-msgstr ""
+msgstr "Cachegrootte, MB"
 
 msgctxt "#30598"
 msgid "Enable caching if using File storage and have speed problems.[CR]Will use more memory, but can improve the speed."
-msgstr ""
+msgstr "Schakel caching in als je bestandsopslag gebruikt en snelheidsproblemen hebt.[CR]Het gebruikt meer geheugen, maar kan de snelheid verbeteren."
 
 msgctxt "#30599"
 msgid "Enable Kodi library synchronization"
-msgstr ""
+msgstr "Kodi-bibliotheeksynchronisatie inschakelen"
 
 msgctxt "#30600"
 msgid "Enable Trakt synchronization"
-msgstr ""
+msgstr "Trakt-synchronisatie inschakelen"
 
 msgctxt "#30601"
 msgid "Enable synchronization while playback"
-msgstr ""
+msgstr "Synchronisatie tijdens het afspelen inschakelen"
 
 msgctxt "#30602"
 msgid "Retry requests to addon after timeout, seconds"
-msgstr ""
+msgstr "Verzoeken aan de add-on opnieuw proberen na de time-out, seconden"
 
 msgctxt "#30603"
 msgid "Addon Startup"
-msgstr ""
+msgstr "Opstarten van de add-on"
 
 msgctxt "#30604"
 msgid "Clean all history"
-msgstr ""
+msgstr "Alle geschiedenis opschonen"
 
 msgctxt "#30605"
 msgid "Cache downloaded torrent files after search"
-msgstr ""
+msgstr "Gedownloade torrentbestanden na het zoeken cachen"
 
 msgctxt "#30606"
 msgid "Show watched state for torrent's files"
-msgstr ""
+msgstr "Bekeken-status tonen voor de bestanden van de torrent"
 
 msgctxt "#30607"
 msgid "Use earliest release date as basic for searching"
-msgstr ""
+msgstr "Vroegste releasedatum als basis voor het zoeken gebruiken"
 
 msgctxt "#30608"
 msgid "Match found in your active torrents, play it?[CR]%s"
-msgstr ""
+msgstr "Overeenkomst gevonden in je actieve torrents, afspelen?[CR]%s"
 
 msgctxt "#30609"
 msgid "Automatically start next episode if available"
-msgstr ""
+msgstr "Volgende aflevering automatisch starten indien beschikbaar"
 
 msgctxt "#30610"
 msgid "Magnet resolve timeout, seconds"
-msgstr ""
+msgstr "Time-out voor het opzoeken van magnetlinks, seconden"
 
 msgctxt "#30611"
 msgid "Application platform type"
-msgstr ""
+msgstr "Platformtype van de applicatie"
 
 msgctxt "#30612"
 msgid "Select file to download"
-msgstr ""
+msgstr "Bestand selecteren om te downloaden"
 
 msgctxt "#30613"
 msgid "... for movie"
-msgstr ""
+msgstr "... voor film"
 
 msgctxt "#30614"
 msgid "... for tv show"
-msgstr ""
+msgstr "... voor serie"
 
 msgctxt "#30615"
 msgid "... for search"
-msgstr ""
+msgstr "... voor zoeken"
 
 msgctxt "#30616"
 msgid "Elementum | Trakt Account"
-msgstr ""
+msgstr "Elementum | Trakt-account"
 
 msgctxt "#30617"
 msgid "Your account is locked for API on Trakt.tv[CR]Please, contact Trakt Support at https://support.trakt.tv ."
-msgstr ""
+msgstr "Je account is geblokkeerd voor de API op Trakt.tv[CR]Neem contact op met de Trakt-ondersteuning via https://support.trakt.tv ."
 
 msgctxt "#30618"
 msgid "%s is downloaded"
-msgstr ""
+msgstr "%s is gedownload"
 
 msgctxt "#30619"
 msgid "Return to [B]%s[/B]"
-msgstr ""
+msgstr "Terug naar [B]%s[/B]"
 
 msgctxt "#30620"
 msgid "Restart Elementum addon"
-msgstr ""
+msgstr "Elementum-add-on herstarten"
 
 msgctxt "#30621"
 msgid "Queued"
-msgstr ""
+msgstr "In wachtrij"
 
 msgctxt "#30622"
 msgid "Checking"
-msgstr ""
+msgstr "Bezig met controleren"
 
 msgctxt "#30623"
 msgid "Finding"
-msgstr ""
+msgstr "Bezig met zoeken"
 
 msgctxt "#30624"
 msgid "Downloading"
-msgstr ""
+msgstr "Bezig met downloaden"
 
 msgctxt "#30625"
 msgid "Finished"
-msgstr ""
+msgstr "Voltooid"
 
 msgctxt "#30626"
 msgid "Seeding"
-msgstr ""
+msgstr "Bezig met seeden"
 
 msgctxt "#30627"
 msgid "Allocating"
-msgstr ""
+msgstr "Bezig met toewijzen"
 
 msgctxt "#30628"
 msgid "Stalled"
-msgstr ""
+msgstr "Vastgelopen"
 
 msgctxt "#30629"
 msgid "Paused"
-msgstr ""
+msgstr "Gepauzeerd"
 
 msgctxt "#30630"
 msgid "Buffering"
-msgstr ""
+msgstr "Bezig met bufferen"
 
 msgctxt "#30631"
 msgid "Playing"
-msgstr ""
+msgstr "Bezig met afspelen"
 
 msgctxt "#30632"
 msgid "Yes (%s seconds)"
-msgstr ""
+msgstr "Ja (%s seconden)"
 
 msgctxt "#30633"
 msgid "No (%s seconds)"
-msgstr ""
+msgstr "Nee (%s seconden)"
 
 msgctxt "#30634"
 msgid "Log level"
-msgstr ""
+msgstr "Logniveau"
 
 msgctxt "#30635"
 msgid "None"
-msgstr ""
+msgstr "Geen"
 
 msgctxt "#30636"
 msgid "Error"
-msgstr ""
+msgstr "Fout"
 
 msgctxt "#30637"
 msgid "Info"
-msgstr ""
+msgstr "Info"
 
 msgctxt "#30638"
 msgid "Debug"
-msgstr ""
+msgstr "Foutopsporing"
 
 msgctxt "#30639"
 msgid "Show Specials in season listings"
-msgstr ""
+msgstr "Specials tonen in seizoenslijsten"
 
 msgctxt "#30640"
 msgid "Bitrate"
-msgstr ""
+msgstr "Bitrate"
 
 msgctxt "#30641"
 msgid "Playback"
-msgstr ""
+msgstr "Afspelen"
 
 msgctxt "#30642"
 msgid "Force Resume options"
-msgstr ""
+msgstr "Hervattingsopties forceren"
 
 msgctxt "#30643"
 msgid "by Kodi"
-msgstr ""
+msgstr "door Kodi"
 
 msgctxt "#30644"
 msgid "by Elementum - Ask"
-msgstr ""
+msgstr "door Elementum - Vragen"
 
 msgctxt "#30645"
 msgid "by Elementum - Force"
-msgstr ""
+msgstr "door Elementum - Forceren"
 
 msgctxt "#30646"
 msgid "Authorize Elementum on Trakt.tv"
-msgstr ""
+msgstr "Elementum autoriseren op Trakt.tv"
 
 msgctxt "#30647"
 msgid "Cancel Authorization for Elementum on Trakt.tv"
-msgstr ""
+msgstr "Autorisatie van Elementum op Trakt.tv annuleren"
 
 msgctxt "#30648"
 msgid "Authorization"
-msgstr ""
+msgstr "Autorisatie"
 
 msgctxt "#30649"
 msgid "To authorize addon for Trakt.tv you need to:[CR]1. Open [B]%s[/B][CR]2. Enter code: [B]%s[/B][CR]3. Wait for notification from Elementum."
-msgstr ""
+msgstr "Om de add-on te autoriseren voor Trakt.tv moet je:[CR]1. [B]%s[/B] openen[CR]2. Deze code invoeren: [B]%s[/B][CR]3. Wachten op de melding van Elementum."
 
 msgctxt "#30650"
 msgid "Successfully authorized for Trakt.tv"
-msgstr ""
+msgstr "Autorisatie voor Trakt.tv geslaagd"
 
 msgctxt "#30651"
 msgid "Could not authorize for Trakt.tv"
-msgstr ""
+msgstr "Kon niet autoriseren voor Trakt.tv"
 
 msgctxt "#30652"
 msgid "Successfully deauthorized for Trakt.tv"
-msgstr ""
+msgstr "Autorisatie voor Trakt.tv succesvol ingetrokken"
 
 msgctxt "#30653"
 msgid "Which files to download"
-msgstr ""
+msgstr "Welke bestanden te downloaden"
 
 msgctxt "#30654"
 msgid "Only playback file"
-msgstr ""
+msgstr "Alleen het afspeelbestand"
 
 msgctxt "#30655"
 msgid "Season files"
-msgstr ""
+msgstr "Bestanden van het seizoen"
 
 msgctxt "#30656"
 msgid "All files"
-msgstr ""
+msgstr "Alle bestanden"
 
 msgctxt "#30657"
 msgid "Disable LSD"
-msgstr ""
+msgstr "LSD uitschakelen"
 
 msgctxt "#30658"
 msgid "Add extra trackers"
-msgstr ""
+msgstr "Extra trackers toevoegen"
 
 msgctxt "#30659"
 msgid "All known trackers"
-msgstr ""
+msgstr "Alle bekende trackers"
 
 msgctxt "#30660"
 msgid "Best trackers"
-msgstr ""
+msgstr "Beste trackers"
 
 msgctxt "#30661"
 msgid "Minimum set"
-msgstr ""
+msgstr "Minimale set"
 
 msgctxt "#30662"
 msgid "Remove original trackers from torrent"
-msgstr ""
+msgstr "Oorspronkelijke trackers uit de torrent verwijderen"
 
 msgctxt "#30663"
 msgid "Show episodes on release day (w/o delay)"
-msgstr ""
+msgstr "Afleveringen tonen op de releasedag (zonder vertraging)"
 
 msgctxt "#30664"
 msgid "Modify trackers in torrent"
-msgstr ""
+msgstr "Trackers in de torrent aanpassen"
 
 msgctxt "#30665"
 msgid "At the time of adding"
-msgstr ""
+msgstr "Bij het toevoegen"
 
 msgctxt "#30666"
 msgid "Every time"
-msgstr ""
+msgstr "Elke keer"
 
 msgctxt "#30667"
 msgid "Mark as watched in Trakt"
-msgstr ""
+msgstr "Als bekeken markeren in Trakt"
 
 msgctxt "#30668"
 msgid "Mark as unwatched in Trakt"
-msgstr ""
+msgstr "Als onbekeken markeren in Trakt"
 
 msgctxt "#30669"
 msgid "Delay addon startup, seconds"
-msgstr ""
+msgstr "Opstarten van de add-on vertragen, seconden"
 
 msgctxt "#30670"
 msgid "Downloading required binary file for '%s'"
-msgstr ""
+msgstr "Vereist binair bestand voor '%s' wordt gedownload"
 
 msgctxt "#30671"
 msgid "List of Opennic DNS IPs"
-msgstr ""
+msgstr "Lijst met OpenNIC-DNS-IP's"
 
 msgctxt "#30672"
 msgid "Compact database"
-msgstr ""
+msgstr "Database comprimeren"
 
 msgctxt "#30673"
 msgid "Compact cache database"
-msgstr ""
+msgstr "Cachedatabase comprimeren"
 
 msgctxt "#30674"
 msgid "Database was compacted"
-msgstr ""
+msgstr "De database is gecomprimeerd"
 
 msgctxt "#30675"
 msgid "Remote host login"
-msgstr ""
+msgstr "Gebruikersnaam van de externe host"
 
 msgctxt "#30676"
 msgid "Remote host password"
-msgstr ""
+msgstr "Wachtwoord van de externe host"
 
 msgctxt "#30677"
 msgid "Force start as a library"
-msgstr ""
+msgstr "Starten als bibliotheek forceren"
 
 msgctxt "#30678"
 msgid "Remove from Kodi library, when movie is deleted from Trakt"
-msgstr ""
+msgstr "Verwijderen uit de Kodi-bibliotheek wanneer de film uit Trakt wordt verwijderd"
 
 msgctxt "#30679"
 msgid "Remove from Kodi library, when show is deleted from Trakt"
-msgstr ""
+msgstr "Verwijderen uit de Kodi-bibliotheek wanneer de serie uit Trakt wordt verwijderd"
 
 msgctxt "#30680"
 msgid "Remove Elementum duplicates from library"
-msgstr ""
+msgstr "Elementum-duplicaten uit de bibliotheek verwijderen"
 
 msgctxt "#30681"
 msgid "[B]Found duplicates in Kodi library:[/B][CR]Movies: [B]%s[/B], Shows: [B]%s[/B], Episodes: [B]%s[/B][CR]Proceed?"
-msgstr ""
+msgstr "[B]Duplicaten gevonden in de Kodi-bibliotheek:[/B][CR]Films: [B]%s[/B], Series: [B]%s[/B], Afleveringen: [B]%s[/B][CR]Doorgaan?"
 
 msgctxt "#30682"
 msgid "No duplicates were found in Kodi library"
-msgstr ""
+msgstr "Er zijn geen duplicaten gevonden in de Kodi-bibliotheek"
 
 msgctxt "#30683"
 msgid "Starting library duplicates removal"
-msgstr ""
+msgstr "Verwijderen van duplicaten uit de bibliotheek wordt gestart"
 
 msgctxt "#30684"
 msgid "Removed Movies: %s, Shows: %s, Episodes: %s"
-msgstr ""
+msgstr "Verwijderd - Films: %s, Series: %s, Afleveringen: %s"
 
 msgctxt "#30685"
 msgid "Remove movies from Elementum database"
-msgstr ""
+msgstr "Films uit de Elementum-database verwijderen"
 
 msgctxt "#30686"
 msgid "Remove shows from Elementum database"
-msgstr ""
+msgstr "Series uit de Elementum-database verwijderen"
 
 msgctxt "#30687"
 msgid "In Elementum library"
-msgstr ""
+msgstr "In de Elementum-bibliotheek"
 
 msgctxt "#30688"
 msgid "Skip searching for installed Elementum repository"
-msgstr ""
+msgstr "Zoeken naar de geïnstalleerde Elementum-repository overslaan"
 
 msgctxt "#30689"
 msgid "Internal DNS client"
-msgstr ""
+msgstr "Interne DNS-client"
 
 msgctxt "#30691"
 msgid "Hide watched"
-msgstr ""
+msgstr "Bekeken verbergen"
 
 msgctxt "#30692"
 msgid "TMDB images quality (affects Kodi performance)"
-msgstr ""
+msgstr "Kwaliteit van TMDB-afbeeldingen (beïnvloedt de prestaties van Kodi)"
 
 msgctxt "#30693"
 msgid "Original"
-msgstr ""
+msgstr "Origineel"
 
 msgctxt "#30694"
 msgid "High"
-msgstr ""
+msgstr "Hoog"
 
 msgctxt "#30695"
 msgid "Medium"
-msgstr ""
+msgstr "Gemiddeld"
 
 msgctxt "#30696"
 msgid "Low"
-msgstr ""
+msgstr "Laag"
 
 msgctxt "#30697"
 msgid "Interface language"
-msgstr ""
+msgstr "Taal van de interface"
 
 msgctxt "#30698"
 msgid "Kodi language"
-msgstr ""
+msgstr "Taal van Kodi"
 
 msgctxt "#30699"
 msgid "Use earliest release date for progress and calendars"
-msgstr ""
+msgstr "Vroegste releasedatum gebruiken voor voortgang en kalenders"
 
 msgctxt "#30700"
 msgid "Interface fallback language"
-msgstr ""
+msgstr "Terugvaltaal van de interface"
 
 msgctxt "#30701"
 msgid "English | en"
-msgstr ""
+msgstr "Engels | en"
 
 msgctxt "#30702"
 msgid "Reached daily limit for subtitles downloads"
-msgstr ""
+msgstr "Daglimiet voor het downloaden van ondertitels bereikt"
 
 msgctxt "#30703"
 msgid "Can be used by search providers or [CR]for debugging"
-msgstr ""
+msgstr "Kan gebruikt worden door zoekproviders of [CR]voor foutopsporing"
 
 msgctxt "#30704"
 msgid "TMDB API Key check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Controle van de TMDB-API-sleutel mislukt, de TMDB-dienst kan niet gebruikt worden"
 
 msgctxt "#30705"
 msgid "TMDB API accessibility check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Controle van de bereikbaarheid van de TMDB-API mislukt, de TMDB-dienst kan niet gebruikt worden"
 
 msgctxt "#30706"
 msgid "Transmission 4.05"
-msgstr ""
+msgstr "Transmission 4.05"
 
 msgctxt "#30707"
 msgid "qBittorrent 3.3.9"
-msgstr ""
+msgstr "qBittorrent 3.3.9"
 
 msgctxt "#30708"
 msgid "qBittorrent 4.6.4"
-msgstr ""
+msgstr "qBittorrent 4.6.4"
 
 msgctxt "#30709"
 msgid "Open [B]%s[/B]"
-msgstr ""
+msgstr "[B]%s[/B] openen"
 
 msgctxt "#30710"
 msgid "BitTorrent ports"
-msgstr ""
+msgstr "BitTorrent-poorten"
 
 msgctxt "#30711"
 msgid "Delete torrent '%s'?"
-msgstr ""
+msgstr "Torrent '%s' verwijderen?"
 
 msgctxt "#30712"
 msgid "Force to always use proxy, can break download in some cases"
-msgstr ""
+msgstr "Altijd het gebruik van de proxy forceren, kan de download in sommige gevallen verstoren"
 
 msgctxt "#30713"
 msgid "Disable NATPMP"
-msgstr ""
+msgstr "NATPMP uitschakelen"
 
 msgctxt "#30714"
 msgid "Re-check torrent's data"
-msgstr ""
+msgstr "Gegevens van de torrent opnieuw controleren"
 
 msgctxt "#30715"
 msgid "Antizapret PAC file URL"
-msgstr ""
+msgstr "URL van het Antizapret-PAC-bestand"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "DNS-over-HTTPS-server"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "Eigen DNS-over-HTTPS-server"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "OpenNIC-DNS-servers gebruiken"

--- a/resources/language/Finnish/strings.po
+++ b/resources/language/Finnish/strings.po
@@ -21,7 +21,7 @@ msgstr "Yleiset"
 
 msgctxt "#30001"
 msgid "Download path"
-msgstr ""
+msgstr "Latauspolku"
 
 msgctxt "#30004"
 msgid "Max upload rate, kB/s"
@@ -97,7 +97,7 @@ msgstr "Valitse tiedosto automaattisesti"
 
 msgctxt "#30025"
 msgid "Limit rates after initial buffering only"
-msgstr ""
+msgstr "Rajoita nopeuksia vasta alkupuskuroinnin jälkeen"
 
 msgctxt "#30026"
 msgid "Library path"
@@ -109,7 +109,7 @@ msgstr "Yhteyksien enimmäismäärä"
 
 msgctxt "#30028"
 msgid "Download after play was stopped"
-msgstr ""
+msgstr "Jatka lataamista toiston pysäyttämisen jälkeen"
 
 msgctxt "#30029"
 msgid "Session saving frequency, seconds"
@@ -273,7 +273,7 @@ msgstr "Väärennä käyttäjätunnus (ei suositella)"
 
 msgctxt "#30075"
 msgid "Default advisable (acceptable)"
-msgstr ""
+msgstr "Oletus suositeltava (hyväksyttävä)"
 
 msgctxt "#30076"
 msgid "libtorrent (Rasterbar) 1.1.0"
@@ -354,7 +354,7 @@ msgstr "Tämä lisäosa toimii vain Elementumin kautta"
 
 msgctxt "#30103"
 msgid "Unable to find Elementum binary[CR]Required platform:"
-msgstr ""
+msgstr "Elementum-binääriä ei löydy[CR]Vaadittu alusta:"
 
 msgctxt "#30104"
 msgid "Insert file or URL"
@@ -410,11 +410,11 @@ msgstr "Etsitään trackereilta..."
 
 msgctxt "#30119"
 msgid "ID of selected userlist for movies"
-msgstr ""
+msgstr "Valitun käyttäjälistan tunnus elokuville"
 
 msgctxt "#30120"
 msgid "ID of selected userlist for shows"
-msgstr ""
+msgstr "Valitun käyttäjälistan tunnus sarjoille"
 
 msgctxt "#30141"
 msgid "Please support Elementum development by visiting[CR]https://elementum.surge.sh/donate/ or https://elementumorg.github.io/donate/"
@@ -450,7 +450,7 @@ msgstr "Välimuisti päivitetty"
 
 msgctxt "#30149"
 msgid "Trakt username not set, check your settings"
-msgstr ""
+msgstr "Trakt-käyttäjätunnusta ei ole asetettu, tarkista asetuksesi"
 
 msgctxt "#30199"
 msgid "No available JSON-RPC connection to Kodi.[CR]Enable both Application control options in Service settings / Control and restart Kodi."
@@ -711,7 +711,7 @@ msgstr "%s poistettiin kirjastosta, haluatko suorittaa kirjaston puhdistuksen?[C
 
 msgctxt "#30279"
 msgid "Video %s was previously removed from library.[CR]Force adding?"
-msgstr ""
+msgstr "Video %s poistettiin aiemmin kirjastosta.[CR]Pakotetaanko lisäys?"
 
 msgctxt "#30282"
 msgid "Nothing left to remove from Elementum"
@@ -791,1491 +791,1491 @@ msgstr "Kaikki ensi-illat"
 
 msgctxt "#30301"
 msgid "Move finished downloads to separate folders"
-msgstr ""
+msgstr "Siirrä valmiit lataukset erillisiin kansioihin"
 
 msgctxt "#30302"
 msgid "Files will only be moved after seeding is finished (see[CR]- BitTorrent settings), and will wait if currently playing"
-msgstr ""
+msgstr "Tiedostot siirretään vasta jakamisen päätyttyä (katso[CR]- BitTorrent-asetukset), ja ne odottavat, jos toisto on käynnissä"
 
 msgctxt "#30303"
 msgid "RAR archive detected. Download will need to be completed before playback can start and will require around twice the amount of space, continue?"
-msgstr ""
+msgstr "RAR-arkisto havaittu. Lataus on saatava valmiiksi ennen kuin toisto voi alkaa, ja se vaatii noin kaksinkertaisen tilan. Jatketaanko?"
 
 msgctxt "#30304"
 msgid "Error creating output pipe for 'unrar' command"
-msgstr ""
+msgstr "Virhe luotaessa tulosputkea 'unrar'-komennolle"
 
 msgctxt "#30305"
 msgid "Error starting 'unrar' command"
-msgstr ""
+msgstr "Virhe käynnistettäessä 'unrar'-komentoa"
 
 msgctxt "#30306"
 msgid "Error waiting for 'unrar' command"
-msgstr ""
+msgstr "Virhe odotettaessa 'unrar'-komentoa"
 
 msgctxt "#30307"
 msgid "Error reading from destination folder"
-msgstr ""
+msgstr "Virhe luettaessa kohdekansiosta"
 
 msgctxt "#30308"
 msgid "Move completed"
-msgstr ""
+msgstr "Siirto valmis"
 
 msgctxt "#30309"
 msgid "Keep"
-msgstr ""
+msgstr "Säilytä"
 
 msgctxt "#30310"
 msgid "Ask to delete"
-msgstr ""
+msgstr "Kysy poistamisesta"
 
 msgctxt "#30311"
 msgid "Delete"
-msgstr ""
+msgstr "Poista"
 
 msgctxt "#30312"
 msgid "Keep files for not finished video"
-msgstr ""
+msgstr "Säilytä keskeneräisten videoiden tiedostot"
 
 msgctxt "#30313"
 msgid "Keep files for watched/downloaded video"
-msgstr ""
+msgstr "Säilytä katsottujen/ladattujen videoiden tiedostot"
 
 msgctxt "#30314"
 msgid "Settings were not initialized.[CR]Save addon settings, then restart Kodi."
-msgstr ""
+msgstr "Asetuksia ei alustettu.[CR]Tallenna lisäosan asetukset ja käynnistä Kodi uudelleen."
 
 msgctxt "#30315"
 msgid "Download storage type"
-msgstr ""
+msgstr "Latausten tallennustyyppi"
 
 msgctxt "#30316"
 msgid "Use files"
-msgstr ""
+msgstr "Käytä tiedostoja"
 
 msgctxt "#30317"
 msgid "Use memory"
-msgstr ""
+msgstr "Käytä muistia"
 
 msgctxt "#30318"
 msgid "Memory size to use for each torrent, Mb"
-msgstr ""
+msgstr "Kullekin torrentille käytettävä muisti, Mt"
 
 msgctxt "#30319"
 msgid "Continue"
-msgstr ""
+msgstr "Jatka"
 
 msgctxt "#30320"
 msgid "Ask to stop"
-msgstr ""
+msgstr "Kysy pysäyttämisestä"
 
 msgctxt "#30321"
 msgid "Stop"
-msgstr ""
+msgstr "Pysäytä"
 
 msgctxt "#30323"
 msgid "New search"
-msgstr ""
+msgstr "Uusi haku"
 
 msgctxt "#30324"
 msgid "Force stream auto-selection from settings"
-msgstr ""
+msgstr "Pakota automaattinen lähteen valinta asetuksista"
 
 msgctxt "#30325"
 msgid "Download"
-msgstr ""
+msgstr "Lataus"
 
 msgctxt "#30326"
 msgid "Kodi library"
-msgstr ""
+msgstr "Kodi-kirjasto"
 
 msgctxt "#30327"
 msgid "Storage"
-msgstr ""
+msgstr "Tallennustila"
 
 msgctxt "#30328"
 msgid "Disable TCP"
-msgstr ""
+msgstr "Poista TCP käytöstä"
 
 msgctxt "#30329"
 msgid "Disable UTP"
-msgstr ""
+msgstr "Poista UTP käytöstä"
 
 msgctxt "#30330"
 msgid "Update Trakt"
-msgstr ""
+msgstr "Päivitä Trakt"
 
 msgctxt "#30332"
 msgid "Reloading configuration..."
-msgstr ""
+msgstr "Ladataan asetuksia uudelleen..."
 
 msgctxt "#30333"
 msgid "Try to find other episodes in the torrent"
-msgstr ""
+msgstr "Yritä löytää muita jaksoja torrentista"
 
 msgctxt "#30347"
 msgid "Could not find binary for architecture '%s'![CR]Try to uninstall this addon, re-download and re-install it from the biggest zip."
-msgstr ""
+msgstr "Binääriä arkkitehtuurille '%s' ei löytynyt![CR]Yritä poistaa tämä lisäosa, ladata se uudelleen ja asentaa suurimmasta zip-paketista."
 
 msgctxt "#30348"
 msgid "Create usual files on the file system and write to them.[CR]Needs selected file's full size to be available on the disk!"
-msgstr ""
+msgstr "Luo tavallisia tiedostoja tiedostojärjestelmään ja kirjoittaa niihin.[CR]Valitun tiedoston koko täytyy olla kokonaan käytettävissä levyllä!"
 
 msgctxt "#30349"
 msgid "Using device's memory to download parts of the torrent.[CR]Disk is used only to download and save .torrent file,"
-msgstr ""
+msgstr "Käyttää laitteen muistia torrentin osien lataamiseen.[CR]Levyä käytetään vain .torrent-tiedoston lataamiseen ja tallentamiseen,"
 
 msgctxt "#30350"
 msgid "so can be any storage. For 1gb memory devices[CR]100mb is enough for memory storage, 200-250mb for bigger devices."
-msgstr ""
+msgstr "joten se voi olla mikä tahansa tallennustila. 1 Gt:n muistin laitteille[CR]100 Mt riittää, suuremmille laitteille 200-250 Mt."
 
 msgctxt "#30351"
 msgid "Same as for usual file storage, but splits file into many small files.[CR]Should be used on FAT-32 file-systems."
-msgstr ""
+msgstr "Kuten tavallinen tiedostotallennus, mutta jakaa tiedoston moneen pieneen tiedostoon.[CR]Käytettävä FAT-32-tiedostojärjestelmissä."
 
 msgctxt "#30352"
 msgid "Same as for usual file storage, but using memory[CR]to lower filesystem operations. Experimental storage!"
-msgstr ""
+msgstr "Kuten tavallinen tiedostotallennus, mutta käyttää muistia[CR]vähentääkseen tiedostojärjestelmän toimintoja. Kokeellinen tallennustila!"
 
 msgctxt "#30355"
 msgid "Changelog"
-msgstr ""
+msgstr "Muutosloki"
 
 msgctxt "#30357"
 msgid "Use Trakt information in Trakt lists"
-msgstr ""
+msgstr "Käytä Trakt-tietoja Trakt-listoissa"
 
 msgctxt "#30358"
 msgid "Trakt update started"
-msgstr ""
+msgstr "Trakt-päivitys aloitettu"
 
 msgctxt "#30359"
 msgid "Do not ask questions before playback"
-msgstr ""
+msgstr "Älä kysy kysymyksiä ennen toistoa"
 
 msgctxt "#30360"
 msgid "My Progress"
-msgstr ""
+msgstr "Edistymiseni"
 
 msgctxt "#30361"
 msgid "My History"
-msgstr ""
+msgstr "Historiani"
 
 msgctxt "#30362"
 msgid "Synchronization"
-msgstr ""
+msgstr "Synkronointi"
 
 msgctxt "#30363"
 msgid "Sync items from collections into Kodi library"
-msgstr ""
+msgstr "Synkronoi kokoelmien kohteet Kodi-kirjastoon"
 
 msgctxt "#30364"
 msgid "Sync items from watchlist into Kodi library"
-msgstr ""
+msgstr "Synkronoi seurantalistan kohteet Kodi-kirjastoon"
 
 msgctxt "#30365"
 msgid "Sync items from user lists into Kodi library"
-msgstr ""
+msgstr "Synkronoi käyttäjälistojen kohteet Kodi-kirjastoon"
 
 msgctxt "#30366"
 msgid "Sync watched states from Trakt into Kodi library"
-msgstr ""
+msgstr "Synkronoi katsotut-tilat Traktista Kodi-kirjastoon"
 
 msgctxt "#30367"
 msgid "Sync back Kodi watched states into Trakt"
-msgstr ""
+msgstr "Synkronoi Kodin katsotut-tilat takaisin Traktiin"
 
 msgctxt "#30369"
 msgid "Disable Upload"
-msgstr ""
+msgstr "Poista lähetys käytöstä"
 
 msgctxt "#30370"
 msgid "Auto-assign network IP"
-msgstr ""
+msgstr "Määritä verkon IP automaattisesti"
 
 msgctxt "#30371"
 msgid "Auto-assign network ports"
-msgstr ""
+msgstr "Määritä verkkoportit automaattisesti"
 
 msgctxt "#30373"
 msgid "Languages"
-msgstr ""
+msgstr "Kielet"
 
 msgctxt "#30374"
 msgid "Countries"
-msgstr ""
+msgstr "Maat"
 
 msgctxt "#30375"
 msgid "By size"
-msgstr ""
+msgstr "Koon mukaan"
 
 msgctxt "#30376"
 msgid "Choose memory size automatically"
-msgstr ""
+msgstr "Valitse muistin koko automaattisesti"
 
 msgctxt "#30377"
 msgid "Size is chosen automatically, based on[CR]physical amount of memory"
-msgstr ""
+msgstr "Koko valitaan automaattisesti käytettävissä olevan[CR]fyysisen muistin määrän perusteella"
 
 msgctxt "#30378"
 msgid "Allow memory usage"
-msgstr ""
+msgstr "Salli muistin käyttö"
 
 msgctxt "#30379"
 msgid "Minimum - 40MB, Default - 8%, Maximum - 15%"
-msgstr ""
+msgstr "Vähintään - 40 Mt, Oletus - 8 %, Enintään - 15 %"
 
 msgctxt "#30380"
 msgid "Minimum"
-msgstr ""
+msgstr "Vähintään"
 
 msgctxt "#30381"
 msgid "Default"
-msgstr ""
+msgstr "Oletus"
 
 msgctxt "#30382"
 msgid "Maximum"
-msgstr ""
+msgstr "Enintään"
 
 msgctxt "#30383"
 msgid "Use Kodi language for subtitles search"
-msgstr ""
+msgstr "Käytä Kodin kieltä tekstitysten haussa"
 
 msgctxt "#30384"
 msgid "Language code for subtitles (example: en, it, es)"
-msgstr ""
+msgstr "Tekstitysten kielikoodi (esimerkki: en, it, es)"
 
 msgctxt "#30386"
 msgid "Disable background progress dialog on playback"
-msgstr ""
+msgstr "Poista taustan edistymisikkuna käytöstä toiston aikana"
 
 msgctxt "#30387"
 msgid "Caching"
-msgstr ""
+msgstr "Välimuisti"
 
 msgctxt "#30388"
 msgid "Cache stream selection"
-msgstr ""
+msgstr "Tallenna lähteen valinta välimuistiin"
 
 msgctxt "#30389"
 msgid "Cache stream search results"
-msgstr ""
+msgstr "Tallenna lähdehaun tulokset välimuistiin"
 
 msgctxt "#30390"
 msgid "Cache search results duration, seconds"
-msgstr ""
+msgstr "Hakutulosten välimuistin kesto, sekuntia"
 
 msgctxt "#30393"
 msgid "Status"
-msgstr ""
+msgstr "Tila"
 
 msgctxt "#30394"
 msgid "Version"
-msgstr ""
+msgstr "Versio"
 
 msgctxt "#30395"
 msgid "IP address"
-msgstr ""
+msgstr "IP-osoite"
 
 msgctxt "#30396"
 msgid "Port"
-msgstr ""
+msgstr "Portti"
 
 msgctxt "#30397"
 msgid "Web UI"
-msgstr ""
+msgstr "Verkkokäyttöliittymä"
 
 msgctxt "#30398"
 msgid "Debug information (with kodi.log)"
-msgstr ""
+msgstr "Virheenkorjaustiedot (kodi.log mukana)"
 
 msgctxt "#30399"
 msgid "Addresses"
-msgstr ""
+msgstr "Osoitteet"
 
 msgctxt "#30400"
 msgid "Statistics"
-msgstr ""
+msgstr "Tilastot"
 
 msgctxt "#30401"
 msgid "Torrent library status"
-msgstr ""
+msgstr "Torrent-kirjaston tila"
 
 msgctxt "#30402"
 msgid "Size of cache.db"
-msgstr ""
+msgstr "cache.db:n koko"
 
 msgctxt "#30403"
 msgid "Size of app.db"
-msgstr ""
+msgstr "app.db:n koko"
 
 msgctxt "#30404"
 msgid "Assigned torrent files"
-msgstr ""
+msgstr "Liitetyt torrent-tiedostot"
 
 msgctxt "#30405"
 msgid "Search queries"
-msgstr ""
+msgstr "Hakukyselyt"
 
 msgctxt "#30406"
 msgid "Remove from history"
-msgstr ""
+msgstr "Poista historiasta"
 
 msgctxt "#30408"
 msgid "Addon Connectivity"
-msgstr ""
+msgstr "Lisäosan yhteys"
 
 msgctxt "#30409"
 msgid "Local port"
-msgstr ""
+msgstr "Paikallinen portti"
 
 msgctxt "#30410"
 msgid "Remote port"
-msgstr ""
+msgstr "Etäportti"
 
 msgctxt "#30411"
 msgid "Remote host"
-msgstr ""
+msgstr "Etäpalvelin"
 
 msgctxt "#30412"
 msgid "Do not start binary (client mode)"
-msgstr ""
+msgstr "Älä käynnistä binääriä (asiakastila)"
 
 msgctxt "#30413"
 msgid "Yes"
-msgstr ""
+msgstr "Kyllä"
 
 msgctxt "#30414"
 msgid "No"
-msgstr ""
+msgstr "Ei"
 
 msgctxt "#30415"
 msgid "Next page (%s)"
-msgstr ""
+msgstr "Seuraava sivu (%s)"
 
 msgctxt "#30416"
 msgid "Percents of playback to mark as watched"
-msgstr ""
+msgstr "Toiston prosenttiosuus katsotuksi merkitsemiseen"
 
 msgctxt "#30417"
 msgid "Use name of production company as Studio for shows"
-msgstr ""
+msgstr "Käytä tuotantoyhtiön nimeä studiona sarjoille"
 
 msgctxt "#30418"
 msgid "Calculate number of unwatched episodes in Shows/Seasons"
-msgstr ""
+msgstr "Laske katsomattomien jaksojen määrä sarjoissa/kausissa"
 
 msgctxt "#30421"
 msgid "Load torrents from torrents folder on startup"
-msgstr ""
+msgstr "Lataa torrentit torrent-kansiosta käynnistyksessä"
 
 msgctxt "#30422"
 msgid "Popular lists"
-msgstr ""
+msgstr "Suositut listat"
 
 msgctxt "#30423"
 msgid "Recommendations"
-msgstr ""
+msgstr "Suositukset"
 
 msgctxt "#30424"
 msgid "Progress"
-msgstr ""
+msgstr "Edistyminen"
 
 msgctxt "#30425"
 msgid "Color of an air date"
-msgstr ""
+msgstr "Esitysajankohdan väri"
 
 msgctxt "#30426"
 msgid "Color of a show name"
-msgstr ""
+msgstr "Sarjan nimen väri"
 
 msgctxt "#30427"
 msgid "Color of an episode name"
-msgstr ""
+msgstr "Jakson nimen väri"
 
 msgctxt "#30428"
 msgid "Hide unaired episodes"
-msgstr ""
+msgstr "Piilota esittämättömät jaksot"
 
 msgctxt "#30429"
 msgid "Sort shows in the list"
-msgstr ""
+msgstr "Järjestä sarjat listassa"
 
 msgctxt "#30430"
 msgid "By latest watched"
-msgstr ""
+msgstr "Viimeksi katsotun mukaan"
 
 msgctxt "#30431"
 msgid "By show name"
-msgstr ""
+msgstr "Sarjan nimen mukaan"
 
 msgctxt "#30432"
 msgid "By air date (newer)"
-msgstr ""
+msgstr "Esitysajankohdan mukaan (uudempi)"
 
 msgctxt "#30433"
 msgid "By air date (older)"
-msgstr ""
+msgstr "Esitysajankohdan mukaan (vanhempi)"
 
 msgctxt "#30434"
 msgid "Date format"
-msgstr ""
+msgstr "Päivämäärän muoto"
 
 msgctxt "#30436"
 msgid "Userlist"
-msgstr ""
+msgstr "Käyttäjälista"
 
 msgctxt "#30438"
 msgid "Userlists"
-msgstr ""
+msgstr "Käyttäjälistat"
 
 msgctxt "#30439"
 msgid "Debug information (without kodi.log)"
-msgstr ""
+msgstr "Virheenkorjaustiedot (ilman kodi.log-tiedostoa)"
 
 msgctxt "#30440"
 msgid "Color of an unaired episode name"
-msgstr ""
+msgstr "Esittämättömän jakson nimen väri"
 
 msgctxt "#30441"
 msgid "Select userlist for movies"
-msgstr ""
+msgstr "Valitse käyttäjälista elokuville"
 
 msgctxt "#30442"
 msgid "Userlist for movies"
-msgstr ""
+msgstr "Käyttäjälista elokuville"
 
 msgctxt "#30443"
 msgid "Selected userlist for movies"
-msgstr ""
+msgstr "Valittu käyttäjälista elokuville"
 
 msgctxt "#30444"
 msgid "Select userlist for shows"
-msgstr ""
+msgstr "Valitse käyttäjälista sarjoille"
 
 msgctxt "#30445"
 msgid "Userlist for shows"
-msgstr ""
+msgstr "Käyttäjälista sarjoille"
 
 msgctxt "#30446"
 msgid "Selected userlist for shows"
-msgstr ""
+msgstr "Valittu käyttäjälista sarjoille"
 
 msgctxt "#30447"
 msgid "Add to Trakt, when movie is added to Kodi library"
-msgstr ""
+msgstr "Lisää Traktiin, kun elokuva lisätään Kodi-kirjastoon"
 
 msgctxt "#30448"
 msgid "Add to Trakt, when show is added to Kodi library"
-msgstr ""
+msgstr "Lisää Traktiin, kun sarja lisätään Kodi-kirjastoon"
 
 msgctxt "#30449"
 msgid "Remove from Trakt, when movie is deleted from Kodi library"
-msgstr ""
+msgstr "Poista Traktista, kun elokuva poistetaan Kodi-kirjastosta"
 
 msgctxt "#30450"
 msgid "Remove from Trakt, when show is deleted from Kodi library"
-msgstr ""
+msgstr "Poista Traktista, kun sarja poistetaan Kodi-kirjastosta"
 
 msgctxt "#30451"
 msgid "Torrent files path"
-msgstr ""
+msgstr "Torrent-tiedostojen polku"
 
 msgctxt "#30452"
 msgid "Reset all paths"
-msgstr ""
+msgstr "Palauta kaikki polut"
 
 msgctxt "#30453"
 msgid "Upload /debug/bundle (with kodi.log) to pastebin"
-msgstr ""
+msgstr "Lähetä /debug/bundle (kodi.log mukana) pastebiniin"
 
 msgctxt "#30454"
 msgid "Paste url:[CR]%s"
-msgstr ""
+msgstr "Paste-osoite:[CR]%s"
 
 msgctxt "#30455"
 msgid "Logging"
-msgstr ""
+msgstr "Lokitus"
 
 msgctxt "#30456"
 msgid "Upload /debug/all (no kodi.log) to pastebin"
-msgstr ""
+msgstr "Lähetä /debug/all (ilman kodi.log-tiedostoa) pastebiniin"
 
 msgctxt "#30457"
 msgid "Uploading file to pastebin"
-msgstr ""
+msgstr "Lähetetään tiedostoa pastebiniin"
 
 msgctxt "#30458"
 msgid "Deleted movies"
-msgstr ""
+msgstr "Poistetut elokuvat"
 
 msgctxt "#30459"
 msgid "Deleted shows"
-msgstr ""
+msgstr "Poistetut sarjat"
 
 msgctxt "#30460"
 msgid "Database"
-msgstr ""
+msgstr "Tietokanta"
 
 msgctxt "#30461"
 msgid "Show information"
-msgstr ""
+msgstr "Näytä tiedot"
 
 msgctxt "#30462"
 msgid "Clear deleted movies"
-msgstr ""
+msgstr "Tyhjennä poistetut elokuvat"
 
 msgctxt "#30463"
 msgid "Clear deleted shows"
-msgstr ""
+msgstr "Tyhjennä poistetut sarjat"
 
 msgctxt "#30464"
 msgid "Clear torrents history"
-msgstr ""
+msgstr "Tyhjennä torrent-historia"
 
 msgctxt "#30465"
 msgid "Clear search history"
-msgstr ""
+msgstr "Tyhjennä hakuhistoria"
 
 msgctxt "#30466"
 msgid "Clear the database"
-msgstr ""
+msgstr "Tyhjennä tietokanta"
 
 msgctxt "#30467"
 msgid "Cache"
-msgstr ""
+msgstr "Välimuisti"
 
 msgctxt "#30468"
 msgid "Clear TMDB cache"
-msgstr ""
+msgstr "Tyhjennä TMDB-välimuisti"
 
 msgctxt "#30469"
 msgid "Clear Trakt cache"
-msgstr ""
+msgstr "Tyhjennä Trakt-välimuisti"
 
 msgctxt "#30470"
 msgid "Clear the cache"
-msgstr ""
+msgstr "Tyhjennä välimuisti"
 
 msgctxt "#30471"
 msgid "Are you sure you want to do it?"
-msgstr ""
+msgstr "Haluatko varmasti tehdä tämän?"
 
 msgctxt "#30472"
 msgid "Database cleared"
-msgstr ""
+msgstr "Tietokanta tyhjennetty"
 
 msgctxt "#30473"
 msgid "Select network interface"
-msgstr ""
+msgstr "Valitse verkkoliitäntä"
 
 msgctxt "#30474"
 msgid "Network interfaces"
-msgstr ""
+msgstr "Verkkoliitännät"
 
 msgctxt "#30475"
 msgid "Strm files language"
-msgstr ""
+msgstr "Strm-tiedostojen kieli"
 
 msgctxt "#30476"
 msgid "Select language"
-msgstr ""
+msgstr "Valitse kieli"
 
 msgctxt "#30477"
 msgid "Original language"
-msgstr ""
+msgstr "Alkuperäinen kieli"
 
 msgctxt "#30478"
 msgid "Searching"
-msgstr ""
+msgstr "Haetaan"
 
 msgctxt "#30480"
 msgid "Run Kodi library update after add/delete"
-msgstr ""
+msgstr "Suorita Kodi-kirjaston päivitys lisäyksen/poiston jälkeen"
 
 msgctxt "#30481"
 msgid "Automatically"
-msgstr ""
+msgstr "Automaattisesti"
 
 msgctxt "#30482"
 msgid "Ask"
-msgstr ""
+msgstr "Kysy"
 
 msgctxt "#30483"
 msgid "Create NFO files for Movie scrapers"
-msgstr ""
+msgstr "Luo NFO-tiedostot elokuvien tiedonkerääjille"
 
 msgctxt "#30484"
 msgid "Create NFO files for TV Show scrapers"
-msgstr ""
+msgstr "Luo NFO-tiedostot sarjojen tiedonkerääjille"
 
 msgctxt "#30485"
 msgid "Concurrent connections limit per second"
-msgstr ""
+msgstr "Samanaikaisten yhteyksien raja sekunnissa"
 
 msgctxt "#30486"
 msgid "Automatic concurrent connections limit per second"
-msgstr ""
+msgstr "Automaattinen samanaikaisten yhteyksien raja sekunnissa"
 
 msgctxt "#30487"
 msgid "Enable built-in HTTP proxy"
-msgstr ""
+msgstr "Ota sisäänrakennettu HTTP-välityspalvelin käyttöön"
 
 msgctxt "#30488"
 msgid "Internal Proxy Port"
-msgstr ""
+msgstr "Sisäisen välityspalvelimen portti"
 
 msgctxt "#30489"
 msgid "Log Internal proxy requests"
-msgstr ""
+msgstr "Kirjaa sisäisen välityspalvelimen pyynnöt"
 
 msgctxt "#30490"
 msgid "Internal HTTP proxy"
-msgstr ""
+msgstr "Sisäinen HTTP-välityspalvelin"
 
 msgctxt "#30491"
 msgid "Use Fanart.tv for posters/images"
-msgstr ""
+msgstr "Käytä Fanart.tv:tä julisteille/kuville"
 
 msgctxt "#30492"
 msgid "Use Proxy for downloading .torrent files"
-msgstr ""
+msgstr "Käytä välityspalvelinta .torrent-tiedostojen lataamiseen"
 
 msgctxt "#30493"
 msgid "Use Proxy for trackers"
-msgstr ""
+msgstr "Käytä välityspalvelinta seurantapalvelimille"
 
 msgctxt "#30494"
 msgid "Use Proxy for torrent downloading"
-msgstr ""
+msgstr "Käytä välityspalvelinta torrenttien lataamiseen"
 
 msgctxt "#30495"
 msgid "Use built-in DNS resolver"
-msgstr ""
+msgstr "Käytä sisäänrakennettua DNS-selvitintä"
 
 msgctxt "#30496"
 msgid "Turn off if you use Tor addresses, or you want [CR]to use DNS settings from OS"
-msgstr ""
+msgstr "Poista käytöstä, jos käytät Tor-osoitteita tai haluat [CR]käyttää käyttöjärjestelmän DNS-asetuksia"
 
 msgctxt "#30497"
 msgid "Use Antizapret proxy (only for Russia)"
-msgstr ""
+msgstr "Käytä Antizapret-välityspalvelinta (vain Venäjälle)"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"
-msgstr ""
+msgstr "Palauta tämä polku arvoon '/'"
 
 msgctxt "#30499"
 msgid "Automatically adjust memory size[CR]for heavy torrents, if possible"
-msgstr ""
+msgstr "Säädä muistin kokoa automaattisesti[CR]raskaille torrenteille, jos mahdollista"
 
 msgctxt "#30500"
 msgid "Automatically adjust buffer size[CR]for heavy torrents"
-msgstr ""
+msgstr "Säädä puskurin kokoa automaattisesti[CR]raskaille torrenteille"
 
 msgctxt "#30502"
 msgid "Adjust buffer according to Kodi advancedsettings.xml, if set"
-msgstr ""
+msgstr "Säädä puskuria Kodin advancedsettings.xml-tiedoston mukaan, jos asetettu"
 
 msgctxt "#30503"
 msgid "Use libtorrent.config to override torrent engine settings"
-msgstr ""
+msgstr "Käytä libtorrent.config-tiedostoa torrent-moottorin asetusten ohittamiseen"
 
 msgctxt "#30504"
 msgid "Located at USERDATA/plugin.video.elementum/libtorrent.config file[CR]Settings apply automatically. Visit https://libtorrent.org for info."
-msgstr ""
+msgstr "Sijaitsee tiedostossa USERDATA/plugin.video.elementum/libtorrent.config[CR]Asetukset tulevat voimaan automaattisesti. Katso lisätietoja osoitteesta https://libtorrent.org ."
 
 msgctxt "#30505"
 msgid "Add episode number to the title"
-msgstr ""
+msgstr "Lisää jakson numero otsikkoon"
 
 msgctxt "#30506"
 msgid "Enable libtorrent logging"
-msgstr ""
+msgstr "Ota libtorrent-lokitus käyttöön"
 
 msgctxt "#30511"
 msgid "Libtorrent settings profile"
-msgstr ""
+msgstr "libtorrent-asetusprofiili"
 
 msgctxt "#30512"
 msgid "Default"
-msgstr ""
+msgstr "Oletus"
 
 msgctxt "#30513"
 msgid "Minimal memory"
-msgstr ""
+msgstr "Vähäinen muisti"
 
 msgctxt "#30514"
 msgid "High speed"
-msgstr ""
+msgstr "Suuri nopeus"
 
 msgctxt "#30515"
 msgid "Load torrents from torrents folder paused"
-msgstr ""
+msgstr "Lataa torrentit torrent-kansiosta keskeytettyinä"
 
 msgctxt "#30516"
 msgid "... resume N seconds earlier"
-msgstr ""
+msgstr "... jatka N sekuntia aiemmin"
 
 msgctxt "#30517"
 msgid "In Kodi library"
-msgstr ""
+msgstr "Kodi-kirjastossa"
 
 msgctxt "#30518"
 msgid "Use libtorrent deadlines"
-msgstr ""
+msgstr "Käytä libtorrentin määräaikoja"
 
 msgctxt "#30519"
 msgid "Use libtorrent pause/resume trick for added torrents"
-msgstr ""
+msgstr "Käytä libtorrentin tauko/jatka-kikkaa lisätyille torrenteille"
 
 msgctxt "#30520"
 msgid "Add item to start menu"
-msgstr ""
+msgstr "Lisää kohde aloitusvalikkoon"
 
 msgctxt "#30521"
 msgid "Delete item from start menu"
-msgstr ""
+msgstr "Poista kohde aloitusvalikosta"
 
 msgctxt "#30522"
 msgid "Minimum file size"
-msgstr ""
+msgstr "Tiedoston vähimmäiskoko"
 
 msgctxt "#30523"
 msgid "Minimum file size for Movies, MB"
-msgstr ""
+msgstr "Tiedoston vähimmäiskoko elokuville, Mt"
 
 msgctxt "#30524"
 msgid "Minimum file size for Shows, MB per minute"
-msgstr ""
+msgstr "Tiedoston vähimmäiskoko sarjoille, Mt minuutissa"
 
 msgctxt "#30525"
 msgid "Automatically start downloading next episode"
-msgstr ""
+msgstr "Aloita seuraavan jakson lataus automaattisesti"
 
 msgctxt "#30527"
 msgid "Donate"
-msgstr ""
+msgstr "Lahjoita"
 
 msgctxt "#30528"
 msgid "Automatically load first found subtitles"
-msgstr ""
+msgstr "Lataa ensimmäiset löydetyt tekstitykset automaattisesti"
 
 msgctxt "#30529"
 msgid "Number of subtitles to load automatically"
-msgstr ""
+msgstr "Automaattisesti ladattavien tekstitysten määrä"
 
 msgctxt "#30530"
 msgid "Delete autoloaded subtitles on player stop"
-msgstr ""
+msgstr "Poista automaattisesti ladatut tekstitykset soittimen pysäytyksessä"
 
 msgctxt "#30531"
 msgid "Download all files from torrent"
-msgstr ""
+msgstr "Lataa kaikki tiedostot torrentista"
 
 msgctxt "#30532"
 msgid "Stop Downloading all files"
-msgstr ""
+msgstr "Pysäytä kaikkien tiedostojen lataus"
 
 msgctxt "#30535"
 msgid "Continue playback from [B]%s[/B]?"
-msgstr ""
+msgstr "Jatketaanko toistoa kohdasta [B]%s[/B]?"
 
 msgctxt "#30536"
 msgid "Skip IPv6 addresses resolving"
-msgstr ""
+msgstr "Ohita IPv6-osoitteiden selvitys"
 
 msgctxt "#30537"
 msgid "Torrents history"
-msgstr ""
+msgstr "Torrent-historia"
 
 msgctxt "#30538"
 msgid "Use torrents history?"
-msgstr ""
+msgstr "Käytetäänkö torrent-historiaa?"
 
 msgctxt "#30539"
 msgid "Store N torrents in history"
-msgstr ""
+msgstr "Säilytä N torrenttia historiassa"
 
 msgctxt "#30540"
 msgid "Subtitles"
-msgstr ""
+msgstr "Tekstitykset"
 
 msgctxt "#30541"
 msgid "Automatic Subtitles Search"
-msgstr ""
+msgstr "Automaattinen tekstitysten haku"
 
 msgctxt "#30542"
 msgid "Disable if subtitles are available in player"
-msgstr ""
+msgstr "Poista käytöstä, jos tekstitykset ovat saatavilla soittimessa"
 
 msgctxt "#30543"
 msgid "Subtitles included in torrent"
-msgstr ""
+msgstr "Torrentin sisältämät tekstitykset"
 
 msgctxt "#30544"
 msgid "Automatic Scrape"
-msgstr ""
+msgstr "Automaattinen keruu"
 
 msgctxt "#30545"
 msgid "Automatic scraping allows to scrape connected providers[CR]to find new movies, if there are results,"
-msgstr ""
+msgstr "Automaattinen keruu hakee yhdistetyistä tarjoajista[CR]uusia elokuvia. Jos tuloksia on"
 
 msgctxt "#30546"
 msgid "Strategy"
-msgstr ""
+msgstr "Strategia"
 
 msgctxt "#30547"
 msgid "Find in each provider"
-msgstr ""
+msgstr "Hae jokaisesta tarjoajasta"
 
 msgctxt "#30548"
 msgid "Find in overall"
-msgstr ""
+msgstr "Hae kokonaisuutena"
 
 msgctxt "#30549"
 msgid "Search is successful when found N results"
-msgstr ""
+msgstr "Haku onnistuu, kun löytyy N tulosta"
 
 msgctxt "#30550"
 msgid "What to search"
-msgstr ""
+msgstr "Mitä haetaan"
 
 msgctxt "#30551"
 msgid "How to search"
-msgstr ""
+msgstr "Miten haetaan"
 
 msgctxt "#30552"
 msgid "Search each N hours"
-msgstr ""
+msgstr "Hae N tunnin välein"
 
 msgctxt "#30553"
 msgid "Find 4K resolution"
-msgstr ""
+msgstr "Etsi 4K-tarkkuutta"
 
 msgctxt "#30554"
 msgid "Find 1080p resolution"
-msgstr ""
+msgstr "Etsi 1080p-tarkkuutta"
 
 msgctxt "#30555"
 msgid "and movie passes checks for number of results[CR]movie can be added to the library."
-msgstr ""
+msgstr "ja elokuva läpäisee tulosmäärän tarkistukset,[CR]se voidaan lisätä kirjastoon."
 
 msgctxt "#30556"
 msgid "Add to the library"
-msgstr ""
+msgstr "Lisää kirjastoon"
 
 msgctxt "#30557"
 msgid "Number of popular movies to search"
-msgstr ""
+msgstr "Haettavien suosittujen elokuvien määrä"
 
 msgctxt "#30558"
 msgid "Latest available movies"
-msgstr ""
+msgstr "Uusimmat saatavilla olevat elokuvat"
 
 msgctxt "#30559"
 msgid "Skip searching for installed providers"
-msgstr ""
+msgstr "Ohita asennettujen tarjoajien haku"
 
 msgctxt "#30560"
 msgid "Files: %s"
-msgstr ""
+msgstr "Tiedostot: %s"
 
 msgctxt "#30561"
 msgid "Interval between requests, seconds"
-msgstr ""
+msgstr "Pyyntöjen väli, sekuntia"
 
 msgctxt "#30562"
 msgid "Open directory with Kodi file browser"
-msgstr ""
+msgstr "Avaa kansio Kodin tiedostoselaimella"
 
 msgctxt "#30563"
 msgid "Synchronize frequency of Trakt, minutes"
-msgstr ""
+msgstr "Trakt-synkronoinnin tiheys, minuuttia"
 
 msgctxt "#30564"
 msgid "Sync hidden items"
-msgstr ""
+msgstr "Synkronoi piilotetut kohteet"
 
 msgctxt "#30565"
 msgid "Sync playback progress into Kodi library"
-msgstr ""
+msgstr "Synkronoi toiston edistyminen Kodi-kirjastoon"
 
 msgctxt "#30566"
 msgid "Lists"
-msgstr ""
+msgstr "Listat"
 
 msgctxt "#30567"
 msgid "Show \"All seasons\" in shows"
-msgstr ""
+msgstr "Näytä \"Kaikki kaudet\" sarjoissa"
 
 msgctxt "#30568"
 msgid "Seasons order"
-msgstr ""
+msgstr "Kausien järjestys"
 
 msgctxt "#30569"
 msgid "Ascending"
-msgstr ""
+msgstr "Nouseva"
 
 msgctxt "#30570"
 msgid "Descending"
-msgstr ""
+msgstr "Laskeva"
 
 msgctxt "#30571"
 msgid "* All seasons"
-msgstr ""
+msgstr "* Kaikki kaudet"
 
 msgctxt "#30572"
 msgid "Log server's response body"
-msgstr ""
+msgstr "Kirjaa palvelimen vastauksen sisältö"
 
 msgctxt "#30573"
 msgid "Select file to play"
-msgstr ""
+msgstr "Valitse toistettava tiedosto"
 
 msgctxt "#30574"
 msgid "Automatically answer Yes after timeout"
-msgstr ""
+msgstr "Vastaa automaattisesti Kyllä aikakatkaisun jälkeen"
 
 msgctxt "#30575"
 msgid "Timeout, seconds"
-msgstr ""
+msgstr "Aikakatkaisu, sekuntia"
 
 msgctxt "#30576"
 msgid "Trakt authentication needs to be updated!"
-msgstr ""
+msgstr "Trakt-todennus täytyy päivittää!"
 
 msgctxt "#30577"
 msgid "End of file Buffer size, MB"
-msgstr ""
+msgstr "Tiedoston lopun puskurin koko, Mt"
 
 msgctxt "#30578"
 msgid "Beginning of file Buffer size, MB"
-msgstr ""
+msgstr "Tiedoston alun puskurin koko, Mt"
 
 msgctxt "#30579"
 msgid "Settings"
-msgstr ""
+msgstr "Asetukset"
 
 msgctxt "#30580"
 msgid "Custom Trakt API Client ID"
-msgstr ""
+msgstr "Mukautettu Trakt-API:n Client ID"
 
 msgctxt "#30581"
 msgid "Custom Trakt API Client Secret"
-msgstr ""
+msgstr "Mukautettu Trakt-API:n Client Secret"
 
 msgctxt "#30582"
 msgid "Settings for %s provider"
-msgstr ""
+msgstr "Tarjoajan %s asetukset"
 
 msgctxt "#30583"
 msgid "Resolving magnet link"
-msgstr ""
+msgstr "Selvitetään magnet-linkkiä"
 
 msgctxt "#30585"
 msgid "Enable library integration with Kodi"
-msgstr ""
+msgstr "Ota kirjastointegraatio Kodin kanssa käyttöön"
 
 msgctxt "#30586"
 msgid "If disabled - Elementum will not get/insert items to Kodi library [CR]and skip watched management with Kodi."
-msgstr ""
+msgstr "Jos poistettu käytöstä, Elementum ei hae eikä lisää kohteita Kodi-kirjastoon [CR]ja ohittaa katsottu-tilan hallinnan Kodin kanssa."
 
 msgctxt "#30587"
 msgid "Show welcome message on start"
-msgstr ""
+msgstr "Näytä tervetuloviesti käynnistyksessä"
 
 msgctxt "#30588"
 msgid "Pre-Play Buffering"
-msgstr ""
+msgstr "Puskurointi ennen toistoa"
 
 msgctxt "#30589"
 msgid "Speed limiting"
-msgstr ""
+msgstr "Nopeusrajoitus"
 
 msgctxt "#30590"
 msgid "Torrents autoload on addon startup"
-msgstr ""
+msgstr "Torrenttien automaattinen lataus lisäosan käynnistyessä"
 
 msgctxt "#30591"
 msgid "Limits for connections"
-msgstr ""
+msgstr "Yhteyksien rajat"
 
 msgctxt "#30592"
 msgid "Seeding"
-msgstr ""
+msgstr "Jakaminen"
 
 msgctxt "#30593"
 msgid "Seed forever"
-msgstr ""
+msgstr "Jaa ikuisesti"
 
 msgctxt "#30594"
 msgid "Network"
-msgstr ""
+msgstr "Verkko"
 
 msgctxt "#30595"
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Sekalaiset"
 
 msgctxt "#30597"
 msgid "Cache size, MB"
-msgstr ""
+msgstr "Välimuistin koko, Mt"
 
 msgctxt "#30598"
 msgid "Enable caching if using File storage and have speed problems.[CR]Will use more memory, but can improve the speed."
-msgstr ""
+msgstr "Ota välimuisti käyttöön, jos käytät tiedostotallennusta ja sinulla on nopeusongelmia.[CR]Se käyttää enemmän muistia, mutta voi parantaa nopeutta."
 
 msgctxt "#30599"
 msgid "Enable Kodi library synchronization"
-msgstr ""
+msgstr "Ota Kodi-kirjaston synkronointi käyttöön"
 
 msgctxt "#30600"
 msgid "Enable Trakt synchronization"
-msgstr ""
+msgstr "Ota Trakt-synkronointi käyttöön"
 
 msgctxt "#30601"
 msgid "Enable synchronization while playback"
-msgstr ""
+msgstr "Ota synkronointi käyttöön toiston aikana"
 
 msgctxt "#30602"
 msgid "Retry requests to addon after timeout, seconds"
-msgstr ""
+msgstr "Yritä pyyntöjä lisäosalle uudelleen aikakatkaisun jälkeen, sekuntia"
 
 msgctxt "#30603"
 msgid "Addon Startup"
-msgstr ""
+msgstr "Lisäosan käynnistys"
 
 msgctxt "#30604"
 msgid "Clean all history"
-msgstr ""
+msgstr "Tyhjennä koko historia"
 
 msgctxt "#30605"
 msgid "Cache downloaded torrent files after search"
-msgstr ""
+msgstr "Tallenna ladatut torrent-tiedostot välimuistiin haun jälkeen"
 
 msgctxt "#30606"
 msgid "Show watched state for torrent's files"
-msgstr ""
+msgstr "Näytä katsottu-tila torrentin tiedostoille"
 
 msgctxt "#30607"
 msgid "Use earliest release date as basic for searching"
-msgstr ""
+msgstr "Käytä varhaisinta julkaisupäivää haun perustana"
 
 msgctxt "#30608"
 msgid "Match found in your active torrents, play it?[CR]%s"
-msgstr ""
+msgstr "Osuma löytyi aktiivisista torrenteistasi, toistetaanko se?[CR]%s"
 
 msgctxt "#30609"
 msgid "Automatically start next episode if available"
-msgstr ""
+msgstr "Aloita seuraava jakso automaattisesti, jos saatavilla"
 
 msgctxt "#30610"
 msgid "Magnet resolve timeout, seconds"
-msgstr ""
+msgstr "Magnet-selvityksen aikakatkaisu, sekuntia"
 
 msgctxt "#30611"
 msgid "Application platform type"
-msgstr ""
+msgstr "Sovelluksen alustatyyppi"
 
 msgctxt "#30612"
 msgid "Select file to download"
-msgstr ""
+msgstr "Valitse ladattava tiedosto"
 
 msgctxt "#30613"
 msgid "... for movie"
-msgstr ""
+msgstr "... elokuvalle"
 
 msgctxt "#30614"
 msgid "... for tv show"
-msgstr ""
+msgstr "... sarjalle"
 
 msgctxt "#30615"
 msgid "... for search"
-msgstr ""
+msgstr "... haulle"
 
 msgctxt "#30616"
 msgid "Elementum | Trakt Account"
-msgstr ""
+msgstr "Elementum | Trakt-tili"
 
 msgctxt "#30617"
 msgid "Your account is locked for API on Trakt.tv[CR]Please, contact Trakt Support at https://support.trakt.tv ."
-msgstr ""
+msgstr "Tilisi on lukittu Trakt.tv:n API:lta[CR]Ota yhteyttä Traktin tukeen osoitteessa https://support.trakt.tv ."
 
 msgctxt "#30618"
 msgid "%s is downloaded"
-msgstr ""
+msgstr "%s on ladattu"
 
 msgctxt "#30619"
 msgid "Return to [B]%s[/B]"
-msgstr ""
+msgstr "Palaa kohteeseen [B]%s[/B]"
 
 msgctxt "#30620"
 msgid "Restart Elementum addon"
-msgstr ""
+msgstr "Käynnistä Elementum-lisäosa uudelleen"
 
 msgctxt "#30621"
 msgid "Queued"
-msgstr ""
+msgstr "Jonossa"
 
 msgctxt "#30622"
 msgid "Checking"
-msgstr ""
+msgstr "Tarkistetaan"
 
 msgctxt "#30623"
 msgid "Finding"
-msgstr ""
+msgstr "Etsitään"
 
 msgctxt "#30624"
 msgid "Downloading"
-msgstr ""
+msgstr "Ladataan"
 
 msgctxt "#30625"
 msgid "Finished"
-msgstr ""
+msgstr "Valmis"
 
 msgctxt "#30626"
 msgid "Seeding"
-msgstr ""
+msgstr "Jaetaan"
 
 msgctxt "#30627"
 msgid "Allocating"
-msgstr ""
+msgstr "Varataan"
 
 msgctxt "#30628"
 msgid "Stalled"
-msgstr ""
+msgstr "Pysähtynyt"
 
 msgctxt "#30629"
 msgid "Paused"
-msgstr ""
+msgstr "Keskeytetty"
 
 msgctxt "#30630"
 msgid "Buffering"
-msgstr ""
+msgstr "Puskuroidaan"
 
 msgctxt "#30631"
 msgid "Playing"
-msgstr ""
+msgstr "Toistetaan"
 
 msgctxt "#30632"
 msgid "Yes (%s seconds)"
-msgstr ""
+msgstr "Kyllä (%s sekuntia)"
 
 msgctxt "#30633"
 msgid "No (%s seconds)"
-msgstr ""
+msgstr "Ei (%s sekuntia)"
 
 msgctxt "#30634"
 msgid "Log level"
-msgstr ""
+msgstr "Lokitustaso"
 
 msgctxt "#30635"
 msgid "None"
-msgstr ""
+msgstr "Ei mitään"
 
 msgctxt "#30636"
 msgid "Error"
-msgstr ""
+msgstr "Virhe"
 
 msgctxt "#30637"
 msgid "Info"
-msgstr ""
+msgstr "Tiedot"
 
 msgctxt "#30638"
 msgid "Debug"
-msgstr ""
+msgstr "Virheenkorjaus"
 
 msgctxt "#30639"
 msgid "Show Specials in season listings"
-msgstr ""
+msgstr "Näytä erikoisjaksot kausilistauksissa"
 
 msgctxt "#30640"
 msgid "Bitrate"
-msgstr ""
+msgstr "Bittinopeus"
 
 msgctxt "#30641"
 msgid "Playback"
-msgstr ""
+msgstr "Toisto"
 
 msgctxt "#30642"
 msgid "Force Resume options"
-msgstr ""
+msgstr "Pakota jatkamisvaihtoehdot"
 
 msgctxt "#30643"
 msgid "by Kodi"
-msgstr ""
+msgstr "Kodin toimesta"
 
 msgctxt "#30644"
 msgid "by Elementum - Ask"
-msgstr ""
+msgstr "Elementumin toimesta - Kysy"
 
 msgctxt "#30645"
 msgid "by Elementum - Force"
-msgstr ""
+msgstr "Elementumin toimesta - Pakota"
 
 msgctxt "#30646"
 msgid "Authorize Elementum on Trakt.tv"
-msgstr ""
+msgstr "Valtuuta Elementum Trakt.tv:ssä"
 
 msgctxt "#30647"
 msgid "Cancel Authorization for Elementum on Trakt.tv"
-msgstr ""
+msgstr "Peruuta Elementumin valtuutus Trakt.tv:ssä"
 
 msgctxt "#30648"
 msgid "Authorization"
-msgstr ""
+msgstr "Valtuutus"
 
 msgctxt "#30649"
 msgid "To authorize addon for Trakt.tv you need to:[CR]1. Open [B]%s[/B][CR]2. Enter code: [B]%s[/B][CR]3. Wait for notification from Elementum."
-msgstr ""
+msgstr "Valtuuttaaksesi lisäosan Trakt.tv:hen sinun täytyy:[CR]1. Avata [B]%s[/B][CR]2. Syöttää koodi: [B]%s[/B][CR]3. Odottaa ilmoitusta Elementumilta."
 
 msgctxt "#30650"
 msgid "Successfully authorized for Trakt.tv"
-msgstr ""
+msgstr "Valtuutus Trakt.tv:hen onnistui"
 
 msgctxt "#30651"
 msgid "Could not authorize for Trakt.tv"
-msgstr ""
+msgstr "Valtuutus Trakt.tv:hen epäonnistui"
 
 msgctxt "#30652"
 msgid "Successfully deauthorized for Trakt.tv"
-msgstr ""
+msgstr "Valtuutuksen peruutus Trakt.tv:ssä onnistui"
 
 msgctxt "#30653"
 msgid "Which files to download"
-msgstr ""
+msgstr "Mitkä tiedostot ladataan"
 
 msgctxt "#30654"
 msgid "Only playback file"
-msgstr ""
+msgstr "Vain toistettava tiedosto"
 
 msgctxt "#30655"
 msgid "Season files"
-msgstr ""
+msgstr "Kauden tiedostot"
 
 msgctxt "#30656"
 msgid "All files"
-msgstr ""
+msgstr "Kaikki tiedostot"
 
 msgctxt "#30657"
 msgid "Disable LSD"
-msgstr ""
+msgstr "Poista LSD käytöstä"
 
 msgctxt "#30658"
 msgid "Add extra trackers"
-msgstr ""
+msgstr "Lisää ylimääräisiä seurantapalvelimia"
 
 msgctxt "#30659"
 msgid "All known trackers"
-msgstr ""
+msgstr "Kaikki tunnetut seurantapalvelimet"
 
 msgctxt "#30660"
 msgid "Best trackers"
-msgstr ""
+msgstr "Parhaat seurantapalvelimet"
 
 msgctxt "#30661"
 msgid "Minimum set"
-msgstr ""
+msgstr "Vähimmäisjoukko"
 
 msgctxt "#30662"
 msgid "Remove original trackers from torrent"
-msgstr ""
+msgstr "Poista alkuperäiset seurantapalvelimet torrentista"
 
 msgctxt "#30663"
 msgid "Show episodes on release day (w/o delay)"
-msgstr ""
+msgstr "Näytä jaksot julkaisupäivänä (ilman viivettä)"
 
 msgctxt "#30664"
 msgid "Modify trackers in torrent"
-msgstr ""
+msgstr "Muokkaa torrentin seurantapalvelimia"
 
 msgctxt "#30665"
 msgid "At the time of adding"
-msgstr ""
+msgstr "Lisäyshetkellä"
 
 msgctxt "#30666"
 msgid "Every time"
-msgstr ""
+msgstr "Joka kerta"
 
 msgctxt "#30667"
 msgid "Mark as watched in Trakt"
-msgstr ""
+msgstr "Merkitse katsotuksi Traktissa"
 
 msgctxt "#30668"
 msgid "Mark as unwatched in Trakt"
-msgstr ""
+msgstr "Merkitse katsomattomaksi Traktissa"
 
 msgctxt "#30669"
 msgid "Delay addon startup, seconds"
-msgstr ""
+msgstr "Viivytä lisäosan käynnistystä, sekuntia"
 
 msgctxt "#30670"
 msgid "Downloading required binary file for '%s'"
-msgstr ""
+msgstr "Ladataan tarvittavaa binääritiedostoa kohteelle '%s'"
 
 msgctxt "#30671"
 msgid "List of Opennic DNS IPs"
-msgstr ""
+msgstr "Luettelo OpenNIC-DNS-osoitteista"
 
 msgctxt "#30672"
 msgid "Compact database"
-msgstr ""
+msgstr "Tiivistä tietokanta"
 
 msgctxt "#30673"
 msgid "Compact cache database"
-msgstr ""
+msgstr "Tiivistä välimuistitietokanta"
 
 msgctxt "#30674"
 msgid "Database was compacted"
-msgstr ""
+msgstr "Tietokanta tiivistettiin"
 
 msgctxt "#30675"
 msgid "Remote host login"
-msgstr ""
+msgstr "Etäpalvelimen käyttäjätunnus"
 
 msgctxt "#30676"
 msgid "Remote host password"
-msgstr ""
+msgstr "Etäpalvelimen salasana"
 
 msgctxt "#30677"
 msgid "Force start as a library"
-msgstr ""
+msgstr "Pakota käynnistys kirjastona"
 
 msgctxt "#30678"
 msgid "Remove from Kodi library, when movie is deleted from Trakt"
-msgstr ""
+msgstr "Poista Kodi-kirjastosta, kun elokuva poistetaan Traktista"
 
 msgctxt "#30679"
 msgid "Remove from Kodi library, when show is deleted from Trakt"
-msgstr ""
+msgstr "Poista Kodi-kirjastosta, kun sarja poistetaan Traktista"
 
 msgctxt "#30680"
 msgid "Remove Elementum duplicates from library"
-msgstr ""
+msgstr "Poista Elementumin kaksoiskappaleet kirjastosta"
 
 msgctxt "#30681"
 msgid "[B]Found duplicates in Kodi library:[/B][CR]Movies: [B]%s[/B], Shows: [B]%s[/B], Episodes: [B]%s[/B][CR]Proceed?"
-msgstr ""
+msgstr "[B]Kodi-kirjastosta löytyi kaksoiskappaleita:[/B][CR]Elokuvat: [B]%s[/B], Sarjat: [B]%s[/B], Jaksot: [B]%s[/B][CR]Jatketaanko?"
 
 msgctxt "#30682"
 msgid "No duplicates were found in Kodi library"
-msgstr ""
+msgstr "Kodi-kirjastosta ei löytynyt kaksoiskappaleita"
 
 msgctxt "#30683"
 msgid "Starting library duplicates removal"
-msgstr ""
+msgstr "Aloitetaan kaksoiskappaleiden poisto kirjastosta"
 
 msgctxt "#30684"
 msgid "Removed Movies: %s, Shows: %s, Episodes: %s"
-msgstr ""
+msgstr "Poistettu - Elokuvat: %s, Sarjat: %s, Jaksot: %s"
 
 msgctxt "#30685"
 msgid "Remove movies from Elementum database"
-msgstr ""
+msgstr "Poista elokuvat Elementumin tietokannasta"
 
 msgctxt "#30686"
 msgid "Remove shows from Elementum database"
-msgstr ""
+msgstr "Poista sarjat Elementumin tietokannasta"
 
 msgctxt "#30687"
 msgid "In Elementum library"
-msgstr ""
+msgstr "Elementum-kirjastossa"
 
 msgctxt "#30688"
 msgid "Skip searching for installed Elementum repository"
-msgstr ""
+msgstr "Ohita asennetun Elementum-lähteen haku"
 
 msgctxt "#30689"
 msgid "Internal DNS client"
-msgstr ""
+msgstr "Sisäinen DNS-asiakas"
 
 msgctxt "#30691"
 msgid "Hide watched"
-msgstr ""
+msgstr "Piilota katsotut"
 
 msgctxt "#30692"
 msgid "TMDB images quality (affects Kodi performance)"
-msgstr ""
+msgstr "TMDB-kuvien laatu (vaikuttaa Kodin suorituskykyyn)"
 
 msgctxt "#30693"
 msgid "Original"
-msgstr ""
+msgstr "Alkuperäinen"
 
 msgctxt "#30694"
 msgid "High"
-msgstr ""
+msgstr "Korkea"
 
 msgctxt "#30695"
 msgid "Medium"
-msgstr ""
+msgstr "Keskitaso"
 
 msgctxt "#30696"
 msgid "Low"
-msgstr ""
+msgstr "Matala"
 
 msgctxt "#30697"
 msgid "Interface language"
-msgstr ""
+msgstr "Käyttöliittymän kieli"
 
 msgctxt "#30698"
 msgid "Kodi language"
-msgstr ""
+msgstr "Kodin kieli"
 
 msgctxt "#30699"
 msgid "Use earliest release date for progress and calendars"
-msgstr ""
+msgstr "Käytä varhaisinta julkaisupäivää edistymiselle ja kalentereille"
 
 msgctxt "#30700"
 msgid "Interface fallback language"
-msgstr ""
+msgstr "Käyttöliittymän varakieli"
 
 msgctxt "#30701"
 msgid "English | en"
-msgstr ""
+msgstr "Englanti | en"
 
 msgctxt "#30702"
 msgid "Reached daily limit for subtitles downloads"
-msgstr ""
+msgstr "Tekstitysten päivittäinen latausraja saavutettu"
 
 msgctxt "#30703"
 msgid "Can be used by search providers or [CR]for debugging"
-msgstr ""
+msgstr "Hakutarjoajat voivat käyttää tätä tai [CR]sitä voi käyttää virheenkorjaukseen"
 
 msgctxt "#30704"
 msgid "TMDB API Key check failed, cannot use TMDB service"
-msgstr ""
+msgstr "TMDB-API-avaimen tarkistus epäonnistui, TMDB-palvelua ei voi käyttää"
 
 msgctxt "#30705"
 msgid "TMDB API accessibility check failed, cannot use TMDB service"
-msgstr ""
+msgstr "TMDB-API:n saavutettavuuden tarkistus epäonnistui, TMDB-palvelua ei voi käyttää"
 
 msgctxt "#30706"
 msgid "Transmission 4.05"
-msgstr ""
+msgstr "Transmission 4.05"
 
 msgctxt "#30707"
 msgid "qBittorrent 3.3.9"
-msgstr ""
+msgstr "qBittorrent 3.3.9"
 
 msgctxt "#30708"
 msgid "qBittorrent 4.6.4"
-msgstr ""
+msgstr "qBittorrent 4.6.4"
 
 msgctxt "#30709"
 msgid "Open [B]%s[/B]"
-msgstr ""
+msgstr "Avaa [B]%s[/B]"
 
 msgctxt "#30710"
 msgid "BitTorrent ports"
-msgstr ""
+msgstr "BitTorrent-portit"
 
 msgctxt "#30711"
 msgid "Delete torrent '%s'?"
-msgstr ""
+msgstr "Poistetaanko torrent '%s'?"
 
 msgctxt "#30712"
 msgid "Force to always use proxy, can break download in some cases"
-msgstr ""
+msgstr "Pakota välityspalvelimen käyttö aina, voi joissakin tapauksissa katkaista latauksen"
 
 msgctxt "#30713"
 msgid "Disable NATPMP"
@@ -2283,20 +2283,20 @@ msgstr "Älä käytä NATPMP:tä"
 
 msgctxt "#30714"
 msgid "Re-check torrent's data"
-msgstr ""
+msgstr "Tarkista torrentin tiedot uudelleen"
 
 msgctxt "#30715"
 msgid "Antizapret PAC file URL"
-msgstr ""
+msgstr "Antizapret PAC -tiedoston osoite"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "DNS over HTTPS -palvelin"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "Mukautettu DNS over HTTPS -palvelin"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "Käytä OpenNIC-DNS-palvelimia"

--- a/resources/language/French/strings.po
+++ b/resources/language/French/strings.po
@@ -417,11 +417,11 @@ msgstr "Recherche sur les “trackers” …"
 
 msgctxt "#30119"
 msgid "ID of selected userlist for movies"
-msgstr ""
+msgstr "ID de la liste d'utilisateur sélectionnée pour les films"
 
 msgctxt "#30120"
 msgid "ID of selected userlist for shows"
-msgstr ""
+msgstr "ID de la liste d'utilisateur sélectionnée pour les séries"
 
 msgctxt "#30141"
 msgid "Please support Elementum development by visiting[CR]https://elementum.surge.sh/donate/ or https://elementumorg.github.io/donate/"
@@ -1469,7 +1469,7 @@ msgstr "Désactiver si vous utiliser des adresses Tort, ou si vous voulez utilis
 
 msgctxt "#30497"
 msgid "Use Antizapret proxy (only for Russia)"
-msgstr ""
+msgstr "Utiliser le proxy Antizapret (Russie uniquement)"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"
@@ -1849,7 +1849,7 @@ msgstr "Activer la synchronisation pendant la lecture"
 
 msgctxt "#30602"
 msgid "Retry requests to addon after timeout, seconds"
-msgstr ""
+msgstr "Réessayer les requêtes vers l'extension après expiration, en secondes"
 
 msgctxt "#30603"
 msgid "Addon Startup"
@@ -2009,7 +2009,7 @@ msgstr "Lecture"
 
 msgctxt "#30642"
 msgid "Force Resume options"
-msgstr ""
+msgstr "Forcer les options de reprise"
 
 msgctxt "#30643"
 msgid "by Kodi"
@@ -2085,7 +2085,7 @@ msgstr "Les meilleurs trackers"
 
 msgctxt "#30661"
 msgid "Minimum set"
-msgstr ""
+msgstr "Ensemble minimal"
 
 msgctxt "#30662"
 msgid "Remove original trackers from torrent"
@@ -2125,7 +2125,7 @@ msgstr "Téléchargement des fichiers binaires requis pour '%s'"
 
 msgctxt "#30671"
 msgid "List of Opennic DNS IPs"
-msgstr ""
+msgstr "Liste des adresses IP des DNS OpenNIC"
 
 msgctxt "#30672"
 msgid "Compact database"
@@ -2193,99 +2193,99 @@ msgstr "Dans la librairie Elementum"
 
 msgctxt "#30688"
 msgid "Skip searching for installed Elementum repository"
-msgstr ""
+msgstr "Ignorer la recherche du dépôt Elementum installé"
 
 msgctxt "#30689"
 msgid "Internal DNS client"
-msgstr ""
+msgstr "Client DNS interne"
 
 msgctxt "#30691"
 msgid "Hide watched"
-msgstr ""
+msgstr "Masquer les éléments vus"
 
 msgctxt "#30692"
 msgid "TMDB images quality (affects Kodi performance)"
-msgstr ""
+msgstr "Qualité des images TMDB (affecte les performances de Kodi)"
 
 msgctxt "#30693"
 msgid "Original"
-msgstr ""
+msgstr "Originale"
 
 msgctxt "#30694"
 msgid "High"
-msgstr ""
+msgstr "Haute"
 
 msgctxt "#30695"
 msgid "Medium"
-msgstr ""
+msgstr "Moyenne"
 
 msgctxt "#30696"
 msgid "Low"
-msgstr ""
+msgstr "Basse"
 
 msgctxt "#30697"
 msgid "Interface language"
-msgstr ""
+msgstr "Langue de l'interface"
 
 msgctxt "#30698"
 msgid "Kodi language"
-msgstr ""
+msgstr "Langue de Kodi"
 
 msgctxt "#30699"
 msgid "Use earliest release date for progress and calendars"
-msgstr ""
+msgstr "Utiliser la date de sortie la plus ancienne pour la progression et les calendriers"
 
 msgctxt "#30700"
 msgid "Interface fallback language"
-msgstr ""
+msgstr "Langue de secours de l'interface"
 
 msgctxt "#30701"
 msgid "English | en"
-msgstr ""
+msgstr "Anglais | en"
 
 msgctxt "#30702"
 msgid "Reached daily limit for subtitles downloads"
-msgstr ""
+msgstr "Limite quotidienne de téléchargements de sous-titres atteinte"
 
 msgctxt "#30703"
 msgid "Can be used by search providers or [CR]for debugging"
-msgstr ""
+msgstr "Peut être utilisé par les fournisseurs de recherche ou[CR]pour le débogage"
 
 msgctxt "#30704"
 msgid "TMDB API Key check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Échec de la vérification de la clé API TMDB, impossible d'utiliser le service TMDB"
 
 msgctxt "#30705"
 msgid "TMDB API accessibility check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Échec de la vérification de l'accessibilité de l'API TMDB, impossible d'utiliser le service TMDB"
 
 msgctxt "#30706"
 msgid "Transmission 4.05"
-msgstr ""
+msgstr "Transmission 4.05"
 
 msgctxt "#30707"
 msgid "qBittorrent 3.3.9"
-msgstr ""
+msgstr "qBittorrent 3.3.9"
 
 msgctxt "#30708"
 msgid "qBittorrent 4.6.4"
-msgstr ""
+msgstr "qBittorrent 4.6.4"
 
 msgctxt "#30709"
 msgid "Open [B]%s[/B]"
-msgstr ""
+msgstr "Ouvrir [B]%s[/B]"
 
 msgctxt "#30710"
 msgid "BitTorrent ports"
-msgstr ""
+msgstr "Ports BitTorrent"
 
 msgctxt "#30711"
 msgid "Delete torrent '%s'?"
-msgstr ""
+msgstr "Supprimer le torrent '%s' ?"
 
 msgctxt "#30712"
 msgid "Force to always use proxy, can break download in some cases"
-msgstr ""
+msgstr "Toujours forcer l'utilisation du proxy, peut interrompre le téléchargement dans certains cas"
 
 msgctxt "#30713"
 msgid "Disable NATPMP"
@@ -2293,20 +2293,20 @@ msgstr "Désactiver NATPMP"
 
 msgctxt "#30714"
 msgid "Re-check torrent's data"
-msgstr ""
+msgstr "Revérifier les données du torrent"
 
 msgctxt "#30715"
 msgid "Antizapret PAC file URL"
-msgstr ""
+msgstr "URL du fichier PAC Antizapret"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "Serveur DNS over HTTPS"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "Serveur DNS over HTTPS personnalisé"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "Utiliser les serveurs DNS OpenNIC"

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -25,7 +25,7 @@ msgstr "Allgemein"
 
 msgctxt "#30001"
 msgid "Download path"
-msgstr ""
+msgstr "Download-Pfad"
 
 msgctxt "#30004"
 msgid "Max upload rate, kB/s"
@@ -101,7 +101,7 @@ msgstr "Stream automatisch auswählen"
 
 msgctxt "#30025"
 msgid "Limit rates after initial buffering only"
-msgstr ""
+msgstr "Raten nur nach dem anfänglichen Puffern begrenzen"
 
 msgctxt "#30026"
 msgid "Library path"
@@ -113,7 +113,7 @@ msgstr "Max Anzahl Verbindungen"
 
 msgctxt "#30028"
 msgid "Download after play was stopped"
-msgstr ""
+msgstr "Nach dem Stoppen der Wiedergabe weiter herunterladen"
 
 msgctxt "#30029"
 msgid "Session saving frequency, seconds"
@@ -233,119 +233,119 @@ msgstr "Update der Bibliothek beim Start verzögern (Sekunden)"
 
 msgctxt "#30060"
 msgid "Library update frequency, hours"
-msgstr ""
+msgstr "Häufigkeit der Bibliotheksaktualisierung, Stunden"
 
 msgctxt "#30063"
 msgid "Disable UPNP"
-msgstr ""
+msgstr "UPNP deaktivieren"
 
 msgctxt "#30064"
 msgid "Encryption policy"
-msgstr ""
+msgstr "Verschlüsselungsrichtlinie"
 
 msgctxt "#30065"
 msgid "Disabled"
-msgstr ""
+msgstr "Deaktiviert"
 
 msgctxt "#30066"
 msgid "Forced"
-msgstr ""
+msgstr "Erzwungen"
 
 msgctxt "#30067"
 msgid "Proxy type"
-msgstr ""
+msgstr "Proxy-Typ"
 
 msgctxt "#30068"
 msgid "SOCKS4"
-msgstr ""
+msgstr "SOCKS4"
 
 msgctxt "#30069"
 msgid "SOCKS5"
-msgstr ""
+msgstr "SOCKS5"
 
 msgctxt "#30071"
 msgid "HTTP"
-msgstr ""
+msgstr "HTTP"
 
 msgctxt "#30073"
 msgid "i2p"
-msgstr ""
+msgstr "i2p"
 
 msgctxt "#30074"
 msgid "Spoof user agent (highly inadvisable)"
-msgstr ""
+msgstr "User-Agent fälschen (dringend abgeraten)"
 
 msgctxt "#30075"
 msgid "Default advisable (acceptable)"
-msgstr ""
+msgstr "Standard empfohlen (akzeptabel)"
 
 msgctxt "#30076"
 msgid "libtorrent (Rasterbar) 1.1.0"
-msgstr ""
+msgstr "libtorrent (Rasterbar) 1.1.0"
 
 msgctxt "#30077"
 msgid "BitTorrent 7.5.0"
-msgstr ""
+msgstr "BitTorrent 7.5.0"
 
 msgctxt "#30078"
 msgid "BitTorrent 7.9.9"
-msgstr ""
+msgstr "BitTorrent 7.9.9"
 
 msgctxt "#30079"
 msgid "µTorrent 3.5.5"
-msgstr ""
+msgstr "µTorrent 3.5.5"
 
 msgctxt "#30080"
 msgid "µTorrent 3.6.0"
-msgstr ""
+msgstr "µTorrent 3.6.0"
 
 msgctxt "#30081"
 msgid "µTorrent 2.2.1"
-msgstr ""
+msgstr "µTorrent 2.2.1"
 
 msgctxt "#30082"
 msgid "Transmission 2.92"
-msgstr ""
+msgstr "Transmission 2.92"
 
 msgctxt "#30083"
 msgid "Deluge 1.3.6"
-msgstr ""
+msgstr "Deluge 1.3.6"
 
 msgctxt "#30084"
 msgid "Deluge 2.1.1"
-msgstr ""
+msgstr "Deluge 2.1.1"
 
 msgctxt "#30085"
 msgid "Vuze 5.7.3.0"
-msgstr ""
+msgstr "Vuze 5.7.3.0"
 
 msgctxt "#30086"
 msgid "Enable tuned storage settings"
-msgstr ""
+msgstr "Optimierte Speichereinstellungen aktivieren"
 
 msgctxt "#30088"
 msgid "Initial buffering timeout, seconds"
-msgstr ""
+msgstr "Zeitüberschreitung beim anfänglichen Puffern, Sekunden"
 
 msgctxt "#30090"
 msgid "Listen interfaces"
-msgstr ""
+msgstr "Eingehende Schnittstellen"
 
 msgctxt "#30091"
 msgid "Outgoing interfaces"
-msgstr ""
+msgstr "Ausgehende Schnittstellen"
 
 msgctxt "#30092"
 msgid "Use fallback fanart if fanart wasn't found"
-msgstr ""
+msgstr "Ersatz-Fanart verwenden, wenn kein Fanart gefunden wurde"
 
 msgctxt "#30093"
 msgid "Disable notification sound"
-msgstr ""
+msgstr "Benachrichtigungston deaktivieren"
 
 msgctxt "#30094"
 msgid "Disable background progress dialog"
-msgstr ""
+msgstr "Fortschrittsdialog im Hintergrund deaktivieren"
 
 # Interface
 msgctxt "#30100"
@@ -358,7 +358,7 @@ msgstr "Dieses Add-on kann nur innerhalb von Elementum verwendet werden"
 
 msgctxt "#30103"
 msgid "Unable to find Elementum binary[CR]Required platform:"
-msgstr ""
+msgstr "Elementum-Binärdatei konnte nicht gefunden werden[CR]Benötigte Plattform:"
 
 msgctxt "#30104"
 msgid "Insert file or URL"
@@ -402,63 +402,63 @@ msgstr "Download Pfad nicht angegeben, überprüfen Sie Ihre Einstellungen"
 
 msgctxt "#30116"
 msgid "Looks like Elementum is still starting up, give it a few seconds..."
-msgstr ""
+msgstr "Elementum scheint noch zu starten, gib ihm ein paar Sekunden ..."
 
 msgctxt "#30117"
 msgid "Resolving torrent files..."
-msgstr ""
+msgstr "Torrent-Dateien werden aufgelöst ..."
 
 msgctxt "#30118"
 msgid "Scraping trackers..."
-msgstr ""
+msgstr "Tracker werden abgefragt ..."
 
 msgctxt "#30119"
 msgid "ID of selected userlist for movies"
-msgstr ""
+msgstr "ID der ausgewählten Benutzerliste für Filme"
 
 msgctxt "#30120"
 msgid "ID of selected userlist for shows"
-msgstr ""
+msgstr "ID der ausgewählten Benutzerliste für Serien"
 
 msgctxt "#30141"
 msgid "Please support Elementum development by visiting[CR]https://elementum.surge.sh/donate/ or https://elementumorg.github.io/donate/"
-msgstr ""
+msgstr "Bitte unterstütze die Entwicklung von Elementum unter[CR]https://elementum.surge.sh/donate/ oder https://elementumorg.github.io/donate/"
 
 msgctxt "#30142"
 msgid "Default view for menus in Movies"
-msgstr ""
+msgstr "Standardansicht für Menüs unter Filme"
 
 msgctxt "#30143"
 msgid "Default view for menus in TV Shows"
-msgstr ""
+msgstr "Standardansicht für Menüs unter Serien"
 
 msgctxt "#30144"
 msgid "Default view for movie genres"
-msgstr ""
+msgstr "Standardansicht für Filmgenres"
 
 msgctxt "#30145"
 msgid "Default view for TV show genres"
-msgstr ""
+msgstr "Standardansicht für Seriengenres"
 
 msgctxt "#30146"
 msgid "Keep downloading '%s'?"
-msgstr ""
+msgstr "'%s' weiter herunterladen?"
 
 msgctxt "#30147"
 msgid "Caches are still warming up, give it a minute or two..."
-msgstr ""
+msgstr "Die Caches werden noch aufgebaut, gib ihnen ein bis zwei Minuten ..."
 
 msgctxt "#30148"
 msgid "Caches warmed up"
-msgstr ""
+msgstr "Caches sind bereit"
 
 msgctxt "#30149"
 msgid "Trakt username not set, check your settings"
-msgstr ""
+msgstr "Trakt-Benutzername nicht gesetzt, überprüfe deine Einstellungen"
 
 msgctxt "#30199"
 msgid "No available JSON-RPC connection to Kodi.[CR]Enable both Application control options in Service settings / Control and restart Kodi."
-msgstr ""
+msgstr "Keine JSON-RPC-Verbindung zu Kodi verfügbar.[CR]Aktiviere beide Optionen zur Anwendungssteuerung unter Diensteinstellungen / Steuerung und starte Kodi neu."
 
 # Elementum daemon
 msgctxt "#30200"
@@ -671,1636 +671,1636 @@ msgstr "Es wurde bereits ein Torrent ausgewählt. Verwenden?[CR]%s"
 
 msgctxt "#30263"
 msgid "My Lists"
-msgstr ""
+msgstr "Meine Listen"
 
 msgctxt "#30268"
 msgid "Toggle watched"
-msgstr ""
+msgstr "Gesehen-Status umschalten"
 
 msgctxt "#30269"
 msgid "Delete downloaded files '%s'?"
-msgstr ""
+msgstr "Heruntergeladene Dateien '%s' löschen?"
 
 msgctxt "#30271"
 msgid "There is now an official multi-provider for Elementum called [COLOR FFFF6B00]Burst[/COLOR], would you like to install it now?"
-msgstr ""
+msgstr "Es gibt jetzt einen offiziellen Multi-Provider für Elementum namens [COLOR FFFF6B00]Burst[/COLOR], möchtest du ihn jetzt installieren?"
 
 msgctxt "#30272"
 msgid "Installation successful, enjoy Elementum [COLOR FFFF6B00]Burst[/COLOR]!"
-msgstr ""
+msgstr "Installation erfolgreich, viel Spaß mit Elementum [COLOR FFFF6B00]Burst[/COLOR]!"
 
 msgctxt "#30273"
 msgid "Shoot... It looks like we couldn't install [COLOR FFFF6B00]Burst[/COLOR] automatically, head over to the Elementum Repository, then under the Program add-ons section to install it."
-msgstr ""
+msgstr "Mist ... [COLOR FFFF6B00]Burst[/COLOR] konnte offenbar nicht automatisch installiert werden. Gehe zum Elementum-Repository und installiere es im Bereich Programm-Add-ons."
 
 msgctxt "#30274"
 msgid "Enable all"
-msgstr ""
+msgstr "Alle aktivieren"
 
 msgctxt "#30275"
 msgid "Disable all"
-msgstr ""
+msgstr "Alle deaktivieren"
 
 msgctxt "#30276"
 msgid "Delete torrent and files"
-msgstr ""
+msgstr "Torrent und Dateien löschen"
 
 msgctxt "#30277"
 msgid "%s added to library, do you want to rescan it?[CR]You can later use Kodi's 'Update library' feature instead."
-msgstr ""
+msgstr "%s wurde zur Bibliothek hinzugefügt, möchtest du sie neu einlesen?[CR]Du kannst später auch die Kodi-Funktion 'Bibliothek aktualisieren' verwenden."
 
 msgctxt "#30278"
 msgid "%s removed from library, do you want to clean it?[CR]You can later use Kodi's 'Clean library' feature instead."
-msgstr ""
+msgstr "%s wurde aus der Bibliothek entfernt, möchtest du sie bereinigen?[CR]Du kannst später auch die Kodi-Funktion 'Bibliothek bereinigen' verwenden."
 
 msgctxt "#30279"
 msgid "Video %s was previously removed from library.[CR]Force adding?"
-msgstr ""
+msgstr "Video %s wurde zuvor aus der Bibliothek entfernt.[CR]Hinzufügen erzwingen?"
 
 msgctxt "#30282"
 msgid "Nothing left to remove from Elementum"
-msgstr ""
+msgstr "Aus Elementum ist nichts mehr zu entfernen"
 
 msgctxt "#30283"
 msgid "Merge to library"
-msgstr ""
+msgstr "In die Bibliothek zusammenführen"
 
 msgctxt "#30284"
 msgid "Show unaired seasons"
-msgstr ""
+msgstr "Nicht ausgestrahlte Staffeln anzeigen"
 
 msgctxt "#30285"
 msgid "Show unaired episodes"
-msgstr ""
+msgstr "Nicht ausgestrahlte Episoden anzeigen"
 
 msgctxt "#30286"
 msgid "%s merged to library, do you want to rescan it?[CR]You can later use Kodi's 'Update library' feature instead."
-msgstr ""
+msgstr "%s wurde in die Bibliothek zusammengeführt, möchtest du sie neu einlesen?[CR]Du kannst später auch die Kodi-Funktion 'Bibliothek aktualisieren' verwenden."
 
 msgctxt "#30287"
 msgid "%s already in library"
-msgstr ""
+msgstr "%s ist bereits in der Bibliothek"
 
 msgctxt "#30288"
 msgid "Library updated, do you want to rescan it?[CR]You can later use Kodi's 'Update library' feature instead."
-msgstr ""
+msgstr "Bibliothek aktualisiert, möchtest du sie neu einlesen?[CR]Du kannst später auch die Kodi-Funktion 'Bibliothek aktualisieren' verwenden."
 
 msgctxt "#30289"
 msgid "Genres"
-msgstr ""
+msgstr "Genres"
 
 msgctxt "#30290"
 msgid "Calendars"
-msgstr ""
+msgstr "Kalender"
 
 msgctxt "#30291"
 msgid "My Movies"
-msgstr ""
+msgstr "Meine Filme"
 
 msgctxt "#30292"
 msgid "My Releases"
-msgstr ""
+msgstr "Meine Veröffentlichungen"
 
 msgctxt "#30293"
 msgid "All Movies"
-msgstr ""
+msgstr "Alle Filme"
 
 msgctxt "#30294"
 msgid "All Releases"
-msgstr ""
+msgstr "Alle Veröffentlichungen"
 
 msgctxt "#30295"
 msgid "My Shows"
-msgstr ""
+msgstr "Meine Serien"
 
 msgctxt "#30296"
 msgid "My New Shows"
-msgstr ""
+msgstr "Meine neuen Serien"
 
 msgctxt "#30297"
 msgid "My Premieres"
-msgstr ""
+msgstr "Meine Premieren"
 
 msgctxt "#30298"
 msgid "All Shows"
-msgstr ""
+msgstr "Alle Serien"
 
 msgctxt "#30299"
 msgid "All New Shows"
-msgstr ""
+msgstr "Alle neuen Serien"
 
 msgctxt "#30300"
 msgid "All Premieres"
-msgstr ""
+msgstr "Alle Premieren"
 
 msgctxt "#30301"
 msgid "Move finished downloads to separate folders"
-msgstr ""
+msgstr "Abgeschlossene Downloads in separate Ordner verschieben"
 
 msgctxt "#30302"
 msgid "Files will only be moved after seeding is finished (see[CR]- BitTorrent settings), and will wait if currently playing"
-msgstr ""
+msgstr "Dateien werden erst nach Abschluss des Seedings verschoben (siehe[CR]- BitTorrent-Einstellungen) und warten bei laufender Wiedergabe"
 
 msgctxt "#30303"
 msgid "RAR archive detected. Download will need to be completed before playback can start and will require around twice the amount of space, continue?"
-msgstr ""
+msgstr "RAR-Archiv erkannt. Der Download muss abgeschlossen sein, bevor die Wiedergabe starten kann, und benötigt etwa doppelt so viel Speicherplatz. Fortfahren?"
 
 msgctxt "#30304"
 msgid "Error creating output pipe for 'unrar' command"
-msgstr ""
+msgstr "Fehler beim Erstellen der Ausgabe-Pipe für den Befehl 'unrar'"
 
 msgctxt "#30305"
 msgid "Error starting 'unrar' command"
-msgstr ""
+msgstr "Fehler beim Starten des Befehls 'unrar'"
 
 msgctxt "#30306"
 msgid "Error waiting for 'unrar' command"
-msgstr ""
+msgstr "Fehler beim Warten auf den Befehl 'unrar'"
 
 msgctxt "#30307"
 msgid "Error reading from destination folder"
-msgstr ""
+msgstr "Fehler beim Lesen aus dem Zielordner"
 
 msgctxt "#30308"
 msgid "Move completed"
-msgstr ""
+msgstr "Verschieben abgeschlossen"
 
 msgctxt "#30309"
 msgid "Keep"
-msgstr ""
+msgstr "Behalten"
 
 msgctxt "#30310"
 msgid "Ask to delete"
-msgstr ""
+msgstr "Vor dem Löschen fragen"
 
 msgctxt "#30311"
 msgid "Delete"
-msgstr ""
+msgstr "Löschen"
 
 msgctxt "#30312"
 msgid "Keep files for not finished video"
-msgstr ""
+msgstr "Dateien nicht abgeschlossener Videos behalten"
 
 msgctxt "#30313"
 msgid "Keep files for watched/downloaded video"
-msgstr ""
+msgstr "Dateien gesehener/heruntergeladener Videos behalten"
 
 msgctxt "#30314"
 msgid "Settings were not initialized.[CR]Save addon settings, then restart Kodi."
-msgstr ""
+msgstr "Die Einstellungen wurden nicht initialisiert.[CR]Speichere die Add-on-Einstellungen und starte Kodi neu."
 
 msgctxt "#30315"
 msgid "Download storage type"
-msgstr ""
+msgstr "Speichertyp für Downloads"
 
 msgctxt "#30316"
 msgid "Use files"
-msgstr ""
+msgstr "Dateien verwenden"
 
 msgctxt "#30317"
 msgid "Use memory"
-msgstr ""
+msgstr "Arbeitsspeicher verwenden"
 
 msgctxt "#30318"
 msgid "Memory size to use for each torrent, Mb"
-msgstr ""
+msgstr "Für jeden Torrent zu verwendender Arbeitsspeicher, MB"
 
 msgctxt "#30319"
 msgid "Continue"
-msgstr ""
+msgstr "Fortfahren"
 
 msgctxt "#30320"
 msgid "Ask to stop"
-msgstr ""
+msgstr "Vor dem Stoppen fragen"
 
 msgctxt "#30321"
 msgid "Stop"
-msgstr ""
+msgstr "Stoppen"
 
 msgctxt "#30323"
 msgid "New search"
-msgstr ""
+msgstr "Neue Suche"
 
 msgctxt "#30324"
 msgid "Force stream auto-selection from settings"
-msgstr ""
+msgstr "Automatische Stream-Auswahl aus den Einstellungen erzwingen"
 
 msgctxt "#30325"
 msgid "Download"
-msgstr ""
+msgstr "Download"
 
 msgctxt "#30326"
 msgid "Kodi library"
-msgstr ""
+msgstr "Kodi-Bibliothek"
 
 msgctxt "#30327"
 msgid "Storage"
-msgstr ""
+msgstr "Speicher"
 
 msgctxt "#30328"
 msgid "Disable TCP"
-msgstr ""
+msgstr "TCP deaktivieren"
 
 msgctxt "#30329"
 msgid "Disable UTP"
-msgstr ""
+msgstr "UTP deaktivieren"
 
 msgctxt "#30330"
 msgid "Update Trakt"
-msgstr ""
+msgstr "Trakt aktualisieren"
 
 msgctxt "#30332"
 msgid "Reloading configuration..."
-msgstr ""
+msgstr "Konfiguration wird neu geladen ..."
 
 msgctxt "#30333"
 msgid "Try to find other episodes in the torrent"
-msgstr ""
+msgstr "Versuchen, weitere Episoden im Torrent zu finden"
 
 msgctxt "#30347"
 msgid "Could not find binary for architecture '%s'![CR]Try to uninstall this addon, re-download and re-install it from the biggest zip."
-msgstr ""
+msgstr "Für die Architektur '%s' wurde keine Binärdatei gefunden![CR]Versuche, dieses Add-on zu deinstallieren, erneut herunterzuladen und aus der größten ZIP-Datei neu zu installieren."
 
 msgctxt "#30348"
 msgid "Create usual files on the file system and write to them.[CR]Needs selected file's full size to be available on the disk!"
-msgstr ""
+msgstr "Erstellt gewöhnliche Dateien im Dateisystem und schreibt in sie.[CR]Die volle Größe der ausgewählten Datei muss auf der Festplatte verfügbar sein!"
 
 msgctxt "#30349"
 msgid "Using device's memory to download parts of the torrent.[CR]Disk is used only to download and save .torrent file,"
-msgstr ""
+msgstr "Verwendet den Arbeitsspeicher des Geräts, um Teile des Torrents herunterzuladen.[CR]Die Festplatte wird nur zum Herunterladen und Speichern der .torrent-Datei verwendet,"
 
 msgctxt "#30350"
 msgid "so can be any storage. For 1gb memory devices[CR]100mb is enough for memory storage, 200-250mb for bigger devices."
-msgstr ""
+msgstr "kann also jeder Speicher sein. Für Geräte mit 1 GB Arbeitsspeicher[CR]reichen 100 MB, für größere Geräte 200-250 MB."
 
 msgctxt "#30351"
 msgid "Same as for usual file storage, but splits file into many small files.[CR]Should be used on FAT-32 file-systems."
-msgstr ""
+msgstr "Wie der gewöhnliche Dateispeicher, teilt die Datei aber in viele kleine Dateien auf.[CR]Sollte auf FAT-32-Dateisystemen verwendet werden."
 
 msgctxt "#30352"
 msgid "Same as for usual file storage, but using memory[CR]to lower filesystem operations. Experimental storage!"
-msgstr ""
+msgstr "Wie der gewöhnliche Dateispeicher, nutzt aber den Arbeitsspeicher,[CR]um Dateisystemoperationen zu reduzieren. Experimenteller Speicher!"
 
 msgctxt "#30355"
 msgid "Changelog"
-msgstr ""
+msgstr "Änderungsprotokoll"
 
 msgctxt "#30357"
 msgid "Use Trakt information in Trakt lists"
-msgstr ""
+msgstr "Trakt-Informationen in Trakt-Listen verwenden"
 
 msgctxt "#30358"
 msgid "Trakt update started"
-msgstr ""
+msgstr "Trakt-Aktualisierung gestartet"
 
 msgctxt "#30359"
 msgid "Do not ask questions before playback"
-msgstr ""
+msgstr "Vor der Wiedergabe keine Fragen stellen"
 
 msgctxt "#30360"
 msgid "My Progress"
-msgstr ""
+msgstr "Mein Fortschritt"
 
 msgctxt "#30361"
 msgid "My History"
-msgstr ""
+msgstr "Mein Verlauf"
 
 msgctxt "#30362"
 msgid "Synchronization"
-msgstr ""
+msgstr "Synchronisierung"
 
 msgctxt "#30363"
 msgid "Sync items from collections into Kodi library"
-msgstr ""
+msgstr "Einträge aus Sammlungen in die Kodi-Bibliothek synchronisieren"
 
 msgctxt "#30364"
 msgid "Sync items from watchlist into Kodi library"
-msgstr ""
+msgstr "Einträge von der Beobachtungsliste in die Kodi-Bibliothek synchronisieren"
 
 msgctxt "#30365"
 msgid "Sync items from user lists into Kodi library"
-msgstr ""
+msgstr "Einträge aus Benutzerlisten in die Kodi-Bibliothek synchronisieren"
 
 msgctxt "#30366"
 msgid "Sync watched states from Trakt into Kodi library"
-msgstr ""
+msgstr "Gesehen-Status von Trakt in die Kodi-Bibliothek synchronisieren"
 
 msgctxt "#30367"
 msgid "Sync back Kodi watched states into Trakt"
-msgstr ""
+msgstr "Gesehen-Status von Kodi zurück zu Trakt synchronisieren"
 
 msgctxt "#30369"
 msgid "Disable Upload"
-msgstr ""
+msgstr "Upload deaktivieren"
 
 msgctxt "#30370"
 msgid "Auto-assign network IP"
-msgstr ""
+msgstr "Netzwerk-IP automatisch zuweisen"
 
 msgctxt "#30371"
 msgid "Auto-assign network ports"
-msgstr ""
+msgstr "Netzwerkports automatisch zuweisen"
 
 msgctxt "#30373"
 msgid "Languages"
-msgstr ""
+msgstr "Sprachen"
 
 msgctxt "#30374"
 msgid "Countries"
-msgstr ""
+msgstr "Länder"
 
 msgctxt "#30375"
 msgid "By size"
-msgstr ""
+msgstr "Nach Größe"
 
 msgctxt "#30376"
 msgid "Choose memory size automatically"
-msgstr ""
+msgstr "Speichergröße automatisch wählen"
 
 msgctxt "#30377"
 msgid "Size is chosen automatically, based on[CR]physical amount of memory"
-msgstr ""
+msgstr "Die Größe wird automatisch anhand der[CR]physisch verfügbaren Speichermenge gewählt"
 
 msgctxt "#30378"
 msgid "Allow memory usage"
-msgstr ""
+msgstr "Speichernutzung erlauben"
 
 msgctxt "#30379"
 msgid "Minimum - 40MB, Default - 8%, Maximum - 15%"
-msgstr ""
+msgstr "Minimum - 40 MB, Standard - 8 %, Maximum - 15 %"
 
 msgctxt "#30380"
 msgid "Minimum"
-msgstr ""
+msgstr "Minimum"
 
 msgctxt "#30381"
 msgid "Default"
-msgstr ""
+msgstr "Standard"
 
 msgctxt "#30382"
 msgid "Maximum"
-msgstr ""
+msgstr "Maximum"
 
 msgctxt "#30383"
 msgid "Use Kodi language for subtitles search"
-msgstr ""
+msgstr "Kodi-Sprache für die Untertitelsuche verwenden"
 
 msgctxt "#30384"
 msgid "Language code for subtitles (example: en, it, es)"
-msgstr ""
+msgstr "Sprachcode für Untertitel (Beispiel: en, it, es)"
 
 msgctxt "#30386"
 msgid "Disable background progress dialog on playback"
-msgstr ""
+msgstr "Fortschrittsdialog im Hintergrund während der Wiedergabe deaktivieren"
 
 msgctxt "#30387"
 msgid "Caching"
-msgstr ""
+msgstr "Zwischenspeicherung"
 
 msgctxt "#30388"
 msgid "Cache stream selection"
-msgstr ""
+msgstr "Stream-Auswahl zwischenspeichern"
 
 msgctxt "#30389"
 msgid "Cache stream search results"
-msgstr ""
+msgstr "Stream-Suchergebnisse zwischenspeichern"
 
 msgctxt "#30390"
 msgid "Cache search results duration, seconds"
-msgstr ""
+msgstr "Dauer der Zwischenspeicherung von Suchergebnissen, Sekunden"
 
 msgctxt "#30393"
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 msgctxt "#30394"
 msgid "Version"
-msgstr ""
+msgstr "Version"
 
 msgctxt "#30395"
 msgid "IP address"
-msgstr ""
+msgstr "IP-Adresse"
 
 msgctxt "#30396"
 msgid "Port"
-msgstr ""
+msgstr "Port"
 
 msgctxt "#30397"
 msgid "Web UI"
-msgstr ""
+msgstr "Weboberfläche"
 
 msgctxt "#30398"
 msgid "Debug information (with kodi.log)"
-msgstr ""
+msgstr "Debug-Informationen (mit kodi.log)"
 
 msgctxt "#30399"
 msgid "Addresses"
-msgstr ""
+msgstr "Adressen"
 
 msgctxt "#30400"
 msgid "Statistics"
-msgstr ""
+msgstr "Statistiken"
 
 msgctxt "#30401"
 msgid "Torrent library status"
-msgstr ""
+msgstr "Status der Torrent-Bibliothek"
 
 msgctxt "#30402"
 msgid "Size of cache.db"
-msgstr ""
+msgstr "Größe von cache.db"
 
 msgctxt "#30403"
 msgid "Size of app.db"
-msgstr ""
+msgstr "Größe von app.db"
 
 msgctxt "#30404"
 msgid "Assigned torrent files"
-msgstr ""
+msgstr "Zugeordnete Torrent-Dateien"
 
 msgctxt "#30405"
 msgid "Search queries"
-msgstr ""
+msgstr "Suchanfragen"
 
 msgctxt "#30406"
 msgid "Remove from history"
-msgstr ""
+msgstr "Aus dem Verlauf entfernen"
 
 msgctxt "#30408"
 msgid "Addon Connectivity"
-msgstr ""
+msgstr "Add-on-Verbindung"
 
 msgctxt "#30409"
 msgid "Local port"
-msgstr ""
+msgstr "Lokaler Port"
 
 msgctxt "#30410"
 msgid "Remote port"
-msgstr ""
+msgstr "Entfernter Port"
 
 msgctxt "#30411"
 msgid "Remote host"
-msgstr ""
+msgstr "Entfernter Host"
 
 msgctxt "#30412"
 msgid "Do not start binary (client mode)"
-msgstr ""
+msgstr "Binärdatei nicht starten (Client-Modus)"
 
 msgctxt "#30413"
 msgid "Yes"
-msgstr ""
+msgstr "Ja"
 
 msgctxt "#30414"
 msgid "No"
-msgstr ""
+msgstr "Nein"
 
 msgctxt "#30415"
 msgid "Next page (%s)"
-msgstr ""
+msgstr "Nächste Seite (%s)"
 
 msgctxt "#30416"
 msgid "Percents of playback to mark as watched"
-msgstr ""
+msgstr "Prozent der Wiedergabe, um als gesehen zu markieren"
 
 msgctxt "#30417"
 msgid "Use name of production company as Studio for shows"
-msgstr ""
+msgstr "Namen der Produktionsfirma als Studio für Serien verwenden"
 
 msgctxt "#30418"
 msgid "Calculate number of unwatched episodes in Shows/Seasons"
-msgstr ""
+msgstr "Anzahl ungesehener Episoden in Serien/Staffeln berechnen"
 
 msgctxt "#30421"
 msgid "Load torrents from torrents folder on startup"
-msgstr ""
+msgstr "Torrents beim Start aus dem Torrents-Ordner laden"
 
 msgctxt "#30422"
 msgid "Popular lists"
-msgstr ""
+msgstr "Beliebte Listen"
 
 msgctxt "#30423"
 msgid "Recommendations"
-msgstr ""
+msgstr "Empfehlungen"
 
 msgctxt "#30424"
 msgid "Progress"
-msgstr ""
+msgstr "Fortschritt"
 
 msgctxt "#30425"
 msgid "Color of an air date"
-msgstr ""
+msgstr "Farbe des Ausstrahlungsdatums"
 
 msgctxt "#30426"
 msgid "Color of a show name"
-msgstr ""
+msgstr "Farbe des Seriennamens"
 
 msgctxt "#30427"
 msgid "Color of an episode name"
-msgstr ""
+msgstr "Farbe des Episodennamens"
 
 msgctxt "#30428"
 msgid "Hide unaired episodes"
-msgstr ""
+msgstr "Nicht ausgestrahlte Episoden ausblenden"
 
 msgctxt "#30429"
 msgid "Sort shows in the list"
-msgstr ""
+msgstr "Serien in der Liste sortieren"
 
 msgctxt "#30430"
 msgid "By latest watched"
-msgstr ""
+msgstr "Nach zuletzt gesehen"
 
 msgctxt "#30431"
 msgid "By show name"
-msgstr ""
+msgstr "Nach Serienname"
 
 msgctxt "#30432"
 msgid "By air date (newer)"
-msgstr ""
+msgstr "Nach Ausstrahlungsdatum (neuer)"
 
 msgctxt "#30433"
 msgid "By air date (older)"
-msgstr ""
+msgstr "Nach Ausstrahlungsdatum (älter)"
 
 msgctxt "#30434"
 msgid "Date format"
-msgstr ""
+msgstr "Datumsformat"
 
 msgctxt "#30436"
 msgid "Userlist"
-msgstr ""
+msgstr "Benutzerliste"
 
 msgctxt "#30438"
 msgid "Userlists"
-msgstr ""
+msgstr "Benutzerlisten"
 
 msgctxt "#30439"
 msgid "Debug information (without kodi.log)"
-msgstr ""
+msgstr "Debug-Informationen (ohne kodi.log)"
 
 msgctxt "#30440"
 msgid "Color of an unaired episode name"
-msgstr ""
+msgstr "Farbe des Namens einer nicht ausgestrahlten Episode"
 
 msgctxt "#30441"
 msgid "Select userlist for movies"
-msgstr ""
+msgstr "Benutzerliste für Filme auswählen"
 
 msgctxt "#30442"
 msgid "Userlist for movies"
-msgstr ""
+msgstr "Benutzerliste für Filme"
 
 msgctxt "#30443"
 msgid "Selected userlist for movies"
-msgstr ""
+msgstr "Ausgewählte Benutzerliste für Filme"
 
 msgctxt "#30444"
 msgid "Select userlist for shows"
-msgstr ""
+msgstr "Benutzerliste für Serien auswählen"
 
 msgctxt "#30445"
 msgid "Userlist for shows"
-msgstr ""
+msgstr "Benutzerliste für Serien"
 
 msgctxt "#30446"
 msgid "Selected userlist for shows"
-msgstr ""
+msgstr "Ausgewählte Benutzerliste für Serien"
 
 msgctxt "#30447"
 msgid "Add to Trakt, when movie is added to Kodi library"
-msgstr ""
+msgstr "Zu Trakt hinzufügen, wenn ein Film zur Kodi-Bibliothek hinzugefügt wird"
 
 msgctxt "#30448"
 msgid "Add to Trakt, when show is added to Kodi library"
-msgstr ""
+msgstr "Zu Trakt hinzufügen, wenn eine Serie zur Kodi-Bibliothek hinzugefügt wird"
 
 msgctxt "#30449"
 msgid "Remove from Trakt, when movie is deleted from Kodi library"
-msgstr ""
+msgstr "Aus Trakt entfernen, wenn ein Film aus der Kodi-Bibliothek gelöscht wird"
 
 msgctxt "#30450"
 msgid "Remove from Trakt, when show is deleted from Kodi library"
-msgstr ""
+msgstr "Aus Trakt entfernen, wenn eine Serie aus der Kodi-Bibliothek gelöscht wird"
 
 msgctxt "#30451"
 msgid "Torrent files path"
-msgstr ""
+msgstr "Pfad für Torrent-Dateien"
 
 msgctxt "#30452"
 msgid "Reset all paths"
-msgstr ""
+msgstr "Alle Pfade zurücksetzen"
 
 msgctxt "#30453"
 msgid "Upload /debug/bundle (with kodi.log) to pastebin"
-msgstr ""
+msgstr "/debug/bundle (mit kodi.log) zu pastebin hochladen"
 
 msgctxt "#30454"
 msgid "Paste url:[CR]%s"
-msgstr ""
+msgstr "Paste-URL:[CR]%s"
 
 msgctxt "#30455"
 msgid "Logging"
-msgstr ""
+msgstr "Protokollierung"
 
 msgctxt "#30456"
 msgid "Upload /debug/all (no kodi.log) to pastebin"
-msgstr ""
+msgstr "/debug/all (ohne kodi.log) zu pastebin hochladen"
 
 msgctxt "#30457"
 msgid "Uploading file to pastebin"
-msgstr ""
+msgstr "Datei wird zu pastebin hochgeladen"
 
 msgctxt "#30458"
 msgid "Deleted movies"
-msgstr ""
+msgstr "Gelöschte Filme"
 
 msgctxt "#30459"
 msgid "Deleted shows"
-msgstr ""
+msgstr "Gelöschte Serien"
 
 msgctxt "#30460"
 msgid "Database"
-msgstr ""
+msgstr "Datenbank"
 
 msgctxt "#30461"
 msgid "Show information"
-msgstr ""
+msgstr "Informationen anzeigen"
 
 msgctxt "#30462"
 msgid "Clear deleted movies"
-msgstr ""
+msgstr "Gelöschte Filme bereinigen"
 
 msgctxt "#30463"
 msgid "Clear deleted shows"
-msgstr ""
+msgstr "Gelöschte Serien bereinigen"
 
 msgctxt "#30464"
 msgid "Clear torrents history"
-msgstr ""
+msgstr "Torrent-Verlauf löschen"
 
 msgctxt "#30465"
 msgid "Clear search history"
-msgstr ""
+msgstr "Suchverlauf löschen"
 
 msgctxt "#30466"
 msgid "Clear the database"
-msgstr ""
+msgstr "Datenbank löschen"
 
 msgctxt "#30467"
 msgid "Cache"
-msgstr ""
+msgstr "Cache"
 
 msgctxt "#30468"
 msgid "Clear TMDB cache"
-msgstr ""
+msgstr "TMDB-Cache leeren"
 
 msgctxt "#30469"
 msgid "Clear Trakt cache"
-msgstr ""
+msgstr "Trakt-Cache leeren"
 
 msgctxt "#30470"
 msgid "Clear the cache"
-msgstr ""
+msgstr "Cache leeren"
 
 msgctxt "#30471"
 msgid "Are you sure you want to do it?"
-msgstr ""
+msgstr "Möchtest du das wirklich tun?"
 
 msgctxt "#30472"
 msgid "Database cleared"
-msgstr ""
+msgstr "Datenbank geleert"
 
 msgctxt "#30473"
 msgid "Select network interface"
-msgstr ""
+msgstr "Netzwerkschnittstelle auswählen"
 
 msgctxt "#30474"
 msgid "Network interfaces"
-msgstr ""
+msgstr "Netzwerkschnittstellen"
 
 msgctxt "#30475"
 msgid "Strm files language"
-msgstr ""
+msgstr "Sprache der Strm-Dateien"
 
 msgctxt "#30476"
 msgid "Select language"
-msgstr ""
+msgstr "Sprache auswählen"
 
 msgctxt "#30477"
 msgid "Original language"
-msgstr ""
+msgstr "Originalsprache"
 
 msgctxt "#30478"
 msgid "Searching"
-msgstr ""
+msgstr "Suche läuft"
 
 msgctxt "#30480"
 msgid "Run Kodi library update after add/delete"
-msgstr ""
+msgstr "Kodi-Bibliotheksaktualisierung nach Hinzufügen/Löschen ausführen"
 
 msgctxt "#30481"
 msgid "Automatically"
-msgstr ""
+msgstr "Automatisch"
 
 msgctxt "#30482"
 msgid "Ask"
-msgstr ""
+msgstr "Fragen"
 
 msgctxt "#30483"
 msgid "Create NFO files for Movie scrapers"
-msgstr ""
+msgstr "NFO-Dateien für Film-Scraper erstellen"
 
 msgctxt "#30484"
 msgid "Create NFO files for TV Show scrapers"
-msgstr ""
+msgstr "NFO-Dateien für Serien-Scraper erstellen"
 
 msgctxt "#30485"
 msgid "Concurrent connections limit per second"
-msgstr ""
+msgstr "Grenze gleichzeitiger Verbindungen pro Sekunde"
 
 msgctxt "#30486"
 msgid "Automatic concurrent connections limit per second"
-msgstr ""
+msgstr "Automatische Grenze gleichzeitiger Verbindungen pro Sekunde"
 
 msgctxt "#30487"
 msgid "Enable built-in HTTP proxy"
-msgstr ""
+msgstr "Integrierten HTTP-Proxy aktivieren"
 
 msgctxt "#30488"
 msgid "Internal Proxy Port"
-msgstr ""
+msgstr "Port des internen Proxys"
 
 msgctxt "#30489"
 msgid "Log Internal proxy requests"
-msgstr ""
+msgstr "Anfragen des internen Proxys protokollieren"
 
 msgctxt "#30490"
 msgid "Internal HTTP proxy"
-msgstr ""
+msgstr "Interner HTTP-Proxy"
 
 msgctxt "#30491"
 msgid "Use Fanart.tv for posters/images"
-msgstr ""
+msgstr "Fanart.tv für Poster/Bilder verwenden"
 
 msgctxt "#30492"
 msgid "Use Proxy for downloading .torrent files"
-msgstr ""
+msgstr "Proxy zum Herunterladen von .torrent-Dateien verwenden"
 
 msgctxt "#30493"
 msgid "Use Proxy for trackers"
-msgstr ""
+msgstr "Proxy für Tracker verwenden"
 
 msgctxt "#30494"
 msgid "Use Proxy for torrent downloading"
-msgstr ""
+msgstr "Proxy für Torrent-Downloads verwenden"
 
 msgctxt "#30495"
 msgid "Use built-in DNS resolver"
-msgstr ""
+msgstr "Integrierten DNS-Resolver verwenden"
 
 msgctxt "#30496"
 msgid "Turn off if you use Tor addresses, or you want [CR]to use DNS settings from OS"
-msgstr ""
+msgstr "Ausschalten, wenn du Tor-Adressen verwendest oder [CR]die DNS-Einstellungen des Betriebssystems nutzen möchtest"
 
 msgctxt "#30497"
 msgid "Use Antizapret proxy (only for Russia)"
-msgstr ""
+msgstr "Antizapret-Proxy verwenden (nur für Russland)"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"
-msgstr ""
+msgstr "Diesen Pfad auf '/' zurücksetzen"
 
 msgctxt "#30499"
 msgid "Automatically adjust memory size[CR]for heavy torrents, if possible"
-msgstr ""
+msgstr "Speichergröße für große Torrents nach Möglichkeit[CR]automatisch anpassen"
 
 msgctxt "#30500"
 msgid "Automatically adjust buffer size[CR]for heavy torrents"
-msgstr ""
+msgstr "Puffergröße für große Torrents[CR]automatisch anpassen"
 
 msgctxt "#30502"
 msgid "Adjust buffer according to Kodi advancedsettings.xml, if set"
-msgstr ""
+msgstr "Puffer gemäß Kodi advancedsettings.xml anpassen, falls gesetzt"
 
 msgctxt "#30503"
 msgid "Use libtorrent.config to override torrent engine settings"
-msgstr ""
+msgstr "libtorrent.config verwenden, um Einstellungen der Torrent-Engine zu überschreiben"
 
 msgctxt "#30504"
 msgid "Located at USERDATA/plugin.video.elementum/libtorrent.config file[CR]Settings apply automatically. Visit https://libtorrent.org for info."
-msgstr ""
+msgstr "Zu finden unter USERDATA/plugin.video.elementum/libtorrent.config[CR]Die Einstellungen werden automatisch übernommen. Infos unter https://libtorrent.org ."
 
 msgctxt "#30505"
 msgid "Add episode number to the title"
-msgstr ""
+msgstr "Episodennummer zum Titel hinzufügen"
 
 msgctxt "#30506"
 msgid "Enable libtorrent logging"
-msgstr ""
+msgstr "libtorrent-Protokollierung aktivieren"
 
 msgctxt "#30511"
 msgid "Libtorrent settings profile"
-msgstr ""
+msgstr "libtorrent-Einstellungsprofil"
 
 msgctxt "#30512"
 msgid "Default"
-msgstr ""
+msgstr "Standard"
 
 msgctxt "#30513"
 msgid "Minimal memory"
-msgstr ""
+msgstr "Minimaler Speicher"
 
 msgctxt "#30514"
 msgid "High speed"
-msgstr ""
+msgstr "Hohe Geschwindigkeit"
 
 msgctxt "#30515"
 msgid "Load torrents from torrents folder paused"
-msgstr ""
+msgstr "Torrents pausiert aus dem Torrents-Ordner laden"
 
 msgctxt "#30516"
 msgid "... resume N seconds earlier"
-msgstr ""
+msgstr "... N Sekunden früher fortsetzen"
 
 msgctxt "#30517"
 msgid "In Kodi library"
-msgstr ""
+msgstr "In der Kodi-Bibliothek"
 
 msgctxt "#30518"
 msgid "Use libtorrent deadlines"
-msgstr ""
+msgstr "libtorrent-Deadlines verwenden"
 
 msgctxt "#30519"
 msgid "Use libtorrent pause/resume trick for added torrents"
-msgstr ""
+msgstr "libtorrent-Pause/Fortsetzen-Trick für hinzugefügte Torrents verwenden"
 
 msgctxt "#30520"
 msgid "Add item to start menu"
-msgstr ""
+msgstr "Eintrag zum Startmenü hinzufügen"
 
 msgctxt "#30521"
 msgid "Delete item from start menu"
-msgstr ""
+msgstr "Eintrag aus dem Startmenü entfernen"
 
 msgctxt "#30522"
 msgid "Minimum file size"
-msgstr ""
+msgstr "Minimale Dateigröße"
 
 msgctxt "#30523"
 msgid "Minimum file size for Movies, MB"
-msgstr ""
+msgstr "Minimale Dateigröße für Filme, MB"
 
 msgctxt "#30524"
 msgid "Minimum file size for Shows, MB per minute"
-msgstr ""
+msgstr "Minimale Dateigröße für Serien, MB pro Minute"
 
 msgctxt "#30525"
 msgid "Automatically start downloading next episode"
-msgstr ""
+msgstr "Nächste Episode automatisch herunterladen"
 
 msgctxt "#30527"
 msgid "Donate"
-msgstr ""
+msgstr "Spenden"
 
 msgctxt "#30528"
 msgid "Automatically load first found subtitles"
-msgstr ""
+msgstr "Erste gefundene Untertitel automatisch laden"
 
 msgctxt "#30529"
 msgid "Number of subtitles to load automatically"
-msgstr ""
+msgstr "Anzahl automatisch zu ladender Untertitel"
 
 msgctxt "#30530"
 msgid "Delete autoloaded subtitles on player stop"
-msgstr ""
+msgstr "Automatisch geladene Untertitel beim Stoppen des Players löschen"
 
 msgctxt "#30531"
 msgid "Download all files from torrent"
-msgstr ""
+msgstr "Alle Dateien aus dem Torrent herunterladen"
 
 msgctxt "#30532"
 msgid "Stop Downloading all files"
-msgstr ""
+msgstr "Download aller Dateien stoppen"
 
 msgctxt "#30535"
 msgid "Continue playback from [B]%s[/B]?"
-msgstr ""
+msgstr "Wiedergabe ab [B]%s[/B] fortsetzen?"
 
 msgctxt "#30536"
 msgid "Skip IPv6 addresses resolving"
-msgstr ""
+msgstr "Auflösung von IPv6-Adressen überspringen"
 
 msgctxt "#30537"
 msgid "Torrents history"
-msgstr ""
+msgstr "Torrent-Verlauf"
 
 msgctxt "#30538"
 msgid "Use torrents history?"
-msgstr ""
+msgstr "Torrent-Verlauf verwenden?"
 
 msgctxt "#30539"
 msgid "Store N torrents in history"
-msgstr ""
+msgstr "N Torrents im Verlauf speichern"
 
 msgctxt "#30540"
 msgid "Subtitles"
-msgstr ""
+msgstr "Untertitel"
 
 msgctxt "#30541"
 msgid "Automatic Subtitles Search"
-msgstr ""
+msgstr "Automatische Untertitelsuche"
 
 msgctxt "#30542"
 msgid "Disable if subtitles are available in player"
-msgstr ""
+msgstr "Deaktivieren, wenn Untertitel im Player verfügbar sind"
 
 msgctxt "#30543"
 msgid "Subtitles included in torrent"
-msgstr ""
+msgstr "Im Torrent enthaltene Untertitel"
 
 msgctxt "#30544"
 msgid "Automatic Scrape"
-msgstr ""
+msgstr "Automatisches Scraping"
 
 msgctxt "#30545"
 msgid "Automatic scraping allows to scrape connected providers[CR]to find new movies, if there are results,"
-msgstr ""
+msgstr "Automatisches Scraping durchsucht verbundene Provider[CR]nach neuen Filmen. Wenn es Ergebnisse gibt"
 
 msgctxt "#30546"
 msgid "Strategy"
-msgstr ""
+msgstr "Strategie"
 
 msgctxt "#30547"
 msgid "Find in each provider"
-msgstr ""
+msgstr "In jedem Provider suchen"
 
 msgctxt "#30548"
 msgid "Find in overall"
-msgstr ""
+msgstr "Insgesamt suchen"
 
 msgctxt "#30549"
 msgid "Search is successful when found N results"
-msgstr ""
+msgstr "Suche ist erfolgreich, wenn N Ergebnisse gefunden wurden"
 
 msgctxt "#30550"
 msgid "What to search"
-msgstr ""
+msgstr "Wonach gesucht wird"
 
 msgctxt "#30551"
 msgid "How to search"
-msgstr ""
+msgstr "Wie gesucht wird"
 
 msgctxt "#30552"
 msgid "Search each N hours"
-msgstr ""
+msgstr "Alle N Stunden suchen"
 
 msgctxt "#30553"
 msgid "Find 4K resolution"
-msgstr ""
+msgstr "4K-Auflösung finden"
 
 msgctxt "#30554"
 msgid "Find 1080p resolution"
-msgstr ""
+msgstr "1080p-Auflösung finden"
 
 msgctxt "#30555"
 msgid "and movie passes checks for number of results[CR]movie can be added to the library."
-msgstr ""
+msgstr "und der Film die Prüfung der Ergebnisanzahl besteht,[CR]kann er zur Bibliothek hinzugefügt werden."
 
 msgctxt "#30556"
 msgid "Add to the library"
-msgstr ""
+msgstr "Zur Bibliothek hinzufügen"
 
 msgctxt "#30557"
 msgid "Number of popular movies to search"
-msgstr ""
+msgstr "Anzahl der zu durchsuchenden beliebten Filme"
 
 msgctxt "#30558"
 msgid "Latest available movies"
-msgstr ""
+msgstr "Neueste verfügbare Filme"
 
 msgctxt "#30559"
 msgid "Skip searching for installed providers"
-msgstr ""
+msgstr "Suche nach installierten Providern überspringen"
 
 msgctxt "#30560"
 msgid "Files: %s"
-msgstr ""
+msgstr "Dateien: %s"
 
 msgctxt "#30561"
 msgid "Interval between requests, seconds"
-msgstr ""
+msgstr "Intervall zwischen Anfragen, Sekunden"
 
 msgctxt "#30562"
 msgid "Open directory with Kodi file browser"
-msgstr ""
+msgstr "Verzeichnis im Kodi-Dateibrowser öffnen"
 
 msgctxt "#30563"
 msgid "Synchronize frequency of Trakt, minutes"
-msgstr ""
+msgstr "Häufigkeit der Trakt-Synchronisierung, Minuten"
 
 msgctxt "#30564"
 msgid "Sync hidden items"
-msgstr ""
+msgstr "Ausgeblendete Einträge synchronisieren"
 
 msgctxt "#30565"
 msgid "Sync playback progress into Kodi library"
-msgstr ""
+msgstr "Wiedergabefortschritt in die Kodi-Bibliothek synchronisieren"
 
 msgctxt "#30566"
 msgid "Lists"
-msgstr ""
+msgstr "Listen"
 
 msgctxt "#30567"
 msgid "Show \"All seasons\" in shows"
-msgstr ""
+msgstr "\"Alle Staffeln\" in Serien anzeigen"
 
 msgctxt "#30568"
 msgid "Seasons order"
-msgstr ""
+msgstr "Reihenfolge der Staffeln"
 
 msgctxt "#30569"
 msgid "Ascending"
-msgstr ""
+msgstr "Aufsteigend"
 
 msgctxt "#30570"
 msgid "Descending"
-msgstr ""
+msgstr "Absteigend"
 
 msgctxt "#30571"
 msgid "* All seasons"
-msgstr ""
+msgstr "* Alle Staffeln"
 
 msgctxt "#30572"
 msgid "Log server's response body"
-msgstr ""
+msgstr "Antwortinhalt des Servers protokollieren"
 
 msgctxt "#30573"
 msgid "Select file to play"
-msgstr ""
+msgstr "Datei zum Abspielen auswählen"
 
 msgctxt "#30574"
 msgid "Automatically answer Yes after timeout"
-msgstr ""
+msgstr "Nach Zeitüberschreitung automatisch mit Ja antworten"
 
 msgctxt "#30575"
 msgid "Timeout, seconds"
-msgstr ""
+msgstr "Zeitüberschreitung, Sekunden"
 
 msgctxt "#30576"
 msgid "Trakt authentication needs to be updated!"
-msgstr ""
+msgstr "Die Trakt-Authentifizierung muss aktualisiert werden!"
 
 msgctxt "#30577"
 msgid "End of file Buffer size, MB"
-msgstr ""
+msgstr "Puffergröße am Dateiende, MB"
 
 msgctxt "#30578"
 msgid "Beginning of file Buffer size, MB"
-msgstr ""
+msgstr "Puffergröße am Dateianfang, MB"
 
 msgctxt "#30579"
 msgid "Settings"
-msgstr ""
+msgstr "Einstellungen"
 
 msgctxt "#30580"
 msgid "Custom Trakt API Client ID"
-msgstr ""
+msgstr "Eigene Client-ID für die Trakt-API"
 
 msgctxt "#30581"
 msgid "Custom Trakt API Client Secret"
-msgstr ""
+msgstr "Eigenes Client-Secret für die Trakt-API"
 
 msgctxt "#30582"
 msgid "Settings for %s provider"
-msgstr ""
+msgstr "Einstellungen für den Provider %s"
 
 msgctxt "#30583"
 msgid "Resolving magnet link"
-msgstr ""
+msgstr "Magnet-Link wird aufgelöst"
 
 msgctxt "#30585"
 msgid "Enable library integration with Kodi"
-msgstr ""
+msgstr "Bibliotheksintegration mit Kodi aktivieren"
 
 msgctxt "#30586"
 msgid "If disabled - Elementum will not get/insert items to Kodi library [CR]and skip watched management with Kodi."
-msgstr ""
+msgstr "Wenn deaktiviert, liest und schreibt Elementum keine Einträge in der Kodi-Bibliothek [CR]und überspringt die Verwaltung des Gesehen-Status mit Kodi."
 
 msgctxt "#30587"
 msgid "Show welcome message on start"
-msgstr ""
+msgstr "Willkommensnachricht beim Start anzeigen"
 
 msgctxt "#30588"
 msgid "Pre-Play Buffering"
-msgstr ""
+msgstr "Puffern vor der Wiedergabe"
 
 msgctxt "#30589"
 msgid "Speed limiting"
-msgstr ""
+msgstr "Geschwindigkeitsbegrenzung"
 
 msgctxt "#30590"
 msgid "Torrents autoload on addon startup"
-msgstr ""
+msgstr "Torrents beim Start des Add-ons automatisch laden"
 
 msgctxt "#30591"
 msgid "Limits for connections"
-msgstr ""
+msgstr "Grenzen für Verbindungen"
 
 msgctxt "#30592"
 msgid "Seeding"
-msgstr ""
+msgstr "Seeding"
 
 msgctxt "#30593"
 msgid "Seed forever"
-msgstr ""
+msgstr "Dauerhaft seeden"
 
 msgctxt "#30594"
 msgid "Network"
-msgstr ""
+msgstr "Netzwerk"
 
 msgctxt "#30595"
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Verschiedenes"
 
 msgctxt "#30597"
 msgid "Cache size, MB"
-msgstr ""
+msgstr "Cache-Größe, MB"
 
 msgctxt "#30598"
 msgid "Enable caching if using File storage and have speed problems.[CR]Will use more memory, but can improve the speed."
-msgstr ""
+msgstr "Aktiviere die Zwischenspeicherung, wenn du Dateispeicher verwendest und Geschwindigkeitsprobleme hast.[CR]Sie benötigt mehr Arbeitsspeicher, kann aber die Geschwindigkeit verbessern."
 
 msgctxt "#30599"
 msgid "Enable Kodi library synchronization"
-msgstr ""
+msgstr "Kodi-Bibliothekssynchronisierung aktivieren"
 
 msgctxt "#30600"
 msgid "Enable Trakt synchronization"
-msgstr ""
+msgstr "Trakt-Synchronisierung aktivieren"
 
 msgctxt "#30601"
 msgid "Enable synchronization while playback"
-msgstr ""
+msgstr "Synchronisierung während der Wiedergabe aktivieren"
 
 msgctxt "#30602"
 msgid "Retry requests to addon after timeout, seconds"
-msgstr ""
+msgstr "Anfragen an das Add-on nach Zeitüberschreitung wiederholen, Sekunden"
 
 msgctxt "#30603"
 msgid "Addon Startup"
-msgstr ""
+msgstr "Start des Add-ons"
 
 msgctxt "#30604"
 msgid "Clean all history"
-msgstr ""
+msgstr "Gesamten Verlauf bereinigen"
 
 msgctxt "#30605"
 msgid "Cache downloaded torrent files after search"
-msgstr ""
+msgstr "Heruntergeladene Torrent-Dateien nach der Suche zwischenspeichern"
 
 msgctxt "#30606"
 msgid "Show watched state for torrent's files"
-msgstr ""
+msgstr "Gesehen-Status für die Dateien des Torrents anzeigen"
 
 msgctxt "#30607"
 msgid "Use earliest release date as basic for searching"
-msgstr ""
+msgstr "Frühestes Veröffentlichungsdatum als Grundlage für die Suche verwenden"
 
 msgctxt "#30608"
 msgid "Match found in your active torrents, play it?[CR]%s"
-msgstr ""
+msgstr "Treffer in deinen aktiven Torrents gefunden, abspielen?[CR]%s"
 
 msgctxt "#30609"
 msgid "Automatically start next episode if available"
-msgstr ""
+msgstr "Nächste Episode automatisch starten, falls verfügbar"
 
 msgctxt "#30610"
 msgid "Magnet resolve timeout, seconds"
-msgstr ""
+msgstr "Zeitüberschreitung bei der Magnet-Auflösung, Sekunden"
 
 msgctxt "#30611"
 msgid "Application platform type"
-msgstr ""
+msgstr "Plattformtyp der Anwendung"
 
 msgctxt "#30612"
 msgid "Select file to download"
-msgstr ""
+msgstr "Datei zum Herunterladen auswählen"
 
 msgctxt "#30613"
 msgid "... for movie"
-msgstr ""
+msgstr "... für Film"
 
 msgctxt "#30614"
 msgid "... for tv show"
-msgstr ""
+msgstr "... für Serie"
 
 msgctxt "#30615"
 msgid "... for search"
-msgstr ""
+msgstr "... für Suche"
 
 msgctxt "#30616"
 msgid "Elementum | Trakt Account"
-msgstr ""
+msgstr "Elementum | Trakt-Konto"
 
 msgctxt "#30617"
 msgid "Your account is locked for API on Trakt.tv[CR]Please, contact Trakt Support at https://support.trakt.tv ."
-msgstr ""
+msgstr "Dein Konto ist für die API auf Trakt.tv gesperrt[CR]Bitte wende dich an den Trakt-Support unter https://support.trakt.tv ."
 
 msgctxt "#30618"
 msgid "%s is downloaded"
-msgstr ""
+msgstr "%s wurde heruntergeladen"
 
 msgctxt "#30619"
 msgid "Return to [B]%s[/B]"
-msgstr ""
+msgstr "Zurück zu [B]%s[/B]"
 
 msgctxt "#30620"
 msgid "Restart Elementum addon"
-msgstr ""
+msgstr "Elementum-Add-on neu starten"
 
 msgctxt "#30621"
 msgid "Queued"
-msgstr ""
+msgstr "In Warteschlange"
 
 msgctxt "#30622"
 msgid "Checking"
-msgstr ""
+msgstr "Wird geprüft"
 
 msgctxt "#30623"
 msgid "Finding"
-msgstr ""
+msgstr "Wird gesucht"
 
 msgctxt "#30624"
 msgid "Downloading"
-msgstr ""
+msgstr "Wird heruntergeladen"
 
 msgctxt "#30625"
 msgid "Finished"
-msgstr ""
+msgstr "Abgeschlossen"
 
 msgctxt "#30626"
 msgid "Seeding"
-msgstr ""
+msgstr "Seeding"
 
 msgctxt "#30627"
 msgid "Allocating"
-msgstr ""
+msgstr "Wird zugewiesen"
 
 msgctxt "#30628"
 msgid "Stalled"
-msgstr ""
+msgstr "Stockt"
 
 msgctxt "#30629"
 msgid "Paused"
-msgstr ""
+msgstr "Pausiert"
 
 msgctxt "#30630"
 msgid "Buffering"
-msgstr ""
+msgstr "Puffert"
 
 msgctxt "#30631"
 msgid "Playing"
-msgstr ""
+msgstr "Wird abgespielt"
 
 msgctxt "#30632"
 msgid "Yes (%s seconds)"
-msgstr ""
+msgstr "Ja (%s Sekunden)"
 
 msgctxt "#30633"
 msgid "No (%s seconds)"
-msgstr ""
+msgstr "Nein (%s Sekunden)"
 
 msgctxt "#30634"
 msgid "Log level"
-msgstr ""
+msgstr "Protokollstufe"
 
 msgctxt "#30635"
 msgid "None"
-msgstr ""
+msgstr "Keine"
 
 msgctxt "#30636"
 msgid "Error"
-msgstr ""
+msgstr "Fehler"
 
 msgctxt "#30637"
 msgid "Info"
-msgstr ""
+msgstr "Info"
 
 msgctxt "#30638"
 msgid "Debug"
-msgstr ""
+msgstr "Debug"
 
 msgctxt "#30639"
 msgid "Show Specials in season listings"
-msgstr ""
+msgstr "Specials in Staffelübersichten anzeigen"
 
 msgctxt "#30640"
 msgid "Bitrate"
-msgstr ""
+msgstr "Bitrate"
 
 msgctxt "#30641"
 msgid "Playback"
-msgstr ""
+msgstr "Wiedergabe"
 
 msgctxt "#30642"
 msgid "Force Resume options"
-msgstr ""
+msgstr "Optionen zum Fortsetzen erzwingen"
 
 msgctxt "#30643"
 msgid "by Kodi"
-msgstr ""
+msgstr "durch Kodi"
 
 msgctxt "#30644"
 msgid "by Elementum - Ask"
-msgstr ""
+msgstr "durch Elementum - Fragen"
 
 msgctxt "#30645"
 msgid "by Elementum - Force"
-msgstr ""
+msgstr "durch Elementum - Erzwingen"
 
 msgctxt "#30646"
 msgid "Authorize Elementum on Trakt.tv"
-msgstr ""
+msgstr "Elementum bei Trakt.tv autorisieren"
 
 msgctxt "#30647"
 msgid "Cancel Authorization for Elementum on Trakt.tv"
-msgstr ""
+msgstr "Autorisierung von Elementum bei Trakt.tv aufheben"
 
 msgctxt "#30648"
 msgid "Authorization"
-msgstr ""
+msgstr "Autorisierung"
 
 msgctxt "#30649"
 msgid "To authorize addon for Trakt.tv you need to:[CR]1. Open [B]%s[/B][CR]2. Enter code: [B]%s[/B][CR]3. Wait for notification from Elementum."
-msgstr ""
+msgstr "Um das Add-on für Trakt.tv zu autorisieren, musst du:[CR]1. [B]%s[/B] öffnen[CR]2. Diesen Code eingeben: [B]%s[/B][CR]3. Auf die Benachrichtigung von Elementum warten."
 
 msgctxt "#30650"
 msgid "Successfully authorized for Trakt.tv"
-msgstr ""
+msgstr "Autorisierung bei Trakt.tv erfolgreich"
 
 msgctxt "#30651"
 msgid "Could not authorize for Trakt.tv"
-msgstr ""
+msgstr "Autorisierung bei Trakt.tv fehlgeschlagen"
 
 msgctxt "#30652"
 msgid "Successfully deauthorized for Trakt.tv"
-msgstr ""
+msgstr "Autorisierung bei Trakt.tv erfolgreich aufgehoben"
 
 msgctxt "#30653"
 msgid "Which files to download"
-msgstr ""
+msgstr "Welche Dateien heruntergeladen werden"
 
 msgctxt "#30654"
 msgid "Only playback file"
-msgstr ""
+msgstr "Nur die Wiedergabedatei"
 
 msgctxt "#30655"
 msgid "Season files"
-msgstr ""
+msgstr "Dateien der Staffel"
 
 msgctxt "#30656"
 msgid "All files"
-msgstr ""
+msgstr "Alle Dateien"
 
 msgctxt "#30657"
 msgid "Disable LSD"
-msgstr ""
+msgstr "LSD deaktivieren"
 
 msgctxt "#30658"
 msgid "Add extra trackers"
-msgstr ""
+msgstr "Zusätzliche Tracker hinzufügen"
 
 msgctxt "#30659"
 msgid "All known trackers"
-msgstr ""
+msgstr "Alle bekannten Tracker"
 
 msgctxt "#30660"
 msgid "Best trackers"
-msgstr ""
+msgstr "Beste Tracker"
 
 msgctxt "#30661"
 msgid "Minimum set"
-msgstr ""
+msgstr "Minimaler Satz"
 
 msgctxt "#30662"
 msgid "Remove original trackers from torrent"
-msgstr ""
+msgstr "Ursprüngliche Tracker aus dem Torrent entfernen"
 
 msgctxt "#30663"
 msgid "Show episodes on release day (w/o delay)"
-msgstr ""
+msgstr "Episoden am Erscheinungstag anzeigen (ohne Verzögerung)"
 
 msgctxt "#30664"
 msgid "Modify trackers in torrent"
-msgstr ""
+msgstr "Tracker im Torrent ändern"
 
 msgctxt "#30665"
 msgid "At the time of adding"
-msgstr ""
+msgstr "Beim Hinzufügen"
 
 msgctxt "#30666"
 msgid "Every time"
-msgstr ""
+msgstr "Jedes Mal"
 
 msgctxt "#30667"
 msgid "Mark as watched in Trakt"
-msgstr ""
+msgstr "In Trakt als gesehen markieren"
 
 msgctxt "#30668"
 msgid "Mark as unwatched in Trakt"
-msgstr ""
+msgstr "In Trakt als ungesehen markieren"
 
 msgctxt "#30669"
 msgid "Delay addon startup, seconds"
-msgstr ""
+msgstr "Start des Add-ons verzögern, Sekunden"
 
 msgctxt "#30670"
 msgid "Downloading required binary file for '%s'"
-msgstr ""
+msgstr "Benötigte Binärdatei für '%s' wird heruntergeladen"
 
 msgctxt "#30671"
 msgid "List of Opennic DNS IPs"
-msgstr ""
+msgstr "Liste der OpenNIC-DNS-IPs"
 
 msgctxt "#30672"
 msgid "Compact database"
-msgstr ""
+msgstr "Datenbank komprimieren"
 
 msgctxt "#30673"
 msgid "Compact cache database"
-msgstr ""
+msgstr "Cache-Datenbank komprimieren"
 
 msgctxt "#30674"
 msgid "Database was compacted"
-msgstr ""
+msgstr "Die Datenbank wurde komprimiert"
 
 msgctxt "#30675"
 msgid "Remote host login"
-msgstr ""
+msgstr "Benutzername des entfernten Hosts"
 
 msgctxt "#30676"
 msgid "Remote host password"
-msgstr ""
+msgstr "Passwort des entfernten Hosts"
 
 msgctxt "#30677"
 msgid "Force start as a library"
-msgstr ""
+msgstr "Start als Bibliothek erzwingen"
 
 msgctxt "#30678"
 msgid "Remove from Kodi library, when movie is deleted from Trakt"
-msgstr ""
+msgstr "Aus der Kodi-Bibliothek entfernen, wenn der Film aus Trakt gelöscht wird"
 
 msgctxt "#30679"
 msgid "Remove from Kodi library, when show is deleted from Trakt"
-msgstr ""
+msgstr "Aus der Kodi-Bibliothek entfernen, wenn die Serie aus Trakt gelöscht wird"
 
 msgctxt "#30680"
 msgid "Remove Elementum duplicates from library"
-msgstr ""
+msgstr "Elementum-Duplikate aus der Bibliothek entfernen"
 
 msgctxt "#30681"
 msgid "[B]Found duplicates in Kodi library:[/B][CR]Movies: [B]%s[/B], Shows: [B]%s[/B], Episodes: [B]%s[/B][CR]Proceed?"
-msgstr ""
+msgstr "[B]Duplikate in der Kodi-Bibliothek gefunden:[/B][CR]Filme: [B]%s[/B], Serien: [B]%s[/B], Episoden: [B]%s[/B][CR]Fortfahren?"
 
 msgctxt "#30682"
 msgid "No duplicates were found in Kodi library"
-msgstr ""
+msgstr "Es wurden keine Duplikate in der Kodi-Bibliothek gefunden"
 
 msgctxt "#30683"
 msgid "Starting library duplicates removal"
-msgstr ""
+msgstr "Entfernen der Duplikate aus der Bibliothek wird gestartet"
 
 msgctxt "#30684"
 msgid "Removed Movies: %s, Shows: %s, Episodes: %s"
-msgstr ""
+msgstr "Entfernt - Filme: %s, Serien: %s, Episoden: %s"
 
 msgctxt "#30685"
 msgid "Remove movies from Elementum database"
-msgstr ""
+msgstr "Filme aus der Elementum-Datenbank entfernen"
 
 msgctxt "#30686"
 msgid "Remove shows from Elementum database"
-msgstr ""
+msgstr "Serien aus der Elementum-Datenbank entfernen"
 
 msgctxt "#30687"
 msgid "In Elementum library"
-msgstr ""
+msgstr "In der Elementum-Bibliothek"
 
 msgctxt "#30688"
 msgid "Skip searching for installed Elementum repository"
-msgstr ""
+msgstr "Suche nach installiertem Elementum-Repository überspringen"
 
 msgctxt "#30689"
 msgid "Internal DNS client"
-msgstr ""
+msgstr "Interner DNS-Client"
 
 msgctxt "#30691"
 msgid "Hide watched"
-msgstr ""
+msgstr "Gesehene ausblenden"
 
 msgctxt "#30692"
 msgid "TMDB images quality (affects Kodi performance)"
-msgstr ""
+msgstr "Qualität der TMDB-Bilder (beeinflusst die Leistung von Kodi)"
 
 msgctxt "#30693"
 msgid "Original"
-msgstr ""
+msgstr "Original"
 
 msgctxt "#30694"
 msgid "High"
-msgstr ""
+msgstr "Hoch"
 
 msgctxt "#30695"
 msgid "Medium"
-msgstr ""
+msgstr "Mittel"
 
 msgctxt "#30696"
 msgid "Low"
-msgstr ""
+msgstr "Niedrig"
 
 msgctxt "#30697"
 msgid "Interface language"
-msgstr ""
+msgstr "Sprache der Oberfläche"
 
 msgctxt "#30698"
 msgid "Kodi language"
-msgstr ""
+msgstr "Sprache von Kodi"
 
 msgctxt "#30699"
 msgid "Use earliest release date for progress and calendars"
-msgstr ""
+msgstr "Frühestes Veröffentlichungsdatum für Fortschritt und Kalender verwenden"
 
 msgctxt "#30700"
 msgid "Interface fallback language"
-msgstr ""
+msgstr "Ausweichsprache der Oberfläche"
 
 msgctxt "#30701"
 msgid "English | en"
-msgstr ""
+msgstr "Englisch | en"
 
 msgctxt "#30702"
 msgid "Reached daily limit for subtitles downloads"
-msgstr ""
+msgstr "Tageslimit für Untertitel-Downloads erreicht"
 
 msgctxt "#30703"
 msgid "Can be used by search providers or [CR]for debugging"
-msgstr ""
+msgstr "Kann von Suchanbietern oder [CR]zur Fehlersuche verwendet werden"
 
 msgctxt "#30704"
 msgid "TMDB API Key check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Prüfung des TMDB-API-Schlüssels fehlgeschlagen, der TMDB-Dienst kann nicht verwendet werden"
 
 msgctxt "#30705"
 msgid "TMDB API accessibility check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Prüfung der Erreichbarkeit der TMDB-API fehlgeschlagen, der TMDB-Dienst kann nicht verwendet werden"
 
 msgctxt "#30706"
 msgid "Transmission 4.05"
-msgstr ""
+msgstr "Transmission 4.05"
 
 msgctxt "#30707"
 msgid "qBittorrent 3.3.9"
-msgstr ""
+msgstr "qBittorrent 3.3.9"
 
 msgctxt "#30708"
 msgid "qBittorrent 4.6.4"
-msgstr ""
+msgstr "qBittorrent 4.6.4"
 
 msgctxt "#30709"
 msgid "Open [B]%s[/B]"
-msgstr ""
+msgstr "[B]%s[/B] öffnen"
 
 msgctxt "#30710"
 msgid "BitTorrent ports"
-msgstr ""
+msgstr "BitTorrent-Ports"
 
 msgctxt "#30711"
 msgid "Delete torrent '%s'?"
-msgstr ""
+msgstr "Torrent '%s' löschen?"
 
 msgctxt "#30712"
 msgid "Force to always use proxy, can break download in some cases"
-msgstr ""
+msgstr "Immer die Verwendung des Proxys erzwingen, kann den Download in manchen Fällen unterbrechen"
 
 msgctxt "#30713"
 msgid "Disable NATPMP"
-msgstr ""
+msgstr "NATPMP deaktivieren"
 
 msgctxt "#30714"
 msgid "Re-check torrent's data"
-msgstr ""
+msgstr "Daten des Torrents erneut prüfen"
 
 msgctxt "#30715"
 msgid "Antizapret PAC file URL"
-msgstr ""
+msgstr "URL der Antizapret-PAC-Datei"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "DNS-over-HTTPS-Server"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "Eigener DNS-over-HTTPS-Server"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "OpenNIC-DNS-Server verwenden"

--- a/resources/language/Greek/strings.po
+++ b/resources/language/Greek/strings.po
@@ -256,19 +256,19 @@ msgstr "Τύπος proxy"
 
 msgctxt "#30068"
 msgid "SOCKS4"
-msgstr ""
+msgstr "SOCKS4"
 
 msgctxt "#30069"
 msgid "SOCKS5"
-msgstr ""
+msgstr "SOCKS5"
 
 msgctxt "#30071"
 msgid "HTTP"
-msgstr ""
+msgstr "HTTP"
 
 msgctxt "#30073"
 msgid "i2p"
-msgstr ""
+msgstr "i2p"
 
 msgctxt "#30074"
 msgid "Spoof user agent (highly inadvisable)"
@@ -280,43 +280,43 @@ msgstr "Προεπιλογή (προτεινεται)"
 
 msgctxt "#30076"
 msgid "libtorrent (Rasterbar) 1.1.0"
-msgstr ""
+msgstr "libtorrent (Rasterbar) 1.1.0"
 
 msgctxt "#30077"
 msgid "BitTorrent 7.5.0"
-msgstr ""
+msgstr "BitTorrent 7.5.0"
 
 msgctxt "#30078"
 msgid "BitTorrent 7.9.9"
-msgstr ""
+msgstr "BitTorrent 7.9.9"
 
 msgctxt "#30079"
 msgid "µTorrent 3.5.5"
-msgstr ""
+msgstr "µTorrent 3.5.5"
 
 msgctxt "#30080"
 msgid "µTorrent 3.6.0"
-msgstr ""
+msgstr "µTorrent 3.6.0"
 
 msgctxt "#30081"
 msgid "µTorrent 2.2.1"
-msgstr ""
+msgstr "µTorrent 2.2.1"
 
 msgctxt "#30082"
 msgid "Transmission 2.92"
-msgstr ""
+msgstr "Transmission 2.92"
 
 msgctxt "#30083"
 msgid "Deluge 1.3.6"
-msgstr ""
+msgstr "Deluge 1.3.6"
 
 msgctxt "#30084"
 msgid "Deluge 2.1.1"
-msgstr ""
+msgstr "Deluge 2.1.1"
 
 msgctxt "#30085"
 msgid "Vuze 5.7.3.0"
-msgstr ""
+msgstr "Vuze 5.7.3.0"
 
 msgctxt "#30086"
 msgid "Enable tuned storage settings"
@@ -328,11 +328,11 @@ msgstr "Αρχικός χρόνος στην ενδιάμεση μνήμη (δε
 
 msgctxt "#30090"
 msgid "Listen interfaces"
-msgstr ""
+msgstr "Διεπαφές ακρόασης"
 
 msgctxt "#30091"
 msgid "Outgoing interfaces"
-msgstr ""
+msgstr "Εξερχόμενες διεπαφές"
 
 msgctxt "#30092"
 msgid "Use fallback fanart if fanart wasn't found"
@@ -413,11 +413,11 @@ msgstr "Αναζήτηση στους trackers..."
 
 msgctxt "#30119"
 msgid "ID of selected userlist for movies"
-msgstr ""
+msgstr "Αναγνωριστικό της επιλεγμένης λίστας χρήστη για ταινίες"
 
 msgctxt "#30120"
 msgid "ID of selected userlist for shows"
-msgstr ""
+msgstr "Αναγνωριστικό της επιλεγμένης λίστας χρήστη για σειρές"
 
 msgctxt "#30141"
 msgid "Please support Elementum development by visiting[CR]https://elementum.surge.sh/donate/ or https://elementumorg.github.io/donate/"
@@ -714,7 +714,7 @@ msgstr "To %s αφαιρέθηκα απο τη συλλογή. Θέλετε να
 
 msgctxt "#30279"
 msgid "Video %s was previously removed from library.[CR]Force adding?"
-msgstr ""
+msgstr "Το βίντεο %s είχε αφαιρεθεί προηγουμένως από τη βιβλιοθήκη.[CR]Να επιβληθεί η προσθήκη;"
 
 msgctxt "#30282"
 msgid "Nothing left to remove from Elementum"
@@ -806,7 +806,7 @@ msgstr "Εντοπίστηκε αρχείο RAR. Θα χρειαστεί να ο
 
 msgctxt "#30304"
 msgid "Error creating output pipe for 'unrar' command"
-msgstr ""
+msgstr "Σφάλμα κατά τη δημιουργία της διοχέτευσης εξόδου για την εντολή 'unrar'"
 
 msgctxt "#30305"
 msgid "Error starting 'unrar' command"
@@ -1086,7 +1086,7 @@ msgstr "Θυρα"
 
 msgctxt "#30397"
 msgid "Web UI"
-msgstr ""
+msgstr "Διαδικτυακή διεπαφή"
 
 msgctxt "#30398"
 msgid "Debug information (with kodi.log)"
@@ -1162,11 +1162,11 @@ msgstr "Ποσοστό της αναπαραγωγής για επισήμανσ
 
 msgctxt "#30417"
 msgid "Use name of production company as Studio for shows"
-msgstr ""
+msgstr "Χρήση του ονόματος της εταιρείας παραγωγής ως στούντιο για τις σειρές"
 
 msgctxt "#30418"
 msgid "Calculate number of unwatched episodes in Shows/Seasons"
-msgstr ""
+msgstr "Υπολογισμός του αριθμού των μη παρακολουθημένων επεισοδίων σε σειρές/κύκλους"
 
 msgctxt "#30421"
 msgid "Load torrents from torrents folder on startup"
@@ -1463,823 +1463,823 @@ msgstr "Απενεργοποιήστε το αυτο αν χρησιμοποιε
 
 msgctxt "#30497"
 msgid "Use Antizapret proxy (only for Russia)"
-msgstr ""
+msgstr "Χρήση διαμεσολαβητή Antizapret (μόνο για τη Ρωσία)"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"
-msgstr ""
+msgstr "Επαναφορά αυτής της διαδρομής σε '/'"
 
 msgctxt "#30499"
 msgid "Automatically adjust memory size[CR]for heavy torrents, if possible"
-msgstr ""
+msgstr "Αυτόματη προσαρμογή του μεγέθους μνήμης[CR]για βαριά torrent, αν είναι δυνατόν"
 
 msgctxt "#30500"
 msgid "Automatically adjust buffer size[CR]for heavy torrents"
-msgstr ""
+msgstr "Αυτόματη προσαρμογή του μεγέθους της ενδιάμεσης μνήμης[CR]για βαριά torrent"
 
 msgctxt "#30502"
 msgid "Adjust buffer according to Kodi advancedsettings.xml, if set"
-msgstr ""
+msgstr "Προσαρμογή της ενδιάμεσης μνήμης σύμφωνα με το advancedsettings.xml του Kodi, αν έχει οριστεί"
 
 msgctxt "#30503"
 msgid "Use libtorrent.config to override torrent engine settings"
-msgstr ""
+msgstr "Χρήση του libtorrent.config για την παράκαμψη των ρυθμίσεων της μηχανής torrent"
 
 msgctxt "#30504"
 msgid "Located at USERDATA/plugin.video.elementum/libtorrent.config file[CR]Settings apply automatically. Visit https://libtorrent.org for info."
-msgstr ""
+msgstr "Βρίσκεται στο αρχείο USERDATA/plugin.video.elementum/libtorrent.config[CR]Οι ρυθμίσεις εφαρμόζονται αυτόματα. Επισκεφθείτε το https://libtorrent.org για πληροφορίες."
 
 msgctxt "#30505"
 msgid "Add episode number to the title"
-msgstr ""
+msgstr "Προσθήκη του αριθμού επεισοδίου στον τίτλο"
 
 msgctxt "#30506"
 msgid "Enable libtorrent logging"
-msgstr ""
+msgstr "Ενεργοποίηση της καταγραφής του libtorrent"
 
 msgctxt "#30511"
 msgid "Libtorrent settings profile"
-msgstr ""
+msgstr "Προφίλ ρυθμίσεων libtorrent"
 
 msgctxt "#30512"
 msgid "Default"
-msgstr ""
+msgstr "Προεπιλογή"
 
 msgctxt "#30513"
 msgid "Minimal memory"
-msgstr ""
+msgstr "Ελάχιστη μνήμη"
 
 msgctxt "#30514"
 msgid "High speed"
-msgstr ""
+msgstr "Υψηλή ταχύτητα"
 
 msgctxt "#30515"
 msgid "Load torrents from torrents folder paused"
-msgstr ""
+msgstr "Φόρτωση των torrent από τον φάκελο torrent σε παύση"
 
 msgctxt "#30516"
 msgid "... resume N seconds earlier"
-msgstr ""
+msgstr "... συνέχιση N δευτερόλεπτα νωρίτερα"
 
 msgctxt "#30517"
 msgid "In Kodi library"
-msgstr ""
+msgstr "Στη βιβλιοθήκη του Kodi"
 
 msgctxt "#30518"
 msgid "Use libtorrent deadlines"
-msgstr ""
+msgstr "Χρήση των προθεσμιών του libtorrent"
 
 msgctxt "#30519"
 msgid "Use libtorrent pause/resume trick for added torrents"
-msgstr ""
+msgstr "Χρήση του τεχνάσματος παύσης/συνέχισης του libtorrent για τα torrent που προστίθενται"
 
 msgctxt "#30520"
 msgid "Add item to start menu"
-msgstr ""
+msgstr "Προσθήκη στοιχείου στο μενού έναρξης"
 
 msgctxt "#30521"
 msgid "Delete item from start menu"
-msgstr ""
+msgstr "Διαγραφή στοιχείου από το μενού έναρξης"
 
 msgctxt "#30522"
 msgid "Minimum file size"
-msgstr ""
+msgstr "Ελάχιστο μέγεθος αρχείου"
 
 msgctxt "#30523"
 msgid "Minimum file size for Movies, MB"
-msgstr ""
+msgstr "Ελάχιστο μέγεθος αρχείου για ταινίες, MB"
 
 msgctxt "#30524"
 msgid "Minimum file size for Shows, MB per minute"
-msgstr ""
+msgstr "Ελάχιστο μέγεθος αρχείου για σειρές, MB ανά λεπτό"
 
 msgctxt "#30525"
 msgid "Automatically start downloading next episode"
-msgstr ""
+msgstr "Αυτόματη έναρξη λήψης του επόμενου επεισοδίου"
 
 msgctxt "#30527"
 msgid "Donate"
-msgstr ""
+msgstr "Δωρεά"
 
 msgctxt "#30528"
 msgid "Automatically load first found subtitles"
-msgstr ""
+msgstr "Αυτόματη φόρτωση των πρώτων υποτίτλων που βρέθηκαν"
 
 msgctxt "#30529"
 msgid "Number of subtitles to load automatically"
-msgstr ""
+msgstr "Αριθμός υποτίτλων για αυτόματη φόρτωση"
 
 msgctxt "#30530"
 msgid "Delete autoloaded subtitles on player stop"
-msgstr ""
+msgstr "Διαγραφή των αυτόματα φορτωμένων υποτίτλων κατά τη διακοπή της αναπαραγωγής"
 
 msgctxt "#30531"
 msgid "Download all files from torrent"
-msgstr ""
+msgstr "Λήψη όλων των αρχείων από το torrent"
 
 msgctxt "#30532"
 msgid "Stop Downloading all files"
-msgstr ""
+msgstr "Διακοπή της λήψης όλων των αρχείων"
 
 msgctxt "#30535"
 msgid "Continue playback from [B]%s[/B]?"
-msgstr ""
+msgstr "Συνέχιση της αναπαραγωγής από [B]%s[/B];"
 
 msgctxt "#30536"
 msgid "Skip IPv6 addresses resolving"
-msgstr ""
+msgstr "Παράλειψη της επίλυσης διευθύνσεων IPv6"
 
 msgctxt "#30537"
 msgid "Torrents history"
-msgstr ""
+msgstr "Ιστορικό torrent"
 
 msgctxt "#30538"
 msgid "Use torrents history?"
-msgstr ""
+msgstr "Χρήση του ιστορικού torrent;"
 
 msgctxt "#30539"
 msgid "Store N torrents in history"
-msgstr ""
+msgstr "Αποθήκευση N torrent στο ιστορικό"
 
 msgctxt "#30540"
 msgid "Subtitles"
-msgstr ""
+msgstr "Υπότιτλοι"
 
 msgctxt "#30541"
 msgid "Automatic Subtitles Search"
-msgstr ""
+msgstr "Αυτόματη αναζήτηση υποτίτλων"
 
 msgctxt "#30542"
 msgid "Disable if subtitles are available in player"
-msgstr ""
+msgstr "Απενεργοποίηση αν οι υπότιτλοι είναι διαθέσιμοι στο πρόγραμμα αναπαραγωγής"
 
 msgctxt "#30543"
 msgid "Subtitles included in torrent"
-msgstr ""
+msgstr "Υπότιτλοι που περιλαμβάνονται στο torrent"
 
 msgctxt "#30544"
 msgid "Automatic Scrape"
-msgstr ""
+msgstr "Αυτόματη συλλογή"
 
 msgctxt "#30545"
 msgid "Automatic scraping allows to scrape connected providers[CR]to find new movies, if there are results,"
-msgstr ""
+msgstr "Η αυτόματη συλλογή επιτρέπει την αναζήτηση στους συνδεδεμένους παρόχους[CR]για νέες ταινίες. Αν υπάρχουν αποτελέσματα"
 
 msgctxt "#30546"
 msgid "Strategy"
-msgstr ""
+msgstr "Στρατηγική"
 
 msgctxt "#30547"
 msgid "Find in each provider"
-msgstr ""
+msgstr "Αναζήτηση σε κάθε πάροχο"
 
 msgctxt "#30548"
 msgid "Find in overall"
-msgstr ""
+msgstr "Αναζήτηση στο σύνολο"
 
 msgctxt "#30549"
 msgid "Search is successful when found N results"
-msgstr ""
+msgstr "Η αναζήτηση είναι επιτυχής όταν βρεθούν N αποτελέσματα"
 
 msgctxt "#30550"
 msgid "What to search"
-msgstr ""
+msgstr "Τι αναζητείται"
 
 msgctxt "#30551"
 msgid "How to search"
-msgstr ""
+msgstr "Πώς γίνεται η αναζήτηση"
 
 msgctxt "#30552"
 msgid "Search each N hours"
-msgstr ""
+msgstr "Αναζήτηση κάθε N ώρες"
 
 msgctxt "#30553"
 msgid "Find 4K resolution"
-msgstr ""
+msgstr "Εύρεση ανάλυσης 4K"
 
 msgctxt "#30554"
 msgid "Find 1080p resolution"
-msgstr ""
+msgstr "Εύρεση ανάλυσης 1080p"
 
 msgctxt "#30555"
 msgid "and movie passes checks for number of results[CR]movie can be added to the library."
-msgstr ""
+msgstr "και η ταινία περνά τους ελέγχους για τον αριθμό των αποτελεσμάτων,[CR]μπορεί να προστεθεί στη βιβλιοθήκη."
 
 msgctxt "#30556"
 msgid "Add to the library"
-msgstr ""
+msgstr "Προσθήκη στη βιβλιοθήκη"
 
 msgctxt "#30557"
 msgid "Number of popular movies to search"
-msgstr ""
+msgstr "Αριθμός δημοφιλών ταινιών προς αναζήτηση"
 
 msgctxt "#30558"
 msgid "Latest available movies"
-msgstr ""
+msgstr "Πιο πρόσφατες διαθέσιμες ταινίες"
 
 msgctxt "#30559"
 msgid "Skip searching for installed providers"
-msgstr ""
+msgstr "Παράλειψη της αναζήτησης εγκατεστημένων παρόχων"
 
 msgctxt "#30560"
 msgid "Files: %s"
-msgstr ""
+msgstr "Αρχεία: %s"
 
 msgctxt "#30561"
 msgid "Interval between requests, seconds"
-msgstr ""
+msgstr "Διάστημα μεταξύ των αιτημάτων, δευτερόλεπτα"
 
 msgctxt "#30562"
 msgid "Open directory with Kodi file browser"
-msgstr ""
+msgstr "Άνοιγμα του καταλόγου με τον περιηγητή αρχείων του Kodi"
 
 msgctxt "#30563"
 msgid "Synchronize frequency of Trakt, minutes"
-msgstr ""
+msgstr "Συχνότητα συγχρονισμού με το Trakt, λεπτά"
 
 msgctxt "#30564"
 msgid "Sync hidden items"
-msgstr ""
+msgstr "Συγχρονισμός των κρυφών στοιχείων"
 
 msgctxt "#30565"
 msgid "Sync playback progress into Kodi library"
-msgstr ""
+msgstr "Συγχρονισμός της προόδου αναπαραγωγής στη βιβλιοθήκη του Kodi"
 
 msgctxt "#30566"
 msgid "Lists"
-msgstr ""
+msgstr "Λίστες"
 
 msgctxt "#30567"
 msgid "Show \"All seasons\" in shows"
-msgstr ""
+msgstr "Εμφάνιση του \"Όλοι οι κύκλοι\" στις σειρές"
 
 msgctxt "#30568"
 msgid "Seasons order"
-msgstr ""
+msgstr "Σειρά των κύκλων"
 
 msgctxt "#30569"
 msgid "Ascending"
-msgstr ""
+msgstr "Αύξουσα"
 
 msgctxt "#30570"
 msgid "Descending"
-msgstr ""
+msgstr "Φθίνουσα"
 
 msgctxt "#30571"
 msgid "* All seasons"
-msgstr ""
+msgstr "* Όλοι οι κύκλοι"
 
 msgctxt "#30572"
 msgid "Log server's response body"
-msgstr ""
+msgstr "Καταγραφή του σώματος της απάντησης του διακομιστή"
 
 msgctxt "#30573"
 msgid "Select file to play"
-msgstr ""
+msgstr "Επιλογή αρχείου για αναπαραγωγή"
 
 msgctxt "#30574"
 msgid "Automatically answer Yes after timeout"
-msgstr ""
+msgstr "Αυτόματη απάντηση Ναι μετά τη λήξη του χρόνου"
 
 msgctxt "#30575"
 msgid "Timeout, seconds"
-msgstr ""
+msgstr "Χρονικό όριο, δευτερόλεπτα"
 
 msgctxt "#30576"
 msgid "Trakt authentication needs to be updated!"
-msgstr ""
+msgstr "Η ταυτοποίηση του Trakt πρέπει να ενημερωθεί!"
 
 msgctxt "#30577"
 msgid "End of file Buffer size, MB"
-msgstr ""
+msgstr "Μέγεθος ενδιάμεσης μνήμης στο τέλος του αρχείου, MB"
 
 msgctxt "#30578"
 msgid "Beginning of file Buffer size, MB"
-msgstr ""
+msgstr "Μέγεθος ενδιάμεσης μνήμης στην αρχή του αρχείου, MB"
 
 msgctxt "#30579"
 msgid "Settings"
-msgstr ""
+msgstr "Ρυθμίσεις"
 
 msgctxt "#30580"
 msgid "Custom Trakt API Client ID"
-msgstr ""
+msgstr "Προσαρμοσμένο Client ID για το API του Trakt"
 
 msgctxt "#30581"
 msgid "Custom Trakt API Client Secret"
-msgstr ""
+msgstr "Προσαρμοσμένο Client Secret για το API του Trakt"
 
 msgctxt "#30582"
 msgid "Settings for %s provider"
-msgstr ""
+msgstr "Ρυθμίσεις για τον πάροχο %s"
 
 msgctxt "#30583"
 msgid "Resolving magnet link"
-msgstr ""
+msgstr "Επίλυση του συνδέσμου magnet"
 
 msgctxt "#30585"
 msgid "Enable library integration with Kodi"
-msgstr ""
+msgstr "Ενεργοποίηση της ενσωμάτωσης με τη βιβλιοθήκη του Kodi"
 
 msgctxt "#30586"
 msgid "If disabled - Elementum will not get/insert items to Kodi library [CR]and skip watched management with Kodi."
-msgstr ""
+msgstr "Αν απενεργοποιηθεί, το Elementum δεν θα διαβάζει ούτε θα εισάγει στοιχεία στη βιβλιοθήκη του Kodi [CR]και θα παραλείπει τη διαχείριση της κατάστασης παρακολούθησης με το Kodi."
 
 msgctxt "#30587"
 msgid "Show welcome message on start"
-msgstr ""
+msgstr "Εμφάνιση του μηνύματος καλωσορίσματος κατά την έναρξη"
 
 msgctxt "#30588"
 msgid "Pre-Play Buffering"
-msgstr ""
+msgstr "Προφόρτωση πριν από την αναπαραγωγή"
 
 msgctxt "#30589"
 msgid "Speed limiting"
-msgstr ""
+msgstr "Περιορισμός ταχύτητας"
 
 msgctxt "#30590"
 msgid "Torrents autoload on addon startup"
-msgstr ""
+msgstr "Αυτόματη φόρτωση των torrent κατά την έναρξη του πρόσθετου"
 
 msgctxt "#30591"
 msgid "Limits for connections"
-msgstr ""
+msgstr "Όρια για τις συνδέσεις"
 
 msgctxt "#30592"
 msgid "Seeding"
-msgstr ""
+msgstr "Διαμοιρασμός"
 
 msgctxt "#30593"
 msgid "Seed forever"
-msgstr ""
+msgstr "Διαμοιρασμός για πάντα"
 
 msgctxt "#30594"
 msgid "Network"
-msgstr ""
+msgstr "Δίκτυο"
 
 msgctxt "#30595"
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Διάφορα"
 
 msgctxt "#30597"
 msgid "Cache size, MB"
-msgstr ""
+msgstr "Μέγεθος της προσωρινής μνήμης, MB"
 
 msgctxt "#30598"
 msgid "Enable caching if using File storage and have speed problems.[CR]Will use more memory, but can improve the speed."
-msgstr ""
+msgstr "Ενεργοποιήστε την προσωρινή μνήμη αν χρησιμοποιείτε αποθήκευση σε αρχεία και έχετε προβλήματα ταχύτητας.[CR]Θα χρησιμοποιήσει περισσότερη μνήμη, αλλά μπορεί να βελτιώσει την ταχύτητα."
 
 msgctxt "#30599"
 msgid "Enable Kodi library synchronization"
-msgstr ""
+msgstr "Ενεργοποίηση του συγχρονισμού με τη βιβλιοθήκη του Kodi"
 
 msgctxt "#30600"
 msgid "Enable Trakt synchronization"
-msgstr ""
+msgstr "Ενεργοποίηση του συγχρονισμού με το Trakt"
 
 msgctxt "#30601"
 msgid "Enable synchronization while playback"
-msgstr ""
+msgstr "Ενεργοποίηση του συγχρονισμού κατά την αναπαραγωγή"
 
 msgctxt "#30602"
 msgid "Retry requests to addon after timeout, seconds"
-msgstr ""
+msgstr "Επανάληψη των αιτημάτων προς το πρόσθετο μετά τη λήξη του χρόνου, δευτερόλεπτα"
 
 msgctxt "#30603"
 msgid "Addon Startup"
-msgstr ""
+msgstr "Έναρξη του πρόσθετου"
 
 msgctxt "#30604"
 msgid "Clean all history"
-msgstr ""
+msgstr "Εκκαθάριση όλου του ιστορικού"
 
 msgctxt "#30605"
 msgid "Cache downloaded torrent files after search"
-msgstr ""
+msgstr "Αποθήκευση των ληφθέντων αρχείων torrent στην προσωρινή μνήμη μετά την αναζήτηση"
 
 msgctxt "#30606"
 msgid "Show watched state for torrent's files"
-msgstr ""
+msgstr "Εμφάνιση της κατάστασης παρακολούθησης για τα αρχεία του torrent"
 
 msgctxt "#30607"
 msgid "Use earliest release date as basic for searching"
-msgstr ""
+msgstr "Χρήση της παλαιότερης ημερομηνίας κυκλοφορίας ως βάση για την αναζήτηση"
 
 msgctxt "#30608"
 msgid "Match found in your active torrents, play it?[CR]%s"
-msgstr ""
+msgstr "Βρέθηκε αντιστοιχία στα ενεργά σας torrent, να αναπαραχθεί;[CR]%s"
 
 msgctxt "#30609"
 msgid "Automatically start next episode if available"
-msgstr ""
+msgstr "Αυτόματη έναρξη του επόμενου επεισοδίου, αν είναι διαθέσιμο"
 
 msgctxt "#30610"
 msgid "Magnet resolve timeout, seconds"
-msgstr ""
+msgstr "Χρονικό όριο επίλυσης magnet, δευτερόλεπτα"
 
 msgctxt "#30611"
 msgid "Application platform type"
-msgstr ""
+msgstr "Τύπος πλατφόρμας της εφαρμογής"
 
 msgctxt "#30612"
 msgid "Select file to download"
-msgstr ""
+msgstr "Επιλογή αρχείου για λήψη"
 
 msgctxt "#30613"
 msgid "... for movie"
-msgstr ""
+msgstr "... για ταινία"
 
 msgctxt "#30614"
 msgid "... for tv show"
-msgstr ""
+msgstr "... για σειρά"
 
 msgctxt "#30615"
 msgid "... for search"
-msgstr ""
+msgstr "... για αναζήτηση"
 
 msgctxt "#30616"
 msgid "Elementum | Trakt Account"
-msgstr ""
+msgstr "Elementum | Λογαριασμός Trakt"
 
 msgctxt "#30617"
 msgid "Your account is locked for API on Trakt.tv[CR]Please, contact Trakt Support at https://support.trakt.tv ."
-msgstr ""
+msgstr "Ο λογαριασμός σας είναι κλειδωμένος για το API στο Trakt.tv[CR]Παρακαλούμε επικοινωνήστε με την υποστήριξη του Trakt στο https://support.trakt.tv ."
 
 msgctxt "#30618"
 msgid "%s is downloaded"
-msgstr ""
+msgstr "Το %s έχει ληφθεί"
 
 msgctxt "#30619"
 msgid "Return to [B]%s[/B]"
-msgstr ""
+msgstr "Επιστροφή στο [B]%s[/B]"
 
 msgctxt "#30620"
 msgid "Restart Elementum addon"
-msgstr ""
+msgstr "Επανεκκίνηση του πρόσθετου Elementum"
 
 msgctxt "#30621"
 msgid "Queued"
-msgstr ""
+msgstr "Σε αναμονή"
 
 msgctxt "#30622"
 msgid "Checking"
-msgstr ""
+msgstr "Έλεγχος"
 
 msgctxt "#30623"
 msgid "Finding"
-msgstr ""
+msgstr "Αναζήτηση"
 
 msgctxt "#30624"
 msgid "Downloading"
-msgstr ""
+msgstr "Λήψη"
 
 msgctxt "#30625"
 msgid "Finished"
-msgstr ""
+msgstr "Ολοκληρώθηκε"
 
 msgctxt "#30626"
 msgid "Seeding"
-msgstr ""
+msgstr "Διαμοιρασμός"
 
 msgctxt "#30627"
 msgid "Allocating"
-msgstr ""
+msgstr "Δέσμευση χώρου"
 
 msgctxt "#30628"
 msgid "Stalled"
-msgstr ""
+msgstr "Σε στασιμότητα"
 
 msgctxt "#30629"
 msgid "Paused"
-msgstr ""
+msgstr "Σε παύση"
 
 msgctxt "#30630"
 msgid "Buffering"
-msgstr ""
+msgstr "Προφόρτωση"
 
 msgctxt "#30631"
 msgid "Playing"
-msgstr ""
+msgstr "Αναπαραγωγή"
 
 msgctxt "#30632"
 msgid "Yes (%s seconds)"
-msgstr ""
+msgstr "Ναι (%s δευτερόλεπτα)"
 
 msgctxt "#30633"
 msgid "No (%s seconds)"
-msgstr ""
+msgstr "Όχι (%s δευτερόλεπτα)"
 
 msgctxt "#30634"
 msgid "Log level"
-msgstr ""
+msgstr "Επίπεδο καταγραφής"
 
 msgctxt "#30635"
 msgid "None"
-msgstr ""
+msgstr "Κανένα"
 
 msgctxt "#30636"
 msgid "Error"
-msgstr ""
+msgstr "Σφάλμα"
 
 msgctxt "#30637"
 msgid "Info"
-msgstr ""
+msgstr "Πληροφορίες"
 
 msgctxt "#30638"
 msgid "Debug"
-msgstr ""
+msgstr "Αποσφαλμάτωση"
 
 msgctxt "#30639"
 msgid "Show Specials in season listings"
-msgstr ""
+msgstr "Εμφάνιση των ειδικών επεισοδίων στις λίστες κύκλων"
 
 msgctxt "#30640"
 msgid "Bitrate"
-msgstr ""
+msgstr "Ρυθμός μετάδοσης"
 
 msgctxt "#30641"
 msgid "Playback"
-msgstr ""
+msgstr "Αναπαραγωγή"
 
 msgctxt "#30642"
 msgid "Force Resume options"
-msgstr ""
+msgstr "Επιβολή των επιλογών συνέχισης"
 
 msgctxt "#30643"
 msgid "by Kodi"
-msgstr ""
+msgstr "από το Kodi"
 
 msgctxt "#30644"
 msgid "by Elementum - Ask"
-msgstr ""
+msgstr "από το Elementum - Ερώτηση"
 
 msgctxt "#30645"
 msgid "by Elementum - Force"
-msgstr ""
+msgstr "από το Elementum - Επιβολή"
 
 msgctxt "#30646"
 msgid "Authorize Elementum on Trakt.tv"
-msgstr ""
+msgstr "Εξουσιοδότηση του Elementum στο Trakt.tv"
 
 msgctxt "#30647"
 msgid "Cancel Authorization for Elementum on Trakt.tv"
-msgstr ""
+msgstr "Ακύρωση της εξουσιοδότησης του Elementum στο Trakt.tv"
 
 msgctxt "#30648"
 msgid "Authorization"
-msgstr ""
+msgstr "Εξουσιοδότηση"
 
 msgctxt "#30649"
 msgid "To authorize addon for Trakt.tv you need to:[CR]1. Open [B]%s[/B][CR]2. Enter code: [B]%s[/B][CR]3. Wait for notification from Elementum."
-msgstr ""
+msgstr "Για να εξουσιοδοτήσετε το πρόσθετο για το Trakt.tv πρέπει να:[CR]1. Ανοίξετε το [B]%s[/B][CR]2. Εισαγάγετε τον κωδικό: [B]%s[/B][CR]3. Περιμένετε την ειδοποίηση από το Elementum."
 
 msgctxt "#30650"
 msgid "Successfully authorized for Trakt.tv"
-msgstr ""
+msgstr "Η εξουσιοδότηση για το Trakt.tv ολοκληρώθηκε με επιτυχία"
 
 msgctxt "#30651"
 msgid "Could not authorize for Trakt.tv"
-msgstr ""
+msgstr "Δεν ήταν δυνατή η εξουσιοδότηση για το Trakt.tv"
 
 msgctxt "#30652"
 msgid "Successfully deauthorized for Trakt.tv"
-msgstr ""
+msgstr "Η εξουσιοδότηση για το Trakt.tv ακυρώθηκε με επιτυχία"
 
 msgctxt "#30653"
 msgid "Which files to download"
-msgstr ""
+msgstr "Ποια αρχεία θα ληφθούν"
 
 msgctxt "#30654"
 msgid "Only playback file"
-msgstr ""
+msgstr "Μόνο το αρχείο αναπαραγωγής"
 
 msgctxt "#30655"
 msgid "Season files"
-msgstr ""
+msgstr "Τα αρχεία του κύκλου"
 
 msgctxt "#30656"
 msgid "All files"
-msgstr ""
+msgstr "Όλα τα αρχεία"
 
 msgctxt "#30657"
 msgid "Disable LSD"
-msgstr ""
+msgstr "Απενεργοποίηση LSD"
 
 msgctxt "#30658"
 msgid "Add extra trackers"
-msgstr ""
+msgstr "Προσθήκη επιπλέον tracker"
 
 msgctxt "#30659"
 msgid "All known trackers"
-msgstr ""
+msgstr "Όλα τα γνωστά tracker"
 
 msgctxt "#30660"
 msgid "Best trackers"
-msgstr ""
+msgstr "Τα καλύτερα tracker"
 
 msgctxt "#30661"
 msgid "Minimum set"
-msgstr ""
+msgstr "Ελάχιστο σύνολο"
 
 msgctxt "#30662"
 msgid "Remove original trackers from torrent"
-msgstr ""
+msgstr "Αφαίρεση των αρχικών tracker από το torrent"
 
 msgctxt "#30663"
 msgid "Show episodes on release day (w/o delay)"
-msgstr ""
+msgstr "Εμφάνιση των επεισοδίων την ημέρα κυκλοφορίας (χωρίς καθυστέρηση)"
 
 msgctxt "#30664"
 msgid "Modify trackers in torrent"
-msgstr ""
+msgstr "Τροποποίηση των tracker στο torrent"
 
 msgctxt "#30665"
 msgid "At the time of adding"
-msgstr ""
+msgstr "Τη στιγμή της προσθήκης"
 
 msgctxt "#30666"
 msgid "Every time"
-msgstr ""
+msgstr "Κάθε φορά"
 
 msgctxt "#30667"
 msgid "Mark as watched in Trakt"
-msgstr ""
+msgstr "Σήμανση ως παρακολουθημένο στο Trakt"
 
 msgctxt "#30668"
 msgid "Mark as unwatched in Trakt"
-msgstr ""
+msgstr "Σήμανση ως μη παρακολουθημένο στο Trakt"
 
 msgctxt "#30669"
 msgid "Delay addon startup, seconds"
-msgstr ""
+msgstr "Καθυστέρηση της έναρξης του πρόσθετου, δευτερόλεπτα"
 
 msgctxt "#30670"
 msgid "Downloading required binary file for '%s'"
-msgstr ""
+msgstr "Λήψη του απαιτούμενου εκτελέσιμου αρχείου για '%s'"
 
 msgctxt "#30671"
 msgid "List of Opennic DNS IPs"
-msgstr ""
+msgstr "Λίστα διευθύνσεων IP των DNS του OpenNIC"
 
 msgctxt "#30672"
 msgid "Compact database"
-msgstr ""
+msgstr "Συμπύκνωση της βάσης δεδομένων"
 
 msgctxt "#30673"
 msgid "Compact cache database"
-msgstr ""
+msgstr "Συμπύκνωση της βάσης δεδομένων της προσωρινής μνήμης"
 
 msgctxt "#30674"
 msgid "Database was compacted"
-msgstr ""
+msgstr "Η βάση δεδομένων συμπυκνώθηκε"
 
 msgctxt "#30675"
 msgid "Remote host login"
-msgstr ""
+msgstr "Όνομα χρήστη του απομακρυσμένου κόμβου"
 
 msgctxt "#30676"
 msgid "Remote host password"
-msgstr ""
+msgstr "Κωδικός πρόσβασης του απομακρυσμένου κόμβου"
 
 msgctxt "#30677"
 msgid "Force start as a library"
-msgstr ""
+msgstr "Επιβολή της έναρξης ως βιβλιοθήκη"
 
 msgctxt "#30678"
 msgid "Remove from Kodi library, when movie is deleted from Trakt"
-msgstr ""
+msgstr "Αφαίρεση από τη βιβλιοθήκη του Kodi όταν η ταινία διαγράφεται από το Trakt"
 
 msgctxt "#30679"
 msgid "Remove from Kodi library, when show is deleted from Trakt"
-msgstr ""
+msgstr "Αφαίρεση από τη βιβλιοθήκη του Kodi όταν η σειρά διαγράφεται από το Trakt"
 
 msgctxt "#30680"
 msgid "Remove Elementum duplicates from library"
-msgstr ""
+msgstr "Αφαίρεση των διπλότυπων του Elementum από τη βιβλιοθήκη"
 
 msgctxt "#30681"
 msgid "[B]Found duplicates in Kodi library:[/B][CR]Movies: [B]%s[/B], Shows: [B]%s[/B], Episodes: [B]%s[/B][CR]Proceed?"
-msgstr ""
+msgstr "[B]Βρέθηκαν διπλότυπα στη βιβλιοθήκη του Kodi:[/B][CR]Ταινίες: [B]%s[/B], Σειρές: [B]%s[/B], Επεισόδια: [B]%s[/B][CR]Να συνεχίσω;"
 
 msgctxt "#30682"
 msgid "No duplicates were found in Kodi library"
-msgstr ""
+msgstr "Δεν βρέθηκαν διπλότυπα στη βιβλιοθήκη του Kodi"
 
 msgctxt "#30683"
 msgid "Starting library duplicates removal"
-msgstr ""
+msgstr "Έναρξη της αφαίρεσης των διπλότυπων από τη βιβλιοθήκη"
 
 msgctxt "#30684"
 msgid "Removed Movies: %s, Shows: %s, Episodes: %s"
-msgstr ""
+msgstr "Αφαιρέθηκαν - Ταινίες: %s, Σειρές: %s, Επεισόδια: %s"
 
 msgctxt "#30685"
 msgid "Remove movies from Elementum database"
-msgstr ""
+msgstr "Αφαίρεση των ταινιών από τη βάση δεδομένων του Elementum"
 
 msgctxt "#30686"
 msgid "Remove shows from Elementum database"
-msgstr ""
+msgstr "Αφαίρεση των σειρών από τη βάση δεδομένων του Elementum"
 
 msgctxt "#30687"
 msgid "In Elementum library"
-msgstr ""
+msgstr "Στη βιβλιοθήκη του Elementum"
 
 msgctxt "#30688"
 msgid "Skip searching for installed Elementum repository"
-msgstr ""
+msgstr "Παράλειψη της αναζήτησης του εγκατεστημένου αποθετηρίου Elementum"
 
 msgctxt "#30689"
 msgid "Internal DNS client"
-msgstr ""
+msgstr "Εσωτερικός πελάτης DNS"
 
 msgctxt "#30691"
 msgid "Hide watched"
-msgstr ""
+msgstr "Απόκρυψη των παρακολουθημένων"
 
 msgctxt "#30692"
 msgid "TMDB images quality (affects Kodi performance)"
-msgstr ""
+msgstr "Ποιότητα των εικόνων του TMDB (επηρεάζει τις επιδόσεις του Kodi)"
 
 msgctxt "#30693"
 msgid "Original"
-msgstr ""
+msgstr "Αρχική"
 
 msgctxt "#30694"
 msgid "High"
-msgstr ""
+msgstr "Υψηλή"
 
 msgctxt "#30695"
 msgid "Medium"
-msgstr ""
+msgstr "Μεσαία"
 
 msgctxt "#30696"
 msgid "Low"
-msgstr ""
+msgstr "Χαμηλή"
 
 msgctxt "#30697"
 msgid "Interface language"
-msgstr ""
+msgstr "Γλώσσα της διεπαφής"
 
 msgctxt "#30698"
 msgid "Kodi language"
-msgstr ""
+msgstr "Γλώσσα του Kodi"
 
 msgctxt "#30699"
 msgid "Use earliest release date for progress and calendars"
-msgstr ""
+msgstr "Χρήση της παλαιότερης ημερομηνίας κυκλοφορίας για την πρόοδο και τα ημερολόγια"
 
 msgctxt "#30700"
 msgid "Interface fallback language"
-msgstr ""
+msgstr "Εφεδρική γλώσσα της διεπαφής"
 
 msgctxt "#30701"
 msgid "English | en"
-msgstr ""
+msgstr "Αγγλικά | en"
 
 msgctxt "#30702"
 msgid "Reached daily limit for subtitles downloads"
-msgstr ""
+msgstr "Συμπληρώθηκε το ημερήσιο όριο λήψεων υποτίτλων"
 
 msgctxt "#30703"
 msgid "Can be used by search providers or [CR]for debugging"
-msgstr ""
+msgstr "Μπορεί να χρησιμοποιηθεί από τους παρόχους αναζήτησης ή [CR]για αποσφαλμάτωση"
 
 msgctxt "#30704"
 msgid "TMDB API Key check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Ο έλεγχος του κλειδιού API του TMDB απέτυχε, δεν είναι δυνατή η χρήση της υπηρεσίας TMDB"
 
 msgctxt "#30705"
 msgid "TMDB API accessibility check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Ο έλεγχος προσβασιμότητας του API του TMDB απέτυχε, δεν είναι δυνατή η χρήση της υπηρεσίας TMDB"
 
 msgctxt "#30706"
 msgid "Transmission 4.05"
-msgstr ""
+msgstr "Transmission 4.05"
 
 msgctxt "#30707"
 msgid "qBittorrent 3.3.9"
-msgstr ""
+msgstr "qBittorrent 3.3.9"
 
 msgctxt "#30708"
 msgid "qBittorrent 4.6.4"
-msgstr ""
+msgstr "qBittorrent 4.6.4"
 
 msgctxt "#30709"
 msgid "Open [B]%s[/B]"
-msgstr ""
+msgstr "Άνοιγμα του [B]%s[/B]"
 
 msgctxt "#30710"
 msgid "BitTorrent ports"
-msgstr ""
+msgstr "Θύρες BitTorrent"
 
 msgctxt "#30711"
 msgid "Delete torrent '%s'?"
-msgstr ""
+msgstr "Να διαγραφεί το torrent '%s';"
 
 msgctxt "#30712"
 msgid "Force to always use proxy, can break download in some cases"
-msgstr ""
+msgstr "Επιβολή της συνεχούς χρήσης του διαμεσολαβητή, σε ορισμένες περιπτώσεις μπορεί να διακόψει τη λήψη"
 
 msgctxt "#30713"
 msgid "Disable NATPMP"
@@ -2287,20 +2287,20 @@ msgstr "Απενεργοποίηση NATPMP"
 
 msgctxt "#30714"
 msgid "Re-check torrent's data"
-msgstr ""
+msgstr "Εκ νέου έλεγχος των δεδομένων του torrent"
 
 msgctxt "#30715"
 msgid "Antizapret PAC file URL"
-msgstr ""
+msgstr "Διεύθυνση URL του αρχείου PAC του Antizapret"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "Διακομιστής DNS over HTTPS"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "Προσαρμοσμένος διακομιστής DNS over HTTPS"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "Χρήση των διακομιστών DNS του OpenNIC"

--- a/resources/language/Hebrew/strings.po
+++ b/resources/language/Hebrew/strings.po
@@ -237,7 +237,7 @@ msgstr "תדירות עדכון הספרייה (בשעות)"
 
 msgctxt "#30063"
 msgid "Disable UPNP"
-msgstr ""
+msgstr "השבת UPNP"
 
 msgctxt "#30064"
 msgid "Encryption policy"
@@ -415,11 +415,11 @@ msgstr "מוצא טראקרים..."
 
 msgctxt "#30119"
 msgid "ID of selected userlist for movies"
-msgstr ""
+msgstr "מזהה רשימת המשתמש שנבחרה לסרטים"
 
 msgctxt "#30120"
 msgid "ID of selected userlist for shows"
-msgstr ""
+msgstr "מזהה רשימת המשתמש שנבחרה לסדרות"
 
 msgctxt "#30141"
 msgid "Please support Elementum development by visiting[CR]https://elementum.surge.sh/donate/ or https://elementumorg.github.io/donate/"
@@ -716,7 +716,7 @@ msgstr "%s הוסרה מהספריה, האם לנקות אותה?[CR]אפשר ל
 
 msgctxt "#30279"
 msgid "Video %s was previously removed from library.[CR]Force adding?"
-msgstr ""
+msgstr "הסרטון %s הוסר בעבר מהספרייה.[CR]לאלץ הוספה?"
 
 msgctxt "#30282"
 msgid "Nothing left to remove from Elementum"
@@ -996,1312 +996,1312 @@ msgstr "כיבוי העלאה"
 
 msgctxt "#30370"
 msgid "Auto-assign network IP"
-msgstr ""
+msgstr "הקצאה אוטומטית של כתובת IP ברשת"
 
 msgctxt "#30371"
 msgid "Auto-assign network ports"
-msgstr ""
+msgstr "הקצאה אוטומטית של פורטים ברשת"
 
 msgctxt "#30373"
 msgid "Languages"
-msgstr ""
+msgstr "שפות"
 
 msgctxt "#30374"
 msgid "Countries"
-msgstr ""
+msgstr "מדינות"
 
 msgctxt "#30375"
 msgid "By size"
-msgstr ""
+msgstr "לפי גודל"
 
 msgctxt "#30376"
 msgid "Choose memory size automatically"
-msgstr ""
+msgstr "בחירה אוטומטית של גודל הזיכרון"
 
 msgctxt "#30377"
 msgid "Size is chosen automatically, based on[CR]physical amount of memory"
-msgstr ""
+msgstr "הגודל נבחר אוטומטית, בהתאם[CR]לכמות הזיכרון הפיזי"
 
 msgctxt "#30378"
 msgid "Allow memory usage"
-msgstr ""
+msgstr "אפשר שימוש בזיכרון"
 
 msgctxt "#30379"
 msgid "Minimum - 40MB, Default - 8%, Maximum - 15%"
-msgstr ""
+msgstr "מינימום - 40MB, ברירת מחדל - 8%, מקסימום - 15%"
 
 msgctxt "#30380"
 msgid "Minimum"
-msgstr ""
+msgstr "מינימום"
 
 msgctxt "#30381"
 msgid "Default"
-msgstr ""
+msgstr "ברירת מחדל"
 
 msgctxt "#30382"
 msgid "Maximum"
-msgstr ""
+msgstr "מקסימום"
 
 msgctxt "#30383"
 msgid "Use Kodi language for subtitles search"
-msgstr ""
+msgstr "שימוש בשפת Kodi לחיפוש כתוביות"
 
 msgctxt "#30384"
 msgid "Language code for subtitles (example: en, it, es)"
-msgstr ""
+msgstr "קוד שפה לכתוביות (לדוגמה: en, it, es)"
 
 msgctxt "#30386"
 msgid "Disable background progress dialog on playback"
-msgstr ""
+msgstr "השבת את חלון ההתקדמות ברקע בזמן ההפעלה"
 
 msgctxt "#30387"
 msgid "Caching"
-msgstr ""
+msgstr "מטמון"
 
 msgctxt "#30388"
 msgid "Cache stream selection"
-msgstr ""
+msgstr "שמירת בחירת הזרם במטמון"
 
 msgctxt "#30389"
 msgid "Cache stream search results"
-msgstr ""
+msgstr "שמירת תוצאות חיפוש הזרמים במטמון"
 
 msgctxt "#30390"
 msgid "Cache search results duration, seconds"
-msgstr ""
+msgstr "משך שמירת תוצאות החיפוש במטמון, שניות"
 
 msgctxt "#30393"
 msgid "Status"
-msgstr ""
+msgstr "מצב"
 
 msgctxt "#30394"
 msgid "Version"
-msgstr ""
+msgstr "גרסה"
 
 msgctxt "#30395"
 msgid "IP address"
-msgstr ""
+msgstr "כתובת IP"
 
 msgctxt "#30396"
 msgid "Port"
-msgstr ""
+msgstr "פורט"
 
 msgctxt "#30397"
 msgid "Web UI"
-msgstr ""
+msgstr "ממשק אינטרנט"
 
 msgctxt "#30398"
 msgid "Debug information (with kodi.log)"
-msgstr ""
+msgstr "מידע ניפוי שגיאות (עם kodi.log)"
 
 msgctxt "#30399"
 msgid "Addresses"
-msgstr ""
+msgstr "כתובות"
 
 msgctxt "#30400"
 msgid "Statistics"
-msgstr ""
+msgstr "סטטיסטיקה"
 
 msgctxt "#30401"
 msgid "Torrent library status"
-msgstr ""
+msgstr "מצב ספריית הטורנטים"
 
 msgctxt "#30402"
 msgid "Size of cache.db"
-msgstr ""
+msgstr "גודל cache.db"
 
 msgctxt "#30403"
 msgid "Size of app.db"
-msgstr ""
+msgstr "גודל app.db"
 
 msgctxt "#30404"
 msgid "Assigned torrent files"
-msgstr ""
+msgstr "קובצי טורנט משויכים"
 
 msgctxt "#30405"
 msgid "Search queries"
-msgstr ""
+msgstr "שאילתות חיפוש"
 
 msgctxt "#30406"
 msgid "Remove from history"
-msgstr ""
+msgstr "הסר מההיסטוריה"
 
 msgctxt "#30408"
 msgid "Addon Connectivity"
-msgstr ""
+msgstr "קישוריות התוסף"
 
 msgctxt "#30409"
 msgid "Local port"
-msgstr ""
+msgstr "פורט מקומי"
 
 msgctxt "#30410"
 msgid "Remote port"
-msgstr ""
+msgstr "פורט מרוחק"
 
 msgctxt "#30411"
 msgid "Remote host"
-msgstr ""
+msgstr "מארח מרוחק"
 
 msgctxt "#30412"
 msgid "Do not start binary (client mode)"
-msgstr ""
+msgstr "אל תפעיל את הקובץ הבינארי (מצב לקוח)"
 
 msgctxt "#30413"
 msgid "Yes"
-msgstr ""
+msgstr "כן"
 
 msgctxt "#30414"
 msgid "No"
-msgstr ""
+msgstr "לא"
 
 msgctxt "#30415"
 msgid "Next page (%s)"
-msgstr ""
+msgstr "העמוד הבא (%s)"
 
 msgctxt "#30416"
 msgid "Percents of playback to mark as watched"
-msgstr ""
+msgstr "אחוז ההפעלה לסימון כנצפה"
 
 msgctxt "#30417"
 msgid "Use name of production company as Studio for shows"
-msgstr ""
+msgstr "שימוש בשם חברת ההפקה כאולפן עבור סדרות"
 
 msgctxt "#30418"
 msgid "Calculate number of unwatched episodes in Shows/Seasons"
-msgstr ""
+msgstr "חישוב מספר הפרקים שלא נצפו בסדרות/עונות"
 
 msgctxt "#30421"
 msgid "Load torrents from torrents folder on startup"
-msgstr ""
+msgstr "טעינת טורנטים מתיקיית הטורנטים בעת ההפעלה"
 
 msgctxt "#30422"
 msgid "Popular lists"
-msgstr ""
+msgstr "רשימות פופולריות"
 
 msgctxt "#30423"
 msgid "Recommendations"
-msgstr ""
+msgstr "המלצות"
 
 msgctxt "#30424"
 msgid "Progress"
-msgstr ""
+msgstr "התקדמות"
 
 msgctxt "#30425"
 msgid "Color of an air date"
-msgstr ""
+msgstr "צבע תאריך השידור"
 
 msgctxt "#30426"
 msgid "Color of a show name"
-msgstr ""
+msgstr "צבע שם הסדרה"
 
 msgctxt "#30427"
 msgid "Color of an episode name"
-msgstr ""
+msgstr "צבע שם הפרק"
 
 msgctxt "#30428"
 msgid "Hide unaired episodes"
-msgstr ""
+msgstr "הסתר פרקים שטרם שודרו"
 
 msgctxt "#30429"
 msgid "Sort shows in the list"
-msgstr ""
+msgstr "מיון הסדרות ברשימה"
 
 msgctxt "#30430"
 msgid "By latest watched"
-msgstr ""
+msgstr "לפי הנצפה לאחרונה"
 
 msgctxt "#30431"
 msgid "By show name"
-msgstr ""
+msgstr "לפי שם הסדרה"
 
 msgctxt "#30432"
 msgid "By air date (newer)"
-msgstr ""
+msgstr "לפי תאריך שידור (חדש יותר)"
 
 msgctxt "#30433"
 msgid "By air date (older)"
-msgstr ""
+msgstr "לפי תאריך שידור (ישן יותר)"
 
 msgctxt "#30434"
 msgid "Date format"
-msgstr ""
+msgstr "תבנית התאריך"
 
 msgctxt "#30436"
 msgid "Userlist"
-msgstr ""
+msgstr "רשימת משתמש"
 
 msgctxt "#30438"
 msgid "Userlists"
-msgstr ""
+msgstr "רשימות משתמש"
 
 msgctxt "#30439"
 msgid "Debug information (without kodi.log)"
-msgstr ""
+msgstr "מידע ניפוי שגיאות (ללא kodi.log)"
 
 msgctxt "#30440"
 msgid "Color of an unaired episode name"
-msgstr ""
+msgstr "צבע שם של פרק שטרם שודר"
 
 msgctxt "#30441"
 msgid "Select userlist for movies"
-msgstr ""
+msgstr "בחר רשימת משתמש לסרטים"
 
 msgctxt "#30442"
 msgid "Userlist for movies"
-msgstr ""
+msgstr "רשימת משתמש לסרטים"
 
 msgctxt "#30443"
 msgid "Selected userlist for movies"
-msgstr ""
+msgstr "רשימת המשתמש שנבחרה לסרטים"
 
 msgctxt "#30444"
 msgid "Select userlist for shows"
-msgstr ""
+msgstr "בחר רשימת משתמש לסדרות"
 
 msgctxt "#30445"
 msgid "Userlist for shows"
-msgstr ""
+msgstr "רשימת משתמש לסדרות"
 
 msgctxt "#30446"
 msgid "Selected userlist for shows"
-msgstr ""
+msgstr "רשימת המשתמש שנבחרה לסדרות"
 
 msgctxt "#30447"
 msgid "Add to Trakt, when movie is added to Kodi library"
-msgstr ""
+msgstr "הוסף ל-Trakt כאשר סרט נוסף לספריית Kodi"
 
 msgctxt "#30448"
 msgid "Add to Trakt, when show is added to Kodi library"
-msgstr ""
+msgstr "הוסף ל-Trakt כאשר סדרה נוספת לספריית Kodi"
 
 msgctxt "#30449"
 msgid "Remove from Trakt, when movie is deleted from Kodi library"
-msgstr ""
+msgstr "הסר מ-Trakt כאשר סרט נמחק מספריית Kodi"
 
 msgctxt "#30450"
 msgid "Remove from Trakt, when show is deleted from Kodi library"
-msgstr ""
+msgstr "הסר מ-Trakt כאשר סדרה נמחקת מספריית Kodi"
 
 msgctxt "#30451"
 msgid "Torrent files path"
-msgstr ""
+msgstr "נתיב קובצי הטורנט"
 
 msgctxt "#30452"
 msgid "Reset all paths"
-msgstr ""
+msgstr "אפס את כל הנתיבים"
 
 msgctxt "#30453"
 msgid "Upload /debug/bundle (with kodi.log) to pastebin"
-msgstr ""
+msgstr "העלה את /debug/bundle (עם kodi.log) ל-pastebin"
 
 msgctxt "#30454"
 msgid "Paste url:[CR]%s"
-msgstr ""
+msgstr "כתובת ה-paste:[CR]%s"
 
 msgctxt "#30455"
 msgid "Logging"
-msgstr ""
+msgstr "רישום ביומן"
 
 msgctxt "#30456"
 msgid "Upload /debug/all (no kodi.log) to pastebin"
-msgstr ""
+msgstr "העלה את /debug/all (ללא kodi.log) ל-pastebin"
 
 msgctxt "#30457"
 msgid "Uploading file to pastebin"
-msgstr ""
+msgstr "מעלה את הקובץ ל-pastebin"
 
 msgctxt "#30458"
 msgid "Deleted movies"
-msgstr ""
+msgstr "סרטים שנמחקו"
 
 msgctxt "#30459"
 msgid "Deleted shows"
-msgstr ""
+msgstr "סדרות שנמחקו"
 
 msgctxt "#30460"
 msgid "Database"
-msgstr ""
+msgstr "מסד נתונים"
 
 msgctxt "#30461"
 msgid "Show information"
-msgstr ""
+msgstr "הצג מידע"
 
 msgctxt "#30462"
 msgid "Clear deleted movies"
-msgstr ""
+msgstr "נקה את הסרטים שנמחקו"
 
 msgctxt "#30463"
 msgid "Clear deleted shows"
-msgstr ""
+msgstr "נקה את הסדרות שנמחקו"
 
 msgctxt "#30464"
 msgid "Clear torrents history"
-msgstr ""
+msgstr "נקה את היסטוריית הטורנטים"
 
 msgctxt "#30465"
 msgid "Clear search history"
-msgstr ""
+msgstr "נקה את היסטוריית החיפושים"
 
 msgctxt "#30466"
 msgid "Clear the database"
-msgstr ""
+msgstr "נקה את מסד הנתונים"
 
 msgctxt "#30467"
 msgid "Cache"
-msgstr ""
+msgstr "מטמון"
 
 msgctxt "#30468"
 msgid "Clear TMDB cache"
-msgstr ""
+msgstr "נקה את מטמון TMDB"
 
 msgctxt "#30469"
 msgid "Clear Trakt cache"
-msgstr ""
+msgstr "נקה את מטמון Trakt"
 
 msgctxt "#30470"
 msgid "Clear the cache"
-msgstr ""
+msgstr "נקה את המטמון"
 
 msgctxt "#30471"
 msgid "Are you sure you want to do it?"
-msgstr ""
+msgstr "האם אתה בטוח שברצונך לעשות זאת?"
 
 msgctxt "#30472"
 msgid "Database cleared"
-msgstr ""
+msgstr "מסד הנתונים נוקה"
 
 msgctxt "#30473"
 msgid "Select network interface"
-msgstr ""
+msgstr "בחר ממשק רשת"
 
 msgctxt "#30474"
 msgid "Network interfaces"
-msgstr ""
+msgstr "ממשקי רשת"
 
 msgctxt "#30475"
 msgid "Strm files language"
-msgstr ""
+msgstr "שפת קובצי strm"
 
 msgctxt "#30476"
 msgid "Select language"
-msgstr ""
+msgstr "בחר שפה"
 
 msgctxt "#30477"
 msgid "Original language"
-msgstr ""
+msgstr "השפה המקורית"
 
 msgctxt "#30478"
 msgid "Searching"
-msgstr ""
+msgstr "מחפש"
 
 msgctxt "#30480"
 msgid "Run Kodi library update after add/delete"
-msgstr ""
+msgstr "הפעל עדכון של ספריית Kodi לאחר הוספה/מחיקה"
 
 msgctxt "#30481"
 msgid "Automatically"
-msgstr ""
+msgstr "אוטומטית"
 
 msgctxt "#30482"
 msgid "Ask"
-msgstr ""
+msgstr "שאל"
 
 msgctxt "#30483"
 msgid "Create NFO files for Movie scrapers"
-msgstr ""
+msgstr "צור קובצי NFO עבור מגרדי הסרטים"
 
 msgctxt "#30484"
 msgid "Create NFO files for TV Show scrapers"
-msgstr ""
+msgstr "צור קובצי NFO עבור מגרדי הסדרות"
 
 msgctxt "#30485"
 msgid "Concurrent connections limit per second"
-msgstr ""
+msgstr "מגבלת חיבורים בו-זמניים לשנייה"
 
 msgctxt "#30486"
 msgid "Automatic concurrent connections limit per second"
-msgstr ""
+msgstr "מגבלה אוטומטית של חיבורים בו-זמניים לשנייה"
 
 msgctxt "#30487"
 msgid "Enable built-in HTTP proxy"
-msgstr ""
+msgstr "הפעל את שרת ה-proxy המובנה של HTTP"
 
 msgctxt "#30488"
 msgid "Internal Proxy Port"
-msgstr ""
+msgstr "פורט ה-proxy הפנימי"
 
 msgctxt "#30489"
 msgid "Log Internal proxy requests"
-msgstr ""
+msgstr "רשום ביומן את בקשות ה-proxy הפנימי"
 
 msgctxt "#30490"
 msgid "Internal HTTP proxy"
-msgstr ""
+msgstr "proxy פנימי של HTTP"
 
 msgctxt "#30491"
 msgid "Use Fanart.tv for posters/images"
-msgstr ""
+msgstr "השתמש ב-Fanart.tv לכרזות/תמונות"
 
 msgctxt "#30492"
 msgid "Use Proxy for downloading .torrent files"
-msgstr ""
+msgstr "השתמש ב-proxy להורדת קובצי ‎.torrent"
 
 msgctxt "#30493"
 msgid "Use Proxy for trackers"
-msgstr ""
+msgstr "השתמש ב-proxy עבור טראקרים"
 
 msgctxt "#30494"
 msgid "Use Proxy for torrent downloading"
-msgstr ""
+msgstr "השתמש ב-proxy להורדת טורנטים"
 
 msgctxt "#30495"
 msgid "Use built-in DNS resolver"
-msgstr ""
+msgstr "השתמש במפענח ה-DNS המובנה"
 
 msgctxt "#30496"
 msgid "Turn off if you use Tor addresses, or you want [CR]to use DNS settings from OS"
-msgstr ""
+msgstr "כבה אם אתה משתמש בכתובות Tor, או אם ברצונך [CR]להשתמש בהגדרות ה-DNS של מערכת ההפעלה"
 
 msgctxt "#30497"
 msgid "Use Antizapret proxy (only for Russia)"
-msgstr ""
+msgstr "השתמש ב-proxy של Antizapret (לרוסיה בלבד)"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"
-msgstr ""
+msgstr "אפס נתיב זה ל-'/'"
 
 msgctxt "#30499"
 msgid "Automatically adjust memory size[CR]for heavy torrents, if possible"
-msgstr ""
+msgstr "התאם אוטומטית את גודל הזיכרון[CR]עבור טורנטים כבדים, אם אפשר"
 
 msgctxt "#30500"
 msgid "Automatically adjust buffer size[CR]for heavy torrents"
-msgstr ""
+msgstr "התאם אוטומטית את גודל המאגר[CR]עבור טורנטים כבדים"
 
 msgctxt "#30502"
 msgid "Adjust buffer according to Kodi advancedsettings.xml, if set"
-msgstr ""
+msgstr "התאם את המאגר בהתאם ל-advancedsettings.xml של Kodi, אם הוגדר"
 
 msgctxt "#30503"
 msgid "Use libtorrent.config to override torrent engine settings"
-msgstr ""
+msgstr "השתמש ב-libtorrent.config כדי לעקוף את הגדרות מנוע הטורנט"
 
 msgctxt "#30504"
 msgid "Located at USERDATA/plugin.video.elementum/libtorrent.config file[CR]Settings apply automatically. Visit https://libtorrent.org for info."
-msgstr ""
+msgstr "נמצא בקובץ USERDATA/plugin.video.elementum/libtorrent.config[CR]ההגדרות חלות אוטומטית. בקר ב-https://libtorrent.org למידע."
 
 msgctxt "#30505"
 msgid "Add episode number to the title"
-msgstr ""
+msgstr "הוסף את מספר הפרק לכותרת"
 
 msgctxt "#30506"
 msgid "Enable libtorrent logging"
-msgstr ""
+msgstr "הפעל רישום ביומן של libtorrent"
 
 msgctxt "#30511"
 msgid "Libtorrent settings profile"
-msgstr ""
+msgstr "פרופיל ההגדרות של libtorrent"
 
 msgctxt "#30512"
 msgid "Default"
-msgstr ""
+msgstr "ברירת מחדל"
 
 msgctxt "#30513"
 msgid "Minimal memory"
-msgstr ""
+msgstr "זיכרון מינימלי"
 
 msgctxt "#30514"
 msgid "High speed"
-msgstr ""
+msgstr "מהירות גבוהה"
 
 msgctxt "#30515"
 msgid "Load torrents from torrents folder paused"
-msgstr ""
+msgstr "טען טורנטים מתיקיית הטורנטים במצב מושהה"
 
 msgctxt "#30516"
 msgid "... resume N seconds earlier"
-msgstr ""
+msgstr "... המשך N שניות מוקדם יותר"
 
 msgctxt "#30517"
 msgid "In Kodi library"
-msgstr ""
+msgstr "בספריית Kodi"
 
 msgctxt "#30518"
 msgid "Use libtorrent deadlines"
-msgstr ""
+msgstr "השתמש במועדי היעד של libtorrent"
 
 msgctxt "#30519"
 msgid "Use libtorrent pause/resume trick for added torrents"
-msgstr ""
+msgstr "השתמש בטריק ההשהיה/המשך של libtorrent עבור טורנטים שנוספו"
 
 msgctxt "#30520"
 msgid "Add item to start menu"
-msgstr ""
+msgstr "הוסף פריט לתפריט ההתחלה"
 
 msgctxt "#30521"
 msgid "Delete item from start menu"
-msgstr ""
+msgstr "מחק פריט מתפריט ההתחלה"
 
 msgctxt "#30522"
 msgid "Minimum file size"
-msgstr ""
+msgstr "גודל קובץ מינימלי"
 
 msgctxt "#30523"
 msgid "Minimum file size for Movies, MB"
-msgstr ""
+msgstr "גודל קובץ מינימלי לסרטים, MB"
 
 msgctxt "#30524"
 msgid "Minimum file size for Shows, MB per minute"
-msgstr ""
+msgstr "גודל קובץ מינימלי לסדרות, MB לדקה"
 
 msgctxt "#30525"
 msgid "Automatically start downloading next episode"
-msgstr ""
+msgstr "התחל אוטומטית להוריד את הפרק הבא"
 
 msgctxt "#30527"
 msgid "Donate"
-msgstr ""
+msgstr "תרומה"
 
 msgctxt "#30528"
 msgid "Automatically load first found subtitles"
-msgstr ""
+msgstr "טען אוטומטית את הכתוביות הראשונות שנמצאו"
 
 msgctxt "#30529"
 msgid "Number of subtitles to load automatically"
-msgstr ""
+msgstr "מספר הכתוביות לטעינה אוטומטית"
 
 msgctxt "#30530"
 msgid "Delete autoloaded subtitles on player stop"
-msgstr ""
+msgstr "מחק את הכתוביות שנטענו אוטומטית בעצירת הנגן"
 
 msgctxt "#30531"
 msgid "Download all files from torrent"
-msgstr ""
+msgstr "הורד את כל הקבצים מהטורנט"
 
 msgctxt "#30532"
 msgid "Stop Downloading all files"
-msgstr ""
+msgstr "עצור את ההורדה של כל הקבצים"
 
 msgctxt "#30535"
 msgid "Continue playback from [B]%s[/B]?"
-msgstr ""
+msgstr "להמשיך את ההפעלה מ-[B]%s[/B]?"
 
 msgctxt "#30536"
 msgid "Skip IPv6 addresses resolving"
-msgstr ""
+msgstr "דלג על פענוח כתובות IPv6"
 
 msgctxt "#30537"
 msgid "Torrents history"
-msgstr ""
+msgstr "היסטוריית טורנטים"
 
 msgctxt "#30538"
 msgid "Use torrents history?"
-msgstr ""
+msgstr "להשתמש בהיסטוריית הטורנטים?"
 
 msgctxt "#30539"
 msgid "Store N torrents in history"
-msgstr ""
+msgstr "שמור N טורנטים בהיסטוריה"
 
 msgctxt "#30540"
 msgid "Subtitles"
-msgstr ""
+msgstr "כתוביות"
 
 msgctxt "#30541"
 msgid "Automatic Subtitles Search"
-msgstr ""
+msgstr "חיפוש אוטומטי של כתוביות"
 
 msgctxt "#30542"
 msgid "Disable if subtitles are available in player"
-msgstr ""
+msgstr "השבת אם הכתוביות זמינות בנגן"
 
 msgctxt "#30543"
 msgid "Subtitles included in torrent"
-msgstr ""
+msgstr "כתוביות הכלולות בטורנט"
 
 msgctxt "#30544"
 msgid "Automatic Scrape"
-msgstr ""
+msgstr "גירוד אוטומטי"
 
 msgctxt "#30545"
 msgid "Automatic scraping allows to scrape connected providers[CR]to find new movies, if there are results,"
-msgstr ""
+msgstr "גירוד אוטומטי מאפשר לחפש אצל הספקים המחוברים[CR]סרטים חדשים. אם יש תוצאות"
 
 msgctxt "#30546"
 msgid "Strategy"
-msgstr ""
+msgstr "אסטרטגיה"
 
 msgctxt "#30547"
 msgid "Find in each provider"
-msgstr ""
+msgstr "חפש אצל כל ספק"
 
 msgctxt "#30548"
 msgid "Find in overall"
-msgstr ""
+msgstr "חפש בסך הכול"
 
 msgctxt "#30549"
 msgid "Search is successful when found N results"
-msgstr ""
+msgstr "החיפוש מצליח כאשר נמצאות N תוצאות"
 
 msgctxt "#30550"
 msgid "What to search"
-msgstr ""
+msgstr "מה לחפש"
 
 msgctxt "#30551"
 msgid "How to search"
-msgstr ""
+msgstr "כיצד לחפש"
 
 msgctxt "#30552"
 msgid "Search each N hours"
-msgstr ""
+msgstr "חפש כל N שעות"
 
 msgctxt "#30553"
 msgid "Find 4K resolution"
-msgstr ""
+msgstr "מצא רזולוציית 4K"
 
 msgctxt "#30554"
 msgid "Find 1080p resolution"
-msgstr ""
+msgstr "מצא רזולוציית 1080p"
 
 msgctxt "#30555"
 msgid "and movie passes checks for number of results[CR]movie can be added to the library."
-msgstr ""
+msgstr "והסרט עובר את בדיקות מספר התוצאות,[CR]ניתן להוסיף אותו לספרייה."
 
 msgctxt "#30556"
 msgid "Add to the library"
-msgstr ""
+msgstr "הוסף לספרייה"
 
 msgctxt "#30557"
 msgid "Number of popular movies to search"
-msgstr ""
+msgstr "מספר הסרטים הפופולריים לחיפוש"
 
 msgctxt "#30558"
 msgid "Latest available movies"
-msgstr ""
+msgstr "הסרטים החדשים ביותר הזמינים"
 
 msgctxt "#30559"
 msgid "Skip searching for installed providers"
-msgstr ""
+msgstr "דלג על חיפוש ספקים מותקנים"
 
 msgctxt "#30560"
 msgid "Files: %s"
-msgstr ""
+msgstr "קבצים: %s"
 
 msgctxt "#30561"
 msgid "Interval between requests, seconds"
-msgstr ""
+msgstr "מרווח בין בקשות, שניות"
 
 msgctxt "#30562"
 msgid "Open directory with Kodi file browser"
-msgstr ""
+msgstr "פתח את התיקייה עם דפדפן הקבצים של Kodi"
 
 msgctxt "#30563"
 msgid "Synchronize frequency of Trakt, minutes"
-msgstr ""
+msgstr "תדירות הסנכרון עם Trakt, דקות"
 
 msgctxt "#30564"
 msgid "Sync hidden items"
-msgstr ""
+msgstr "סנכרן פריטים מוסתרים"
 
 msgctxt "#30565"
 msgid "Sync playback progress into Kodi library"
-msgstr ""
+msgstr "סנכרן את התקדמות ההפעלה לספריית Kodi"
 
 msgctxt "#30566"
 msgid "Lists"
-msgstr ""
+msgstr "רשימות"
 
 msgctxt "#30567"
 msgid "Show \"All seasons\" in shows"
-msgstr ""
+msgstr "הצג \"כל העונות\" בסדרות"
 
 msgctxt "#30568"
 msgid "Seasons order"
-msgstr ""
+msgstr "סדר העונות"
 
 msgctxt "#30569"
 msgid "Ascending"
-msgstr ""
+msgstr "עולה"
 
 msgctxt "#30570"
 msgid "Descending"
-msgstr ""
+msgstr "יורד"
 
 msgctxt "#30571"
 msgid "* All seasons"
-msgstr ""
+msgstr "* כל העונות"
 
 msgctxt "#30572"
 msgid "Log server's response body"
-msgstr ""
+msgstr "רשום ביומן את גוף התגובה של השרת"
 
 msgctxt "#30573"
 msgid "Select file to play"
-msgstr ""
+msgstr "בחר קובץ להפעלה"
 
 msgctxt "#30574"
 msgid "Automatically answer Yes after timeout"
-msgstr ""
+msgstr "ענה כן אוטומטית לאחר פקיעת הזמן"
 
 msgctxt "#30575"
 msgid "Timeout, seconds"
-msgstr ""
+msgstr "פקיעת זמן, שניות"
 
 msgctxt "#30576"
 msgid "Trakt authentication needs to be updated!"
-msgstr ""
+msgstr "יש לעדכן את האימות של Trakt!"
 
 msgctxt "#30577"
 msgid "End of file Buffer size, MB"
-msgstr ""
+msgstr "גודל המאגר בסוף הקובץ, MB"
 
 msgctxt "#30578"
 msgid "Beginning of file Buffer size, MB"
-msgstr ""
+msgstr "גודל המאגר בתחילת הקובץ, MB"
 
 msgctxt "#30579"
 msgid "Settings"
-msgstr ""
+msgstr "הגדרות"
 
 msgctxt "#30580"
 msgid "Custom Trakt API Client ID"
-msgstr ""
+msgstr "Client ID מותאם אישית ל-API של Trakt"
 
 msgctxt "#30581"
 msgid "Custom Trakt API Client Secret"
-msgstr ""
+msgstr "Client Secret מותאם אישית ל-API של Trakt"
 
 msgctxt "#30582"
 msgid "Settings for %s provider"
-msgstr ""
+msgstr "הגדרות עבור הספק %s"
 
 msgctxt "#30583"
 msgid "Resolving magnet link"
-msgstr ""
+msgstr "מפענח את קישור ה-magnet"
 
 msgctxt "#30585"
 msgid "Enable library integration with Kodi"
-msgstr ""
+msgstr "הפעל שילוב עם ספריית Kodi"
 
 msgctxt "#30586"
 msgid "If disabled - Elementum will not get/insert items to Kodi library [CR]and skip watched management with Kodi."
-msgstr ""
+msgstr "אם מושבת, Elementum לא יקרא ולא יוסיף פריטים לספריית Kodi [CR]וידלג על ניהול מצב הצפייה עם Kodi."
 
 msgctxt "#30587"
 msgid "Show welcome message on start"
-msgstr ""
+msgstr "הצג הודעת ברוך הבא בהפעלה"
 
 msgctxt "#30588"
 msgid "Pre-Play Buffering"
-msgstr ""
+msgstr "אגירה לפני ההפעלה"
 
 msgctxt "#30589"
 msgid "Speed limiting"
-msgstr ""
+msgstr "הגבלת מהירות"
 
 msgctxt "#30590"
 msgid "Torrents autoload on addon startup"
-msgstr ""
+msgstr "טעינה אוטומטית של טורנטים בהפעלת התוסף"
 
 msgctxt "#30591"
 msgid "Limits for connections"
-msgstr ""
+msgstr "מגבלות לחיבורים"
 
 msgctxt "#30592"
 msgid "Seeding"
-msgstr ""
+msgstr "שיתוף"
 
 msgctxt "#30593"
 msgid "Seed forever"
-msgstr ""
+msgstr "שתף לתמיד"
 
 msgctxt "#30594"
 msgid "Network"
-msgstr ""
+msgstr "רשת"
 
 msgctxt "#30595"
 msgid "Miscellaneous"
-msgstr ""
+msgstr "שונות"
 
 msgctxt "#30597"
 msgid "Cache size, MB"
-msgstr ""
+msgstr "גודל המטמון, MB"
 
 msgctxt "#30598"
 msgid "Enable caching if using File storage and have speed problems.[CR]Will use more memory, but can improve the speed."
-msgstr ""
+msgstr "הפעל את המטמון אם אתה משתמש באחסון בקבצים ויש לך בעיות מהירות.[CR]הוא ישתמש ביותר זיכרון, אך עשוי לשפר את המהירות."
 
 msgctxt "#30599"
 msgid "Enable Kodi library synchronization"
-msgstr ""
+msgstr "הפעל סנכרון עם ספריית Kodi"
 
 msgctxt "#30600"
 msgid "Enable Trakt synchronization"
-msgstr ""
+msgstr "הפעל סנכרון עם Trakt"
 
 msgctxt "#30601"
 msgid "Enable synchronization while playback"
-msgstr ""
+msgstr "הפעל סנכרון בזמן ההפעלה"
 
 msgctxt "#30602"
 msgid "Retry requests to addon after timeout, seconds"
-msgstr ""
+msgstr "נסה שוב בקשות לתוסף לאחר פקיעת הזמן, שניות"
 
 msgctxt "#30603"
 msgid "Addon Startup"
-msgstr ""
+msgstr "הפעלת התוסף"
 
 msgctxt "#30604"
 msgid "Clean all history"
-msgstr ""
+msgstr "נקה את כל ההיסטוריה"
 
 msgctxt "#30605"
 msgid "Cache downloaded torrent files after search"
-msgstr ""
+msgstr "שמור במטמון את קובצי הטורנט שהורדו לאחר החיפוש"
 
 msgctxt "#30606"
 msgid "Show watched state for torrent's files"
-msgstr ""
+msgstr "הצג את מצב הצפייה עבור קובצי הטורנט"
 
 msgctxt "#30607"
 msgid "Use earliest release date as basic for searching"
-msgstr ""
+msgstr "השתמש בתאריך היציאה המוקדם ביותר כבסיס לחיפוש"
 
 msgctxt "#30608"
 msgid "Match found in your active torrents, play it?[CR]%s"
-msgstr ""
+msgstr "נמצאה התאמה בטורנטים הפעילים שלך, להפעיל אותה?[CR]%s"
 
 msgctxt "#30609"
 msgid "Automatically start next episode if available"
-msgstr ""
+msgstr "התחל אוטומטית את הפרק הבא אם הוא זמין"
 
 msgctxt "#30610"
 msgid "Magnet resolve timeout, seconds"
-msgstr ""
+msgstr "פקיעת זמן לפענוח magnet, שניות"
 
 msgctxt "#30611"
 msgid "Application platform type"
-msgstr ""
+msgstr "סוג פלטפורמת היישום"
 
 msgctxt "#30612"
 msgid "Select file to download"
-msgstr ""
+msgstr "בחר קובץ להורדה"
 
 msgctxt "#30613"
 msgid "... for movie"
-msgstr ""
+msgstr "... עבור סרט"
 
 msgctxt "#30614"
 msgid "... for tv show"
-msgstr ""
+msgstr "... עבור סדרה"
 
 msgctxt "#30615"
 msgid "... for search"
-msgstr ""
+msgstr "... עבור חיפוש"
 
 msgctxt "#30616"
 msgid "Elementum | Trakt Account"
-msgstr ""
+msgstr "Elementum | חשבון Trakt"
 
 msgctxt "#30617"
 msgid "Your account is locked for API on Trakt.tv[CR]Please, contact Trakt Support at https://support.trakt.tv ."
-msgstr ""
+msgstr "החשבון שלך נעול עבור ה-API ב-Trakt.tv[CR]אנא פנה לתמיכה של Trakt בכתובת https://support.trakt.tv ."
 
 msgctxt "#30618"
 msgid "%s is downloaded"
-msgstr ""
+msgstr "%s הורד"
 
 msgctxt "#30619"
 msgid "Return to [B]%s[/B]"
-msgstr ""
+msgstr "חזרה אל [B]%s[/B]"
 
 msgctxt "#30620"
 msgid "Restart Elementum addon"
-msgstr ""
+msgstr "הפעל מחדש את התוסף Elementum"
 
 msgctxt "#30621"
 msgid "Queued"
-msgstr ""
+msgstr "בתור"
 
 msgctxt "#30622"
 msgid "Checking"
-msgstr ""
+msgstr "בודק"
 
 msgctxt "#30623"
 msgid "Finding"
-msgstr ""
+msgstr "מחפש"
 
 msgctxt "#30624"
 msgid "Downloading"
-msgstr ""
+msgstr "מוריד"
 
 msgctxt "#30625"
 msgid "Finished"
-msgstr ""
+msgstr "הסתיים"
 
 msgctxt "#30626"
 msgid "Seeding"
-msgstr ""
+msgstr "משתף"
 
 msgctxt "#30627"
 msgid "Allocating"
-msgstr ""
+msgstr "מקצה מקום"
 
 msgctxt "#30628"
 msgid "Stalled"
-msgstr ""
+msgstr "תקוע"
 
 msgctxt "#30629"
 msgid "Paused"
-msgstr ""
+msgstr "מושהה"
 
 msgctxt "#30630"
 msgid "Buffering"
-msgstr ""
+msgstr "אוגר"
 
 msgctxt "#30631"
 msgid "Playing"
-msgstr ""
+msgstr "מנגן"
 
 msgctxt "#30632"
 msgid "Yes (%s seconds)"
-msgstr ""
+msgstr "כן (%s שניות)"
 
 msgctxt "#30633"
 msgid "No (%s seconds)"
-msgstr ""
+msgstr "לא (%s שניות)"
 
 msgctxt "#30634"
 msgid "Log level"
-msgstr ""
+msgstr "רמת הרישום ביומן"
 
 msgctxt "#30635"
 msgid "None"
-msgstr ""
+msgstr "ללא"
 
 msgctxt "#30636"
 msgid "Error"
-msgstr ""
+msgstr "שגיאה"
 
 msgctxt "#30637"
 msgid "Info"
-msgstr ""
+msgstr "מידע"
 
 msgctxt "#30638"
 msgid "Debug"
-msgstr ""
+msgstr "ניפוי שגיאות"
 
 msgctxt "#30639"
 msgid "Show Specials in season listings"
-msgstr ""
+msgstr "הצג פרקים מיוחדים ברשימות העונות"
 
 msgctxt "#30640"
 msgid "Bitrate"
-msgstr ""
+msgstr "קצב סיביות"
 
 msgctxt "#30641"
 msgid "Playback"
-msgstr ""
+msgstr "הפעלה"
 
 msgctxt "#30642"
 msgid "Force Resume options"
-msgstr ""
+msgstr "אלץ את אפשרויות ההמשך"
 
 msgctxt "#30643"
 msgid "by Kodi"
-msgstr ""
+msgstr "על ידי Kodi"
 
 msgctxt "#30644"
 msgid "by Elementum - Ask"
-msgstr ""
+msgstr "על ידי Elementum - שאל"
 
 msgctxt "#30645"
 msgid "by Elementum - Force"
-msgstr ""
+msgstr "על ידי Elementum - אלץ"
 
 msgctxt "#30646"
 msgid "Authorize Elementum on Trakt.tv"
-msgstr ""
+msgstr "אשר את Elementum ב-Trakt.tv"
 
 msgctxt "#30647"
 msgid "Cancel Authorization for Elementum on Trakt.tv"
-msgstr ""
+msgstr "בטל את האישור של Elementum ב-Trakt.tv"
 
 msgctxt "#30648"
 msgid "Authorization"
-msgstr ""
+msgstr "אישור"
 
 msgctxt "#30649"
 msgid "To authorize addon for Trakt.tv you need to:[CR]1. Open [B]%s[/B][CR]2. Enter code: [B]%s[/B][CR]3. Wait for notification from Elementum."
-msgstr ""
+msgstr "כדי לאשר את התוסף ל-Trakt.tv עליך:[CR]1. לפתוח את [B]%s[/B][CR]2. להזין את הקוד: [B]%s[/B][CR]3. להמתין להודעה מ-Elementum."
 
 msgctxt "#30650"
 msgid "Successfully authorized for Trakt.tv"
-msgstr ""
+msgstr "האישור ל-Trakt.tv הצליח"
 
 msgctxt "#30651"
 msgid "Could not authorize for Trakt.tv"
-msgstr ""
+msgstr "לא ניתן היה לאשר את Trakt.tv"
 
 msgctxt "#30652"
 msgid "Successfully deauthorized for Trakt.tv"
-msgstr ""
+msgstr "האישור ל-Trakt.tv בוטל בהצלחה"
 
 msgctxt "#30653"
 msgid "Which files to download"
-msgstr ""
+msgstr "אילו קבצים להוריד"
 
 msgctxt "#30654"
 msgid "Only playback file"
-msgstr ""
+msgstr "רק את קובץ ההפעלה"
 
 msgctxt "#30655"
 msgid "Season files"
-msgstr ""
+msgstr "את קובצי העונה"
 
 msgctxt "#30656"
 msgid "All files"
-msgstr ""
+msgstr "את כל הקבצים"
 
 msgctxt "#30657"
 msgid "Disable LSD"
-msgstr ""
+msgstr "השבת LSD"
 
 msgctxt "#30658"
 msgid "Add extra trackers"
-msgstr ""
+msgstr "הוסף טראקרים נוספים"
 
 msgctxt "#30659"
 msgid "All known trackers"
-msgstr ""
+msgstr "כל הטראקרים הידועים"
 
 msgctxt "#30660"
 msgid "Best trackers"
-msgstr ""
+msgstr "הטראקרים הטובים ביותר"
 
 msgctxt "#30661"
 msgid "Minimum set"
-msgstr ""
+msgstr "ערכה מינימלית"
 
 msgctxt "#30662"
 msgid "Remove original trackers from torrent"
-msgstr ""
+msgstr "הסר את הטראקרים המקוריים מהטורנט"
 
 msgctxt "#30663"
 msgid "Show episodes on release day (w/o delay)"
-msgstr ""
+msgstr "הצג פרקים ביום היציאה (ללא עיכוב)"
 
 msgctxt "#30664"
 msgid "Modify trackers in torrent"
-msgstr ""
+msgstr "שנה את הטראקרים בטורנט"
 
 msgctxt "#30665"
 msgid "At the time of adding"
-msgstr ""
+msgstr "בעת ההוספה"
 
 msgctxt "#30666"
 msgid "Every time"
-msgstr ""
+msgstr "בכל פעם"
 
 msgctxt "#30667"
 msgid "Mark as watched in Trakt"
-msgstr ""
+msgstr "סמן כנצפה ב-Trakt"
 
 msgctxt "#30668"
 msgid "Mark as unwatched in Trakt"
-msgstr ""
+msgstr "סמן כלא נצפה ב-Trakt"
 
 msgctxt "#30669"
 msgid "Delay addon startup, seconds"
-msgstr ""
+msgstr "עכב את הפעלת התוסף, שניות"
 
 msgctxt "#30670"
 msgid "Downloading required binary file for '%s'"
-msgstr ""
+msgstr "מוריד את הקובץ הבינארי הנדרש עבור '%s'"
 
 msgctxt "#30671"
 msgid "List of Opennic DNS IPs"
-msgstr ""
+msgstr "רשימת כתובות ה-IP של שרתי ה-DNS של OpenNIC"
 
 msgctxt "#30672"
 msgid "Compact database"
-msgstr ""
+msgstr "כווץ את מסד הנתונים"
 
 msgctxt "#30673"
 msgid "Compact cache database"
-msgstr ""
+msgstr "כווץ את מסד הנתונים של המטמון"
 
 msgctxt "#30674"
 msgid "Database was compacted"
-msgstr ""
+msgstr "מסד הנתונים כווץ"
 
 msgctxt "#30675"
 msgid "Remote host login"
-msgstr ""
+msgstr "שם משתמש של המארח המרוחק"
 
 msgctxt "#30676"
 msgid "Remote host password"
-msgstr ""
+msgstr "סיסמה של המארח המרוחק"
 
 msgctxt "#30677"
 msgid "Force start as a library"
-msgstr ""
+msgstr "אלץ הפעלה כספרייה"
 
 msgctxt "#30678"
 msgid "Remove from Kodi library, when movie is deleted from Trakt"
-msgstr ""
+msgstr "הסר מספריית Kodi כאשר הסרט נמחק מ-Trakt"
 
 msgctxt "#30679"
 msgid "Remove from Kodi library, when show is deleted from Trakt"
-msgstr ""
+msgstr "הסר מספריית Kodi כאשר הסדרה נמחקת מ-Trakt"
 
 msgctxt "#30680"
 msgid "Remove Elementum duplicates from library"
-msgstr ""
+msgstr "הסר כפילויות של Elementum מהספרייה"
 
 msgctxt "#30681"
 msgid "[B]Found duplicates in Kodi library:[/B][CR]Movies: [B]%s[/B], Shows: [B]%s[/B], Episodes: [B]%s[/B][CR]Proceed?"
-msgstr ""
+msgstr "[B]נמצאו כפילויות בספריית Kodi:[/B][CR]סרטים: [B]%s[/B], סדרות: [B]%s[/B], פרקים: [B]%s[/B][CR]להמשיך?"
 
 msgctxt "#30682"
 msgid "No duplicates were found in Kodi library"
-msgstr ""
+msgstr "לא נמצאו כפילויות בספריית Kodi"
 
 msgctxt "#30683"
 msgid "Starting library duplicates removal"
-msgstr ""
+msgstr "מתחיל בהסרת הכפילויות מהספרייה"
 
 msgctxt "#30684"
 msgid "Removed Movies: %s, Shows: %s, Episodes: %s"
-msgstr ""
+msgstr "הוסרו - סרטים: %s, סדרות: %s, פרקים: %s"
 
 msgctxt "#30685"
 msgid "Remove movies from Elementum database"
-msgstr ""
+msgstr "הסר את הסרטים ממסד הנתונים של Elementum"
 
 msgctxt "#30686"
 msgid "Remove shows from Elementum database"
-msgstr ""
+msgstr "הסר את הסדרות ממסד הנתונים של Elementum"
 
 msgctxt "#30687"
 msgid "In Elementum library"
-msgstr ""
+msgstr "בספריית Elementum"
 
 msgctxt "#30688"
 msgid "Skip searching for installed Elementum repository"
-msgstr ""
+msgstr "דלג על החיפוש אחר מאגר Elementum המותקן"
 
 msgctxt "#30689"
 msgid "Internal DNS client"
-msgstr ""
+msgstr "לקוח DNS פנימי"
 
 msgctxt "#30691"
 msgid "Hide watched"
-msgstr ""
+msgstr "הסתר את הנצפים"
 
 msgctxt "#30692"
 msgid "TMDB images quality (affects Kodi performance)"
-msgstr ""
+msgstr "איכות התמונות של TMDB (משפיעה על הביצועים של Kodi)"
 
 msgctxt "#30693"
 msgid "Original"
-msgstr ""
+msgstr "מקורית"
 
 msgctxt "#30694"
 msgid "High"
-msgstr ""
+msgstr "גבוהה"
 
 msgctxt "#30695"
 msgid "Medium"
-msgstr ""
+msgstr "בינונית"
 
 msgctxt "#30696"
 msgid "Low"
-msgstr ""
+msgstr "נמוכה"
 
 msgctxt "#30697"
 msgid "Interface language"
-msgstr ""
+msgstr "שפת הממשק"
 
 msgctxt "#30698"
 msgid "Kodi language"
-msgstr ""
+msgstr "שפת Kodi"
 
 msgctxt "#30699"
 msgid "Use earliest release date for progress and calendars"
-msgstr ""
+msgstr "השתמש בתאריך היציאה המוקדם ביותר עבור ההתקדמות והלוחות"
 
 msgctxt "#30700"
 msgid "Interface fallback language"
-msgstr ""
+msgstr "שפת גיבוי לממשק"
 
 msgctxt "#30701"
 msgid "English | en"
-msgstr ""
+msgstr "אנגלית | en"
 
 msgctxt "#30702"
 msgid "Reached daily limit for subtitles downloads"
-msgstr ""
+msgstr "הגעת למגבלה היומית של הורדות כתוביות"
 
 msgctxt "#30703"
 msgid "Can be used by search providers or [CR]for debugging"
-msgstr ""
+msgstr "ניתן לשימוש על ידי ספקי החיפוש או [CR]לניפוי שגיאות"
 
 msgctxt "#30704"
 msgid "TMDB API Key check failed, cannot use TMDB service"
-msgstr ""
+msgstr "בדיקת מפתח ה-API של TMDB נכשלה, לא ניתן להשתמש בשירות TMDB"
 
 msgctxt "#30705"
 msgid "TMDB API accessibility check failed, cannot use TMDB service"
-msgstr ""
+msgstr "בדיקת הנגישות של ה-API של TMDB נכשלה, לא ניתן להשתמש בשירות TMDB"
 
 msgctxt "#30706"
 msgid "Transmission 4.05"
-msgstr ""
+msgstr "Transmission 4.05"
 
 msgctxt "#30707"
 msgid "qBittorrent 3.3.9"
-msgstr ""
+msgstr "qBittorrent 3.3.9"
 
 msgctxt "#30708"
 msgid "qBittorrent 4.6.4"
-msgstr ""
+msgstr "qBittorrent 4.6.4"
 
 msgctxt "#30709"
 msgid "Open [B]%s[/B]"
-msgstr ""
+msgstr "פתח את [B]%s[/B]"
 
 msgctxt "#30710"
 msgid "BitTorrent ports"
-msgstr ""
+msgstr "פורטים של BitTorrent"
 
 msgctxt "#30711"
 msgid "Delete torrent '%s'?"
-msgstr ""
+msgstr "למחוק את הטורנט '%s'?"
 
 msgctxt "#30712"
 msgid "Force to always use proxy, can break download in some cases"
-msgstr ""
+msgstr "אלץ שימוש קבוע ב-proxy, במקרים מסוימים עלול לשבש את ההורדה"
 
 msgctxt "#30713"
 msgid "Disable NATPMP"
-msgstr ""
+msgstr "השבת NATPMP"
 
 msgctxt "#30714"
 msgid "Re-check torrent's data"
-msgstr ""
+msgstr "בדוק שוב את נתוני הטורנט"
 
 msgctxt "#30715"
 msgid "Antizapret PAC file URL"
-msgstr ""
+msgstr "כתובת ה-URL של קובץ ה-PAC של Antizapret"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "שרת DNS over HTTPS"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "שרת DNS over HTTPS מותאם אישית"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "השתמש בשרתי ה-DNS של OpenNIC"

--- a/resources/language/Hungarian/strings.po
+++ b/resources/language/Hungarian/strings.po
@@ -23,7 +23,7 @@ msgstr "Általános"
 
 msgctxt "#30001"
 msgid "Download path"
-msgstr ""
+msgstr "Letöltési útvonal"
 
 msgctxt "#30004"
 msgid "Max upload rate, kB/s"
@@ -111,7 +111,7 @@ msgstr "Kapcsolatszám korlátozás"
 
 msgctxt "#30028"
 msgid "Download after play was stopped"
-msgstr ""
+msgstr "Letöltés folytatása a lejátszás leállítása után"
 
 msgctxt "#30029"
 msgid "Session saving frequency, seconds"
@@ -235,7 +235,7 @@ msgstr "Könyvtár frissítési időköz (órákban)"
 
 msgctxt "#30063"
 msgid "Disable UPNP"
-msgstr ""
+msgstr "UPNP letiltása"
 
 msgctxt "#30064"
 msgid "Encryption policy"
@@ -275,47 +275,47 @@ msgstr "User agent átejtés (nagyon nem ajánlott)"
 
 msgctxt "#30075"
 msgid "Default advisable (acceptable)"
-msgstr ""
+msgstr "Alapértelmezett ajánlott (elfogadható)"
 
 msgctxt "#30076"
 msgid "libtorrent (Rasterbar) 1.1.0"
-msgstr ""
+msgstr "libtorrent (Rasterbar) 1.1.0"
 
 msgctxt "#30077"
 msgid "BitTorrent 7.5.0"
-msgstr ""
+msgstr "BitTorrent 7.5.0"
 
 msgctxt "#30078"
 msgid "BitTorrent 7.9.9"
-msgstr ""
+msgstr "BitTorrent 7.9.9"
 
 msgctxt "#30079"
 msgid "µTorrent 3.5.5"
-msgstr ""
+msgstr "µTorrent 3.5.5"
 
 msgctxt "#30080"
 msgid "µTorrent 3.6.0"
-msgstr ""
+msgstr "µTorrent 3.6.0"
 
 msgctxt "#30081"
 msgid "µTorrent 2.2.1"
-msgstr ""
+msgstr "µTorrent 2.2.1"
 
 msgctxt "#30082"
 msgid "Transmission 2.92"
-msgstr ""
+msgstr "Transmission 2.92"
 
 msgctxt "#30083"
 msgid "Deluge 1.3.6"
-msgstr ""
+msgstr "Deluge 1.3.6"
 
 msgctxt "#30084"
 msgid "Deluge 2.1.1"
-msgstr ""
+msgstr "Deluge 2.1.1"
 
 msgctxt "#30085"
 msgid "Vuze 5.7.3.0"
-msgstr ""
+msgstr "Vuze 5.7.3.0"
 
 msgctxt "#30086"
 msgid "Enable tuned storage settings"
@@ -364,7 +364,7 @@ msgstr "Válasszon fájlt vagy URL-t"
 
 msgctxt "#30105"
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 msgctxt "#30106"
 msgid "File"
@@ -380,7 +380,7 @@ msgstr "Fájl elérési útvonala"
 
 msgctxt "#30109"
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 msgctxt "#30110"
 msgid "Crashed too many times, aborting..."
@@ -412,11 +412,11 @@ msgstr "Trackerek scrappelése..."
 
 msgctxt "#30119"
 msgid "ID of selected userlist for movies"
-msgstr ""
+msgstr "A kiválasztott felhasználói lista azonosítója filmekhez"
 
 msgctxt "#30120"
 msgid "ID of selected userlist for shows"
-msgstr ""
+msgstr "A kiválasztott felhasználói lista azonosítója sorozatokhoz"
 
 msgctxt "#30141"
 msgid "Please support Elementum development by visiting[CR]https://elementum.surge.sh/donate/ or https://elementumorg.github.io/donate/"
@@ -509,7 +509,7 @@ msgstr "Legtöbb szavazatot kapott"
 
 msgctxt "#30213"
 msgid "IMDB Top 250"
-msgstr ""
+msgstr "IMDB Top 250"
 
 msgctxt "#30214"
 msgid "Movies"
@@ -713,7 +713,7 @@ msgstr "%s eltávolítva a könyvtárából. Szeretné megtisztítani a könytá
 
 msgctxt "#30279"
 msgid "Video %s was previously removed from library.[CR]Force adding?"
-msgstr ""
+msgstr "A(z) %s videó korábban el lett távolítva a médiatárból.[CR]Kényszerítve hozzáadod?"
 
 msgctxt "#30282"
 msgid "Nothing left to remove from Elementum"
@@ -765,7 +765,7 @@ msgstr "Összes film"
 
 msgctxt "#30294"
 msgid "All Releases"
-msgstr ""
+msgstr "Összes megjelenés"
 
 msgctxt "#30295"
 msgid "My Shows"
@@ -825,1480 +825,1480 @@ msgstr "Átmozgatás befejezve!"
 
 msgctxt "#30309"
 msgid "Keep"
-msgstr ""
+msgstr "Megtartás"
 
 msgctxt "#30310"
 msgid "Ask to delete"
-msgstr ""
+msgstr "Rákérdezés törlés előtt"
 
 msgctxt "#30311"
 msgid "Delete"
-msgstr ""
+msgstr "Törlés"
 
 msgctxt "#30312"
 msgid "Keep files for not finished video"
-msgstr ""
+msgstr "Befejezetlen videók fájljainak megtartása"
 
 msgctxt "#30313"
 msgid "Keep files for watched/downloaded video"
-msgstr ""
+msgstr "Megtekintett/letöltött videók fájljainak megtartása"
 
 msgctxt "#30314"
 msgid "Settings were not initialized.[CR]Save addon settings, then restart Kodi."
-msgstr ""
+msgstr "A beállítások nem lettek inicializálva.[CR]Mentsd el a kiegészítő beállításait, majd indítsd újra a Kodit."
 
 msgctxt "#30315"
 msgid "Download storage type"
-msgstr ""
+msgstr "Letöltések tárolási típusa"
 
 msgctxt "#30316"
 msgid "Use files"
-msgstr ""
+msgstr "Fájlok használata"
 
 msgctxt "#30317"
 msgid "Use memory"
-msgstr ""
+msgstr "Memória használata"
 
 msgctxt "#30318"
 msgid "Memory size to use for each torrent, Mb"
-msgstr ""
+msgstr "Torrentenként használt memória, MB"
 
 msgctxt "#30319"
 msgid "Continue"
-msgstr ""
+msgstr "Folytatás"
 
 msgctxt "#30320"
 msgid "Ask to stop"
-msgstr ""
+msgstr "Rákérdezés leállítás előtt"
 
 msgctxt "#30321"
 msgid "Stop"
-msgstr ""
+msgstr "Leállítás"
 
 msgctxt "#30323"
 msgid "New search"
-msgstr ""
+msgstr "Új keresés"
 
 msgctxt "#30324"
 msgid "Force stream auto-selection from settings"
-msgstr ""
+msgstr "Automatikus adatfolyam-választás kényszerítése a beállításokból"
 
 msgctxt "#30325"
 msgid "Download"
-msgstr ""
+msgstr "Letöltés"
 
 msgctxt "#30326"
 msgid "Kodi library"
-msgstr ""
+msgstr "Kodi médiatár"
 
 msgctxt "#30327"
 msgid "Storage"
-msgstr ""
+msgstr "Tárolás"
 
 msgctxt "#30328"
 msgid "Disable TCP"
-msgstr ""
+msgstr "TCP letiltása"
 
 msgctxt "#30329"
 msgid "Disable UTP"
-msgstr ""
+msgstr "UTP letiltása"
 
 msgctxt "#30330"
 msgid "Update Trakt"
-msgstr ""
+msgstr "Trakt frissítése"
 
 msgctxt "#30332"
 msgid "Reloading configuration..."
-msgstr ""
+msgstr "Konfiguráció újratöltése..."
 
 msgctxt "#30333"
 msgid "Try to find other episodes in the torrent"
-msgstr ""
+msgstr "Próbálja megkeresni a többi epizódot a torrentben"
 
 msgctxt "#30347"
 msgid "Could not find binary for architecture '%s'![CR]Try to uninstall this addon, re-download and re-install it from the biggest zip."
-msgstr ""
+msgstr "Nem található bináris fájl a(z) '%s' architektúrához![CR]Próbáld eltávolítani ezt a kiegészítőt, letölteni újra, és a legnagyobb zip-ből telepíteni."
 
 msgctxt "#30348"
 msgid "Create usual files on the file system and write to them.[CR]Needs selected file's full size to be available on the disk!"
-msgstr ""
+msgstr "Szokásos fájlokat hoz létre a fájlrendszeren, és azokba ír.[CR]A kiválasztott fájl teljes méretének elérhetőnek kell lennie a lemezen!"
 
 msgctxt "#30349"
 msgid "Using device's memory to download parts of the torrent.[CR]Disk is used only to download and save .torrent file,"
-msgstr ""
+msgstr "Az eszköz memóriáját használja a torrent részeinek letöltéséhez.[CR]A lemezt csak a .torrent fájl letöltésére és mentésére használja,"
 
 msgctxt "#30350"
 msgid "so can be any storage. For 1gb memory devices[CR]100mb is enough for memory storage, 200-250mb for bigger devices."
-msgstr ""
+msgstr "így bármilyen tároló lehet. 1 GB memóriájú eszközökhöz[CR]100 MB elég, nagyobb eszközökhöz 200-250 MB."
 
 msgctxt "#30351"
 msgid "Same as for usual file storage, but splits file into many small files.[CR]Should be used on FAT-32 file-systems."
-msgstr ""
+msgstr "Ugyanaz, mint a szokásos fájltárolás, de sok kis fájlra bontja a fájlt.[CR]FAT-32 fájlrendszereken érdemes használni."
 
 msgctxt "#30352"
 msgid "Same as for usual file storage, but using memory[CR]to lower filesystem operations. Experimental storage!"
-msgstr ""
+msgstr "Ugyanaz, mint a szokásos fájltárolás, de memóriát használ[CR]a fájlrendszer-műveletek csökkentésére. Kísérleti tároló!"
 
 msgctxt "#30355"
 msgid "Changelog"
-msgstr ""
+msgstr "Változásnapló"
 
 msgctxt "#30357"
 msgid "Use Trakt information in Trakt lists"
-msgstr ""
+msgstr "Trakt-információk használata a Trakt listákban"
 
 msgctxt "#30358"
 msgid "Trakt update started"
-msgstr ""
+msgstr "Trakt frissítés elindult"
 
 msgctxt "#30359"
 msgid "Do not ask questions before playback"
-msgstr ""
+msgstr "Ne tegyen fel kérdéseket a lejátszás előtt"
 
 msgctxt "#30360"
 msgid "My Progress"
-msgstr ""
+msgstr "Haladásom"
 
 msgctxt "#30361"
 msgid "My History"
-msgstr ""
+msgstr "Előzményeim"
 
 msgctxt "#30362"
 msgid "Synchronization"
-msgstr ""
+msgstr "Szinkronizálás"
 
 msgctxt "#30363"
 msgid "Sync items from collections into Kodi library"
-msgstr ""
+msgstr "Gyűjtemények elemeinek szinkronizálása a Kodi médiatárba"
 
 msgctxt "#30364"
 msgid "Sync items from watchlist into Kodi library"
-msgstr ""
+msgstr "A figyelőlista elemeinek szinkronizálása a Kodi médiatárba"
 
 msgctxt "#30365"
 msgid "Sync items from user lists into Kodi library"
-msgstr ""
+msgstr "Felhasználói listák elemeinek szinkronizálása a Kodi médiatárba"
 
 msgctxt "#30366"
 msgid "Sync watched states from Trakt into Kodi library"
-msgstr ""
+msgstr "Megtekintett állapotok szinkronizálása a Traktból a Kodi médiatárba"
 
 msgctxt "#30367"
 msgid "Sync back Kodi watched states into Trakt"
-msgstr ""
+msgstr "A Kodi megtekintett állapotainak visszaszinkronizálása a Traktba"
 
 msgctxt "#30369"
 msgid "Disable Upload"
-msgstr ""
+msgstr "Feltöltés letiltása"
 
 msgctxt "#30370"
 msgid "Auto-assign network IP"
-msgstr ""
+msgstr "Hálózati IP automatikus hozzárendelése"
 
 msgctxt "#30371"
 msgid "Auto-assign network ports"
-msgstr ""
+msgstr "Hálózati portok automatikus hozzárendelése"
 
 msgctxt "#30373"
 msgid "Languages"
-msgstr ""
+msgstr "Nyelvek"
 
 msgctxt "#30374"
 msgid "Countries"
-msgstr ""
+msgstr "Országok"
 
 msgctxt "#30375"
 msgid "By size"
-msgstr ""
+msgstr "Méret szerint"
 
 msgctxt "#30376"
 msgid "Choose memory size automatically"
-msgstr ""
+msgstr "Memóriaméret automatikus kiválasztása"
 
 msgctxt "#30377"
 msgid "Size is chosen automatically, based on[CR]physical amount of memory"
-msgstr ""
+msgstr "A méret automatikusan kerül kiválasztásra a[CR]rendelkezésre álló fizikai memória alapján"
 
 msgctxt "#30378"
 msgid "Allow memory usage"
-msgstr ""
+msgstr "Memóriahasználat engedélyezése"
 
 msgctxt "#30379"
 msgid "Minimum - 40MB, Default - 8%, Maximum - 15%"
-msgstr ""
+msgstr "Minimum - 40 MB, Alapértelmezett - 8%, Maximum - 15%"
 
 msgctxt "#30380"
 msgid "Minimum"
-msgstr ""
+msgstr "Minimum"
 
 msgctxt "#30381"
 msgid "Default"
-msgstr ""
+msgstr "Alapértelmezett"
 
 msgctxt "#30382"
 msgid "Maximum"
-msgstr ""
+msgstr "Maximum"
 
 msgctxt "#30383"
 msgid "Use Kodi language for subtitles search"
-msgstr ""
+msgstr "A Kodi nyelvének használata a feliratkereséshez"
 
 msgctxt "#30384"
 msgid "Language code for subtitles (example: en, it, es)"
-msgstr ""
+msgstr "Feliratok nyelvi kódja (például: en, it, es)"
 
 msgctxt "#30386"
 msgid "Disable background progress dialog on playback"
-msgstr ""
+msgstr "Háttérben futó folyamatjelző letiltása lejátszás közben"
 
 msgctxt "#30387"
 msgid "Caching"
-msgstr ""
+msgstr "Gyorsítótárazás"
 
 msgctxt "#30388"
 msgid "Cache stream selection"
-msgstr ""
+msgstr "Adatfolyam-választás gyorsítótárazása"
 
 msgctxt "#30389"
 msgid "Cache stream search results"
-msgstr ""
+msgstr "Adatfolyam-keresési eredmények gyorsítótárazása"
 
 msgctxt "#30390"
 msgid "Cache search results duration, seconds"
-msgstr ""
+msgstr "Keresési eredmények gyorsítótárazásának időtartama, másodperc"
 
 msgctxt "#30393"
 msgid "Status"
-msgstr ""
+msgstr "Állapot"
 
 msgctxt "#30394"
 msgid "Version"
-msgstr ""
+msgstr "Verzió"
 
 msgctxt "#30395"
 msgid "IP address"
-msgstr ""
+msgstr "IP-cím"
 
 msgctxt "#30396"
 msgid "Port"
-msgstr ""
+msgstr "Port"
 
 msgctxt "#30397"
 msgid "Web UI"
-msgstr ""
+msgstr "Webes felület"
 
 msgctxt "#30398"
 msgid "Debug information (with kodi.log)"
-msgstr ""
+msgstr "Hibakeresési információk (kodi.log fájllal)"
 
 msgctxt "#30399"
 msgid "Addresses"
-msgstr ""
+msgstr "Címek"
 
 msgctxt "#30400"
 msgid "Statistics"
-msgstr ""
+msgstr "Statisztikák"
 
 msgctxt "#30401"
 msgid "Torrent library status"
-msgstr ""
+msgstr "A torrent könyvtár állapota"
 
 msgctxt "#30402"
 msgid "Size of cache.db"
-msgstr ""
+msgstr "A cache.db mérete"
 
 msgctxt "#30403"
 msgid "Size of app.db"
-msgstr ""
+msgstr "Az app.db mérete"
 
 msgctxt "#30404"
 msgid "Assigned torrent files"
-msgstr ""
+msgstr "Hozzárendelt torrent fájlok"
 
 msgctxt "#30405"
 msgid "Search queries"
-msgstr ""
+msgstr "Keresési lekérdezések"
 
 msgctxt "#30406"
 msgid "Remove from history"
-msgstr ""
+msgstr "Eltávolítás az előzményekből"
 
 msgctxt "#30408"
 msgid "Addon Connectivity"
-msgstr ""
+msgstr "Kiegészítő kapcsolat"
 
 msgctxt "#30409"
 msgid "Local port"
-msgstr ""
+msgstr "Helyi port"
 
 msgctxt "#30410"
 msgid "Remote port"
-msgstr ""
+msgstr "Távoli port"
 
 msgctxt "#30411"
 msgid "Remote host"
-msgstr ""
+msgstr "Távoli kiszolgáló"
 
 msgctxt "#30412"
 msgid "Do not start binary (client mode)"
-msgstr ""
+msgstr "Ne indítsa el a bináris fájlt (kliens mód)"
 
 msgctxt "#30413"
 msgid "Yes"
-msgstr ""
+msgstr "Igen"
 
 msgctxt "#30414"
 msgid "No"
-msgstr ""
+msgstr "Nem"
 
 msgctxt "#30415"
 msgid "Next page (%s)"
-msgstr ""
+msgstr "Következő oldal (%s)"
 
 msgctxt "#30416"
 msgid "Percents of playback to mark as watched"
-msgstr ""
+msgstr "A lejátszás hány százalékánál jelölje megtekintettnek"
 
 msgctxt "#30417"
 msgid "Use name of production company as Studio for shows"
-msgstr ""
+msgstr "A gyártó cég nevének használata stúdióként a sorozatoknál"
 
 msgctxt "#30418"
 msgid "Calculate number of unwatched episodes in Shows/Seasons"
-msgstr ""
+msgstr "A meg nem tekintett epizódok számának kiszámítása a sorozatoknál/évadoknál"
 
 msgctxt "#30421"
 msgid "Load torrents from torrents folder on startup"
-msgstr ""
+msgstr "Torrentek betöltése a torrents mappából indításkor"
 
 msgctxt "#30422"
 msgid "Popular lists"
-msgstr ""
+msgstr "Népszerű listák"
 
 msgctxt "#30423"
 msgid "Recommendations"
-msgstr ""
+msgstr "Ajánlások"
 
 msgctxt "#30424"
 msgid "Progress"
-msgstr ""
+msgstr "Haladás"
 
 msgctxt "#30425"
 msgid "Color of an air date"
-msgstr ""
+msgstr "A sugárzás dátumának színe"
 
 msgctxt "#30426"
 msgid "Color of a show name"
-msgstr ""
+msgstr "A sorozat nevének színe"
 
 msgctxt "#30427"
 msgid "Color of an episode name"
-msgstr ""
+msgstr "Az epizód nevének színe"
 
 msgctxt "#30428"
 msgid "Hide unaired episodes"
-msgstr ""
+msgstr "Le nem adott epizódok elrejtése"
 
 msgctxt "#30429"
 msgid "Sort shows in the list"
-msgstr ""
+msgstr "Sorozatok rendezése a listában"
 
 msgctxt "#30430"
 msgid "By latest watched"
-msgstr ""
+msgstr "Legutóbb megtekintett szerint"
 
 msgctxt "#30431"
 msgid "By show name"
-msgstr ""
+msgstr "Sorozat neve szerint"
 
 msgctxt "#30432"
 msgid "By air date (newer)"
-msgstr ""
+msgstr "Sugárzás dátuma szerint (újabb)"
 
 msgctxt "#30433"
 msgid "By air date (older)"
-msgstr ""
+msgstr "Sugárzás dátuma szerint (régebbi)"
 
 msgctxt "#30434"
 msgid "Date format"
-msgstr ""
+msgstr "Dátumformátum"
 
 msgctxt "#30436"
 msgid "Userlist"
-msgstr ""
+msgstr "Felhasználói lista"
 
 msgctxt "#30438"
 msgid "Userlists"
-msgstr ""
+msgstr "Felhasználói listák"
 
 msgctxt "#30439"
 msgid "Debug information (without kodi.log)"
-msgstr ""
+msgstr "Hibakeresési információk (kodi.log nélkül)"
 
 msgctxt "#30440"
 msgid "Color of an unaired episode name"
-msgstr ""
+msgstr "Egy le nem adott epizód nevének színe"
 
 msgctxt "#30441"
 msgid "Select userlist for movies"
-msgstr ""
+msgstr "Felhasználói lista kiválasztása filmekhez"
 
 msgctxt "#30442"
 msgid "Userlist for movies"
-msgstr ""
+msgstr "Felhasználói lista filmekhez"
 
 msgctxt "#30443"
 msgid "Selected userlist for movies"
-msgstr ""
+msgstr "Kiválasztott felhasználói lista filmekhez"
 
 msgctxt "#30444"
 msgid "Select userlist for shows"
-msgstr ""
+msgstr "Felhasználói lista kiválasztása sorozatokhoz"
 
 msgctxt "#30445"
 msgid "Userlist for shows"
-msgstr ""
+msgstr "Felhasználói lista sorozatokhoz"
 
 msgctxt "#30446"
 msgid "Selected userlist for shows"
-msgstr ""
+msgstr "Kiválasztott felhasználói lista sorozatokhoz"
 
 msgctxt "#30447"
 msgid "Add to Trakt, when movie is added to Kodi library"
-msgstr ""
+msgstr "Hozzáadás a Trakthoz, amikor egy film bekerül a Kodi médiatárba"
 
 msgctxt "#30448"
 msgid "Add to Trakt, when show is added to Kodi library"
-msgstr ""
+msgstr "Hozzáadás a Trakthoz, amikor egy sorozat bekerül a Kodi médiatárba"
 
 msgctxt "#30449"
 msgid "Remove from Trakt, when movie is deleted from Kodi library"
-msgstr ""
+msgstr "Eltávolítás a Traktból, amikor egy filmet törölnek a Kodi médiatárból"
 
 msgctxt "#30450"
 msgid "Remove from Trakt, when show is deleted from Kodi library"
-msgstr ""
+msgstr "Eltávolítás a Traktból, amikor egy sorozatot törölnek a Kodi médiatárból"
 
 msgctxt "#30451"
 msgid "Torrent files path"
-msgstr ""
+msgstr "Torrent fájlok útvonala"
 
 msgctxt "#30452"
 msgid "Reset all paths"
-msgstr ""
+msgstr "Összes útvonal visszaállítása"
 
 msgctxt "#30453"
 msgid "Upload /debug/bundle (with kodi.log) to pastebin"
-msgstr ""
+msgstr "A /debug/bundle feltöltése (kodi.log fájllal) a pastebinre"
 
 msgctxt "#30454"
 msgid "Paste url:[CR]%s"
-msgstr ""
+msgstr "Paste URL:[CR]%s"
 
 msgctxt "#30455"
 msgid "Logging"
-msgstr ""
+msgstr "Naplózás"
 
 msgctxt "#30456"
 msgid "Upload /debug/all (no kodi.log) to pastebin"
-msgstr ""
+msgstr "A /debug/all feltöltése (kodi.log nélkül) a pastebinre"
 
 msgctxt "#30457"
 msgid "Uploading file to pastebin"
-msgstr ""
+msgstr "Fájl feltöltése a pastebinre"
 
 msgctxt "#30458"
 msgid "Deleted movies"
-msgstr ""
+msgstr "Törölt filmek"
 
 msgctxt "#30459"
 msgid "Deleted shows"
-msgstr ""
+msgstr "Törölt sorozatok"
 
 msgctxt "#30460"
 msgid "Database"
-msgstr ""
+msgstr "Adatbázis"
 
 msgctxt "#30461"
 msgid "Show information"
-msgstr ""
+msgstr "Információk megjelenítése"
 
 msgctxt "#30462"
 msgid "Clear deleted movies"
-msgstr ""
+msgstr "Törölt filmek tisztítása"
 
 msgctxt "#30463"
 msgid "Clear deleted shows"
-msgstr ""
+msgstr "Törölt sorozatok tisztítása"
 
 msgctxt "#30464"
 msgid "Clear torrents history"
-msgstr ""
+msgstr "Torrent előzmények törlése"
 
 msgctxt "#30465"
 msgid "Clear search history"
-msgstr ""
+msgstr "Keresési előzmények törlése"
 
 msgctxt "#30466"
 msgid "Clear the database"
-msgstr ""
+msgstr "Az adatbázis törlése"
 
 msgctxt "#30467"
 msgid "Cache"
-msgstr ""
+msgstr "Gyorsítótár"
 
 msgctxt "#30468"
 msgid "Clear TMDB cache"
-msgstr ""
+msgstr "TMDB gyorsítótár ürítése"
 
 msgctxt "#30469"
 msgid "Clear Trakt cache"
-msgstr ""
+msgstr "Trakt gyorsítótár ürítése"
 
 msgctxt "#30470"
 msgid "Clear the cache"
-msgstr ""
+msgstr "A gyorsítótár ürítése"
 
 msgctxt "#30471"
 msgid "Are you sure you want to do it?"
-msgstr ""
+msgstr "Biztosan ezt szeretnéd tenni?"
 
 msgctxt "#30472"
 msgid "Database cleared"
-msgstr ""
+msgstr "Az adatbázis törölve"
 
 msgctxt "#30473"
 msgid "Select network interface"
-msgstr ""
+msgstr "Hálózati csatoló kiválasztása"
 
 msgctxt "#30474"
 msgid "Network interfaces"
-msgstr ""
+msgstr "Hálózati csatolók"
 
 msgctxt "#30475"
 msgid "Strm files language"
-msgstr ""
+msgstr "Strm fájlok nyelve"
 
 msgctxt "#30476"
 msgid "Select language"
-msgstr ""
+msgstr "Nyelv kiválasztása"
 
 msgctxt "#30477"
 msgid "Original language"
-msgstr ""
+msgstr "Eredeti nyelv"
 
 msgctxt "#30478"
 msgid "Searching"
-msgstr ""
+msgstr "Keresés"
 
 msgctxt "#30480"
 msgid "Run Kodi library update after add/delete"
-msgstr ""
+msgstr "Kodi médiatár frissítése hozzáadás/törlés után"
 
 msgctxt "#30481"
 msgid "Automatically"
-msgstr ""
+msgstr "Automatikusan"
 
 msgctxt "#30482"
 msgid "Ask"
-msgstr ""
+msgstr "Rákérdezés"
 
 msgctxt "#30483"
 msgid "Create NFO files for Movie scrapers"
-msgstr ""
+msgstr "NFO fájlok létrehozása a filmes adatgyűjtőkhöz"
 
 msgctxt "#30484"
 msgid "Create NFO files for TV Show scrapers"
-msgstr ""
+msgstr "NFO fájlok létrehozása a sorozatos adatgyűjtőkhöz"
 
 msgctxt "#30485"
 msgid "Concurrent connections limit per second"
-msgstr ""
+msgstr "Egyidejű kapcsolatok korlátja másodpercenként"
 
 msgctxt "#30486"
 msgid "Automatic concurrent connections limit per second"
-msgstr ""
+msgstr "Egyidejű kapcsolatok automatikus korlátja másodpercenként"
 
 msgctxt "#30487"
 msgid "Enable built-in HTTP proxy"
-msgstr ""
+msgstr "Beépített HTTP proxy engedélyezése"
 
 msgctxt "#30488"
 msgid "Internal Proxy Port"
-msgstr ""
+msgstr "A belső proxy portja"
 
 msgctxt "#30489"
 msgid "Log Internal proxy requests"
-msgstr ""
+msgstr "A belső proxy kéréseinek naplózása"
 
 msgctxt "#30490"
 msgid "Internal HTTP proxy"
-msgstr ""
+msgstr "Belső HTTP proxy"
 
 msgctxt "#30491"
 msgid "Use Fanart.tv for posters/images"
-msgstr ""
+msgstr "A Fanart.tv használata plakátokhoz/képekhez"
 
 msgctxt "#30492"
 msgid "Use Proxy for downloading .torrent files"
-msgstr ""
+msgstr "Proxy használata a .torrent fájlok letöltéséhez"
 
 msgctxt "#30493"
 msgid "Use Proxy for trackers"
-msgstr ""
+msgstr "Proxy használata a trackerekhez"
 
 msgctxt "#30494"
 msgid "Use Proxy for torrent downloading"
-msgstr ""
+msgstr "Proxy használata a torrentek letöltéséhez"
 
 msgctxt "#30495"
 msgid "Use built-in DNS resolver"
-msgstr ""
+msgstr "A beépített DNS-feloldó használata"
 
 msgctxt "#30496"
 msgid "Turn off if you use Tor addresses, or you want [CR]to use DNS settings from OS"
-msgstr ""
+msgstr "Kapcsold ki, ha Tor címeket használsz, vagy ha [CR]az operációs rendszer DNS-beállításait szeretnéd használni"
 
 msgctxt "#30497"
 msgid "Use Antizapret proxy (only for Russia)"
-msgstr ""
+msgstr "Antizapret proxy használata (csak Oroszországban)"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"
-msgstr ""
+msgstr "Ezen útvonal visszaállítása erre: '/'"
 
 msgctxt "#30499"
 msgid "Automatically adjust memory size[CR]for heavy torrents, if possible"
-msgstr ""
+msgstr "A memóriaméret automatikus igazítása[CR]nagy torrentekhez, ha lehetséges"
 
 msgctxt "#30500"
 msgid "Automatically adjust buffer size[CR]for heavy torrents"
-msgstr ""
+msgstr "A puffer méretének automatikus igazítása[CR]nagy torrentekhez"
 
 msgctxt "#30502"
 msgid "Adjust buffer according to Kodi advancedsettings.xml, if set"
-msgstr ""
+msgstr "A puffer igazítása a Kodi advancedsettings.xml fájljához, ha be van állítva"
 
 msgctxt "#30503"
 msgid "Use libtorrent.config to override torrent engine settings"
-msgstr ""
+msgstr "A libtorrent.config használata a torrent motor beállításainak felülbírálásához"
 
 msgctxt "#30504"
 msgid "Located at USERDATA/plugin.video.elementum/libtorrent.config file[CR]Settings apply automatically. Visit https://libtorrent.org for info."
-msgstr ""
+msgstr "A USERDATA/plugin.video.elementum/libtorrent.config fájlban található[CR]A beállítások automatikusan érvénybe lépnek. Információkért látogasd meg a https://libtorrent.org oldalt."
 
 msgctxt "#30505"
 msgid "Add episode number to the title"
-msgstr ""
+msgstr "Epizódszám hozzáadása a címhez"
 
 msgctxt "#30506"
 msgid "Enable libtorrent logging"
-msgstr ""
+msgstr "A libtorrent naplózásának engedélyezése"
 
 msgctxt "#30511"
 msgid "Libtorrent settings profile"
-msgstr ""
+msgstr "libtorrent beállítási profil"
 
 msgctxt "#30512"
 msgid "Default"
-msgstr ""
+msgstr "Alapértelmezett"
 
 msgctxt "#30513"
 msgid "Minimal memory"
-msgstr ""
+msgstr "Minimális memória"
 
 msgctxt "#30514"
 msgid "High speed"
-msgstr ""
+msgstr "Nagy sebesség"
 
 msgctxt "#30515"
 msgid "Load torrents from torrents folder paused"
-msgstr ""
+msgstr "Torrentek betöltése szüneteltetve a torrents mappából"
 
 msgctxt "#30516"
 msgid "... resume N seconds earlier"
-msgstr ""
+msgstr "... folytatás N másodperccel korábban"
 
 msgctxt "#30517"
 msgid "In Kodi library"
-msgstr ""
+msgstr "A Kodi médiatárban"
 
 msgctxt "#30518"
 msgid "Use libtorrent deadlines"
-msgstr ""
+msgstr "A libtorrent határidőinek használata"
 
 msgctxt "#30519"
 msgid "Use libtorrent pause/resume trick for added torrents"
-msgstr ""
+msgstr "A libtorrent szüneteltetés/folytatás trükkjének használata a hozzáadott torrenteknél"
 
 msgctxt "#30520"
 msgid "Add item to start menu"
-msgstr ""
+msgstr "Elem hozzáadása a kezdőmenühöz"
 
 msgctxt "#30521"
 msgid "Delete item from start menu"
-msgstr ""
+msgstr "Elem törlése a kezdőmenüből"
 
 msgctxt "#30522"
 msgid "Minimum file size"
-msgstr ""
+msgstr "Minimális fájlméret"
 
 msgctxt "#30523"
 msgid "Minimum file size for Movies, MB"
-msgstr ""
+msgstr "Minimális fájlméret filmekhez, MB"
 
 msgctxt "#30524"
 msgid "Minimum file size for Shows, MB per minute"
-msgstr ""
+msgstr "Minimális fájlméret sorozatokhoz, MB percenként"
 
 msgctxt "#30525"
 msgid "Automatically start downloading next episode"
-msgstr ""
+msgstr "A következő epizód letöltésének automatikus indítása"
 
 msgctxt "#30527"
 msgid "Donate"
-msgstr ""
+msgstr "Támogatás"
 
 msgctxt "#30528"
 msgid "Automatically load first found subtitles"
-msgstr ""
+msgstr "Az első megtalált feliratok automatikus betöltése"
 
 msgctxt "#30529"
 msgid "Number of subtitles to load automatically"
-msgstr ""
+msgstr "Automatikusan betöltendő feliratok száma"
 
 msgctxt "#30530"
 msgid "Delete autoloaded subtitles on player stop"
-msgstr ""
+msgstr "Az automatikusan betöltött feliratok törlése a lejátszó leállításakor"
 
 msgctxt "#30531"
 msgid "Download all files from torrent"
-msgstr ""
+msgstr "Az összes fájl letöltése a torrentből"
 
 msgctxt "#30532"
 msgid "Stop Downloading all files"
-msgstr ""
+msgstr "Az összes fájl letöltésének leállítása"
 
 msgctxt "#30535"
 msgid "Continue playback from [B]%s[/B]?"
-msgstr ""
+msgstr "Folytatod a lejátszást innen: [B]%s[/B]?"
 
 msgctxt "#30536"
 msgid "Skip IPv6 addresses resolving"
-msgstr ""
+msgstr "IPv6 címek feloldásának kihagyása"
 
 msgctxt "#30537"
 msgid "Torrents history"
-msgstr ""
+msgstr "Torrent előzmények"
 
 msgctxt "#30538"
 msgid "Use torrents history?"
-msgstr ""
+msgstr "Használod a torrent előzményeket?"
 
 msgctxt "#30539"
 msgid "Store N torrents in history"
-msgstr ""
+msgstr "N torrent tárolása az előzményekben"
 
 msgctxt "#30540"
 msgid "Subtitles"
-msgstr ""
+msgstr "Feliratok"
 
 msgctxt "#30541"
 msgid "Automatic Subtitles Search"
-msgstr ""
+msgstr "Automatikus feliratkeresés"
 
 msgctxt "#30542"
 msgid "Disable if subtitles are available in player"
-msgstr ""
+msgstr "Tiltsd le, ha a feliratok elérhetők a lejátszóban"
 
 msgctxt "#30543"
 msgid "Subtitles included in torrent"
-msgstr ""
+msgstr "A torrentben található feliratok"
 
 msgctxt "#30544"
 msgid "Automatic Scrape"
-msgstr ""
+msgstr "Automatikus gyűjtés"
 
 msgctxt "#30545"
 msgid "Automatic scraping allows to scrape connected providers[CR]to find new movies, if there are results,"
-msgstr ""
+msgstr "Az automatikus gyűjtés lehetővé teszi a csatlakoztatott szolgáltatókban[CR]új filmek keresését. Ha vannak találatok"
 
 msgctxt "#30546"
 msgid "Strategy"
-msgstr ""
+msgstr "Stratégia"
 
 msgctxt "#30547"
 msgid "Find in each provider"
-msgstr ""
+msgstr "Keresés minden szolgáltatóban"
 
 msgctxt "#30548"
 msgid "Find in overall"
-msgstr ""
+msgstr "Keresés összesítve"
 
 msgctxt "#30549"
 msgid "Search is successful when found N results"
-msgstr ""
+msgstr "A keresés sikeres, ha N találat van"
 
 msgctxt "#30550"
 msgid "What to search"
-msgstr ""
+msgstr "Mit keressen"
 
 msgctxt "#30551"
 msgid "How to search"
-msgstr ""
+msgstr "Hogyan keressen"
 
 msgctxt "#30552"
 msgid "Search each N hours"
-msgstr ""
+msgstr "Keresés N óránként"
 
 msgctxt "#30553"
 msgid "Find 4K resolution"
-msgstr ""
+msgstr "4K felbontás keresése"
 
 msgctxt "#30554"
 msgid "Find 1080p resolution"
-msgstr ""
+msgstr "1080p felbontás keresése"
 
 msgctxt "#30555"
 msgid "and movie passes checks for number of results[CR]movie can be added to the library."
-msgstr ""
+msgstr "és a film megfelel a találatszám ellenőrzésének,[CR]a film hozzáadható a médiatárhoz."
 
 msgctxt "#30556"
 msgid "Add to the library"
-msgstr ""
+msgstr "Hozzáadás a médiatárhoz"
 
 msgctxt "#30557"
 msgid "Number of popular movies to search"
-msgstr ""
+msgstr "A keresendő népszerű filmek száma"
 
 msgctxt "#30558"
 msgid "Latest available movies"
-msgstr ""
+msgstr "Legújabb elérhető filmek"
 
 msgctxt "#30559"
 msgid "Skip searching for installed providers"
-msgstr ""
+msgstr "A telepített szolgáltatók keresésének kihagyása"
 
 msgctxt "#30560"
 msgid "Files: %s"
-msgstr ""
+msgstr "Fájlok: %s"
 
 msgctxt "#30561"
 msgid "Interval between requests, seconds"
-msgstr ""
+msgstr "Kérések közötti időköz, másodperc"
 
 msgctxt "#30562"
 msgid "Open directory with Kodi file browser"
-msgstr ""
+msgstr "Könyvtár megnyitása a Kodi fájlböngészőjével"
 
 msgctxt "#30563"
 msgid "Synchronize frequency of Trakt, minutes"
-msgstr ""
+msgstr "A Trakt szinkronizálásának gyakorisága, perc"
 
 msgctxt "#30564"
 msgid "Sync hidden items"
-msgstr ""
+msgstr "Rejtett elemek szinkronizálása"
 
 msgctxt "#30565"
 msgid "Sync playback progress into Kodi library"
-msgstr ""
+msgstr "A lejátszási haladás szinkronizálása a Kodi médiatárba"
 
 msgctxt "#30566"
 msgid "Lists"
-msgstr ""
+msgstr "Listák"
 
 msgctxt "#30567"
 msgid "Show \"All seasons\" in shows"
-msgstr ""
+msgstr "A \"Minden évad\" megjelenítése a sorozatoknál"
 
 msgctxt "#30568"
 msgid "Seasons order"
-msgstr ""
+msgstr "Évadok sorrendje"
 
 msgctxt "#30569"
 msgid "Ascending"
-msgstr ""
+msgstr "Növekvő"
 
 msgctxt "#30570"
 msgid "Descending"
-msgstr ""
+msgstr "Csökkenő"
 
 msgctxt "#30571"
 msgid "* All seasons"
-msgstr ""
+msgstr "* Minden évad"
 
 msgctxt "#30572"
 msgid "Log server's response body"
-msgstr ""
+msgstr "A kiszolgáló válaszának törzsét naplózza"
 
 msgctxt "#30573"
 msgid "Select file to play"
-msgstr ""
+msgstr "Válaszd ki a lejátszandó fájlt"
 
 msgctxt "#30574"
 msgid "Automatically answer Yes after timeout"
-msgstr ""
+msgstr "Automatikus Igen válasz az időtúllépés után"
 
 msgctxt "#30575"
 msgid "Timeout, seconds"
-msgstr ""
+msgstr "Időtúllépés, másodperc"
 
 msgctxt "#30576"
 msgid "Trakt authentication needs to be updated!"
-msgstr ""
+msgstr "A Trakt hitelesítést frissíteni kell!"
 
 msgctxt "#30577"
 msgid "End of file Buffer size, MB"
-msgstr ""
+msgstr "A fájl végi puffer mérete, MB"
 
 msgctxt "#30578"
 msgid "Beginning of file Buffer size, MB"
-msgstr ""
+msgstr "A fájl eleji puffer mérete, MB"
 
 msgctxt "#30579"
 msgid "Settings"
-msgstr ""
+msgstr "Beállítások"
 
 msgctxt "#30580"
 msgid "Custom Trakt API Client ID"
-msgstr ""
+msgstr "Egyéni Trakt API Client ID"
 
 msgctxt "#30581"
 msgid "Custom Trakt API Client Secret"
-msgstr ""
+msgstr "Egyéni Trakt API Client Secret"
 
 msgctxt "#30582"
 msgid "Settings for %s provider"
-msgstr ""
+msgstr "A(z) %s szolgáltató beállításai"
 
 msgctxt "#30583"
 msgid "Resolving magnet link"
-msgstr ""
+msgstr "Magnet hivatkozás feloldása"
 
 msgctxt "#30585"
 msgid "Enable library integration with Kodi"
-msgstr ""
+msgstr "A Kodi médiatárral való integráció engedélyezése"
 
 msgctxt "#30586"
 msgid "If disabled - Elementum will not get/insert items to Kodi library [CR]and skip watched management with Kodi."
-msgstr ""
+msgstr "Ha le van tiltva, az Elementum nem olvas és nem szúr be elemeket a Kodi médiatárba [CR]és kihagyja a megtekintett állapot kezelését a Kodival."
 
 msgctxt "#30587"
 msgid "Show welcome message on start"
-msgstr ""
+msgstr "Üdvözlő üzenet megjelenítése indításkor"
 
 msgctxt "#30588"
 msgid "Pre-Play Buffering"
-msgstr ""
+msgstr "Pufferelés a lejátszás előtt"
 
 msgctxt "#30589"
 msgid "Speed limiting"
-msgstr ""
+msgstr "Sebességkorlátozás"
 
 msgctxt "#30590"
 msgid "Torrents autoload on addon startup"
-msgstr ""
+msgstr "Torrentek automatikus betöltése a kiegészítő indításakor"
 
 msgctxt "#30591"
 msgid "Limits for connections"
-msgstr ""
+msgstr "Kapcsolatok korlátai"
 
 msgctxt "#30592"
 msgid "Seeding"
-msgstr ""
+msgstr "Megosztás"
 
 msgctxt "#30593"
 msgid "Seed forever"
-msgstr ""
+msgstr "Megosztás örökre"
 
 msgctxt "#30594"
 msgid "Network"
-msgstr ""
+msgstr "Hálózat"
 
 msgctxt "#30595"
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Egyebek"
 
 msgctxt "#30597"
 msgid "Cache size, MB"
-msgstr ""
+msgstr "Gyorsítótár mérete, MB"
 
 msgctxt "#30598"
 msgid "Enable caching if using File storage and have speed problems.[CR]Will use more memory, but can improve the speed."
-msgstr ""
+msgstr "Engedélyezd a gyorsítótárazást, ha fájltárolást használsz és sebességproblémáid vannak.[CR]Több memóriát használ, de javíthatja a sebességet."
 
 msgctxt "#30599"
 msgid "Enable Kodi library synchronization"
-msgstr ""
+msgstr "A Kodi médiatár szinkronizálásának engedélyezése"
 
 msgctxt "#30600"
 msgid "Enable Trakt synchronization"
-msgstr ""
+msgstr "A Trakt szinkronizálásának engedélyezése"
 
 msgctxt "#30601"
 msgid "Enable synchronization while playback"
-msgstr ""
+msgstr "Szinkronizálás engedélyezése lejátszás közben"
 
 msgctxt "#30602"
 msgid "Retry requests to addon after timeout, seconds"
-msgstr ""
+msgstr "Kérések újrapróbálása a kiegészítő felé időtúllépés után, másodperc"
 
 msgctxt "#30603"
 msgid "Addon Startup"
-msgstr ""
+msgstr "A kiegészítő indítása"
 
 msgctxt "#30604"
 msgid "Clean all history"
-msgstr ""
+msgstr "Az összes előzmény tisztítása"
 
 msgctxt "#30605"
 msgid "Cache downloaded torrent files after search"
-msgstr ""
+msgstr "A letöltött torrent fájlok gyorsítótárazása a keresés után"
 
 msgctxt "#30606"
 msgid "Show watched state for torrent's files"
-msgstr ""
+msgstr "A megtekintett állapot megjelenítése a torrent fájljaihoz"
 
 msgctxt "#30607"
 msgid "Use earliest release date as basic for searching"
-msgstr ""
+msgstr "A legkorábbi megjelenési dátum használata a keresés alapjául"
 
 msgctxt "#30608"
 msgid "Match found in your active torrents, play it?[CR]%s"
-msgstr ""
+msgstr "Egyezés található az aktív torrentjeid között, lejátszod?[CR]%s"
 
 msgctxt "#30609"
 msgid "Automatically start next episode if available"
-msgstr ""
+msgstr "A következő epizód automatikus indítása, ha elérhető"
 
 msgctxt "#30610"
 msgid "Magnet resolve timeout, seconds"
-msgstr ""
+msgstr "Magnet feloldás időtúllépése, másodperc"
 
 msgctxt "#30611"
 msgid "Application platform type"
-msgstr ""
+msgstr "Az alkalmazás platformtípusa"
 
 msgctxt "#30612"
 msgid "Select file to download"
-msgstr ""
+msgstr "Válaszd ki a letöltendő fájlt"
 
 msgctxt "#30613"
 msgid "... for movie"
-msgstr ""
+msgstr "... filmhez"
 
 msgctxt "#30614"
 msgid "... for tv show"
-msgstr ""
+msgstr "... sorozathoz"
 
 msgctxt "#30615"
 msgid "... for search"
-msgstr ""
+msgstr "... kereséshez"
 
 msgctxt "#30616"
 msgid "Elementum | Trakt Account"
-msgstr ""
+msgstr "Elementum | Trakt fiók"
 
 msgctxt "#30617"
 msgid "Your account is locked for API on Trakt.tv[CR]Please, contact Trakt Support at https://support.trakt.tv ."
-msgstr ""
+msgstr "A fiókod zárolva van a Trakt.tv API-jához[CR]Kérjük, vedd fel a kapcsolatot a Trakt támogatásával itt: https://support.trakt.tv ."
 
 msgctxt "#30618"
 msgid "%s is downloaded"
-msgstr ""
+msgstr "A(z) %s letöltve"
 
 msgctxt "#30619"
 msgid "Return to [B]%s[/B]"
-msgstr ""
+msgstr "Vissza ide: [B]%s[/B]"
 
 msgctxt "#30620"
 msgid "Restart Elementum addon"
-msgstr ""
+msgstr "Az Elementum kiegészítő újraindítása"
 
 msgctxt "#30621"
 msgid "Queued"
-msgstr ""
+msgstr "Sorban áll"
 
 msgctxt "#30622"
 msgid "Checking"
-msgstr ""
+msgstr "Ellenőrzés"
 
 msgctxt "#30623"
 msgid "Finding"
-msgstr ""
+msgstr "Keresés"
 
 msgctxt "#30624"
 msgid "Downloading"
-msgstr ""
+msgstr "Letöltés"
 
 msgctxt "#30625"
 msgid "Finished"
-msgstr ""
+msgstr "Befejezve"
 
 msgctxt "#30626"
 msgid "Seeding"
-msgstr ""
+msgstr "Megosztás"
 
 msgctxt "#30627"
 msgid "Allocating"
-msgstr ""
+msgstr "Helyfoglalás"
 
 msgctxt "#30628"
 msgid "Stalled"
-msgstr ""
+msgstr "Elakadt"
 
 msgctxt "#30629"
 msgid "Paused"
-msgstr ""
+msgstr "Szüneteltetve"
 
 msgctxt "#30630"
 msgid "Buffering"
-msgstr ""
+msgstr "Pufferelés"
 
 msgctxt "#30631"
 msgid "Playing"
-msgstr ""
+msgstr "Lejátszás"
 
 msgctxt "#30632"
 msgid "Yes (%s seconds)"
-msgstr ""
+msgstr "Igen (%s másodperc)"
 
 msgctxt "#30633"
 msgid "No (%s seconds)"
-msgstr ""
+msgstr "Nem (%s másodperc)"
 
 msgctxt "#30634"
 msgid "Log level"
-msgstr ""
+msgstr "Naplózási szint"
 
 msgctxt "#30635"
 msgid "None"
-msgstr ""
+msgstr "Nincs"
 
 msgctxt "#30636"
 msgid "Error"
-msgstr ""
+msgstr "Hiba"
 
 msgctxt "#30637"
 msgid "Info"
-msgstr ""
+msgstr "Információ"
 
 msgctxt "#30638"
 msgid "Debug"
-msgstr ""
+msgstr "Hibakeresés"
 
 msgctxt "#30639"
 msgid "Show Specials in season listings"
-msgstr ""
+msgstr "Különkiadások megjelenítése az évadlistákban"
 
 msgctxt "#30640"
 msgid "Bitrate"
-msgstr ""
+msgstr "Bitráta"
 
 msgctxt "#30641"
 msgid "Playback"
-msgstr ""
+msgstr "Lejátszás"
 
 msgctxt "#30642"
 msgid "Force Resume options"
-msgstr ""
+msgstr "A folytatási beállítások kényszerítése"
 
 msgctxt "#30643"
 msgid "by Kodi"
-msgstr ""
+msgstr "a Kodi által"
 
 msgctxt "#30644"
 msgid "by Elementum - Ask"
-msgstr ""
+msgstr "az Elementum által - Rákérdezés"
 
 msgctxt "#30645"
 msgid "by Elementum - Force"
-msgstr ""
+msgstr "az Elementum által - Kényszerítés"
 
 msgctxt "#30646"
 msgid "Authorize Elementum on Trakt.tv"
-msgstr ""
+msgstr "Az Elementum engedélyezése a Trakt.tv oldalon"
 
 msgctxt "#30647"
 msgid "Cancel Authorization for Elementum on Trakt.tv"
-msgstr ""
+msgstr "Az Elementum engedélyezésének visszavonása a Trakt.tv oldalon"
 
 msgctxt "#30648"
 msgid "Authorization"
-msgstr ""
+msgstr "Engedélyezés"
 
 msgctxt "#30649"
 msgid "To authorize addon for Trakt.tv you need to:[CR]1. Open [B]%s[/B][CR]2. Enter code: [B]%s[/B][CR]3. Wait for notification from Elementum."
-msgstr ""
+msgstr "A kiegészítő Trakt.tv-hez való engedélyezéséhez a következőket kell tenned:[CR]1. Nyisd meg: [B]%s[/B][CR]2. Add meg a kódot: [B]%s[/B][CR]3. Várd meg az Elementum értesítését."
 
 msgctxt "#30650"
 msgid "Successfully authorized for Trakt.tv"
-msgstr ""
+msgstr "A Trakt.tv engedélyezése sikeres"
 
 msgctxt "#30651"
 msgid "Could not authorize for Trakt.tv"
-msgstr ""
+msgstr "Nem sikerült engedélyezni a Trakt.tv-t"
 
 msgctxt "#30652"
 msgid "Successfully deauthorized for Trakt.tv"
-msgstr ""
+msgstr "A Trakt.tv engedélyezésének visszavonása sikeres"
 
 msgctxt "#30653"
 msgid "Which files to download"
-msgstr ""
+msgstr "Mely fájlokat töltse le"
 
 msgctxt "#30654"
 msgid "Only playback file"
-msgstr ""
+msgstr "Csak a lejátszandó fájlt"
 
 msgctxt "#30655"
 msgid "Season files"
-msgstr ""
+msgstr "Az évad fájljait"
 
 msgctxt "#30656"
 msgid "All files"
-msgstr ""
+msgstr "Az összes fájlt"
 
 msgctxt "#30657"
 msgid "Disable LSD"
-msgstr ""
+msgstr "LSD letiltása"
 
 msgctxt "#30658"
 msgid "Add extra trackers"
-msgstr ""
+msgstr "További trackerek hozzáadása"
 
 msgctxt "#30659"
 msgid "All known trackers"
-msgstr ""
+msgstr "Az összes ismert tracker"
 
 msgctxt "#30660"
 msgid "Best trackers"
-msgstr ""
+msgstr "A legjobb trackerek"
 
 msgctxt "#30661"
 msgid "Minimum set"
-msgstr ""
+msgstr "Minimális készlet"
 
 msgctxt "#30662"
 msgid "Remove original trackers from torrent"
-msgstr ""
+msgstr "Az eredeti trackerek eltávolítása a torrentből"
 
 msgctxt "#30663"
 msgid "Show episodes on release day (w/o delay)"
-msgstr ""
+msgstr "Epizódok megjelenítése a megjelenés napján (késleltetés nélkül)"
 
 msgctxt "#30664"
 msgid "Modify trackers in torrent"
-msgstr ""
+msgstr "A trackerek módosítása a torrentben"
 
 msgctxt "#30665"
 msgid "At the time of adding"
-msgstr ""
+msgstr "A hozzáadás pillanatában"
 
 msgctxt "#30666"
 msgid "Every time"
-msgstr ""
+msgstr "Minden alkalommal"
 
 msgctxt "#30667"
 msgid "Mark as watched in Trakt"
-msgstr ""
+msgstr "Megjelölés megtekintettként a Traktban"
 
 msgctxt "#30668"
 msgid "Mark as unwatched in Trakt"
-msgstr ""
+msgstr "Megjelölés meg nem tekintettként a Traktban"
 
 msgctxt "#30669"
 msgid "Delay addon startup, seconds"
-msgstr ""
+msgstr "A kiegészítő indításának késleltetése, másodperc"
 
 msgctxt "#30670"
 msgid "Downloading required binary file for '%s'"
-msgstr ""
+msgstr "A(z) '%s' számára szükséges bináris fájl letöltése"
 
 msgctxt "#30671"
 msgid "List of Opennic DNS IPs"
-msgstr ""
+msgstr "Az OpenNIC DNS IP-címeinek listája"
 
 msgctxt "#30672"
 msgid "Compact database"
-msgstr ""
+msgstr "Adatbázis tömörítése"
 
 msgctxt "#30673"
 msgid "Compact cache database"
-msgstr ""
+msgstr "A gyorsítótár adatbázisának tömörítése"
 
 msgctxt "#30674"
 msgid "Database was compacted"
-msgstr ""
+msgstr "Az adatbázis tömörítve lett"
 
 msgctxt "#30675"
 msgid "Remote host login"
-msgstr ""
+msgstr "A távoli kiszolgáló felhasználóneve"
 
 msgctxt "#30676"
 msgid "Remote host password"
-msgstr ""
+msgstr "A távoli kiszolgáló jelszava"
 
 msgctxt "#30677"
 msgid "Force start as a library"
-msgstr ""
+msgstr "Indítás kényszerítése médiatárként"
 
 msgctxt "#30678"
 msgid "Remove from Kodi library, when movie is deleted from Trakt"
-msgstr ""
+msgstr "Eltávolítás a Kodi médiatárból, amikor a filmet törlik a Traktból"
 
 msgctxt "#30679"
 msgid "Remove from Kodi library, when show is deleted from Trakt"
-msgstr ""
+msgstr "Eltávolítás a Kodi médiatárból, amikor a sorozatot törlik a Traktból"
 
 msgctxt "#30680"
 msgid "Remove Elementum duplicates from library"
-msgstr ""
+msgstr "Az Elementum duplikátumainak eltávolítása a médiatárból"
 
 msgctxt "#30681"
 msgid "[B]Found duplicates in Kodi library:[/B][CR]Movies: [B]%s[/B], Shows: [B]%s[/B], Episodes: [B]%s[/B][CR]Proceed?"
-msgstr ""
+msgstr "[B]Duplikátumok találhatók a Kodi médiatárban:[/B][CR]Filmek: [B]%s[/B], Sorozatok: [B]%s[/B], Epizódok: [B]%s[/B][CR]Folytatod?"
 
 msgctxt "#30682"
 msgid "No duplicates were found in Kodi library"
-msgstr ""
+msgstr "Nem található duplikátum a Kodi médiatárban"
 
 msgctxt "#30683"
 msgid "Starting library duplicates removal"
-msgstr ""
+msgstr "A duplikátumok eltávolításának indítása a médiatárból"
 
 msgctxt "#30684"
 msgid "Removed Movies: %s, Shows: %s, Episodes: %s"
-msgstr ""
+msgstr "Eltávolítva - Filmek: %s, Sorozatok: %s, Epizódok: %s"
 
 msgctxt "#30685"
 msgid "Remove movies from Elementum database"
-msgstr ""
+msgstr "Filmek eltávolítása az Elementum adatbázisából"
 
 msgctxt "#30686"
 msgid "Remove shows from Elementum database"
-msgstr ""
+msgstr "Sorozatok eltávolítása az Elementum adatbázisából"
 
 msgctxt "#30687"
 msgid "In Elementum library"
-msgstr ""
+msgstr "Az Elementum médiatárában"
 
 msgctxt "#30688"
 msgid "Skip searching for installed Elementum repository"
-msgstr ""
+msgstr "A telepített Elementum tároló keresésének kihagyása"
 
 msgctxt "#30689"
 msgid "Internal DNS client"
-msgstr ""
+msgstr "Belső DNS kliens"
 
 msgctxt "#30691"
 msgid "Hide watched"
-msgstr ""
+msgstr "Megtekintettek elrejtése"
 
 msgctxt "#30692"
 msgid "TMDB images quality (affects Kodi performance)"
-msgstr ""
+msgstr "A TMDB képek minősége (befolyásolja a Kodi teljesítményét)"
 
 msgctxt "#30693"
 msgid "Original"
-msgstr ""
+msgstr "Eredeti"
 
 msgctxt "#30694"
 msgid "High"
-msgstr ""
+msgstr "Magas"
 
 msgctxt "#30695"
 msgid "Medium"
-msgstr ""
+msgstr "Közepes"
 
 msgctxt "#30696"
 msgid "Low"
-msgstr ""
+msgstr "Alacsony"
 
 msgctxt "#30697"
 msgid "Interface language"
-msgstr ""
+msgstr "A felület nyelve"
 
 msgctxt "#30698"
 msgid "Kodi language"
-msgstr ""
+msgstr "A Kodi nyelve"
 
 msgctxt "#30699"
 msgid "Use earliest release date for progress and calendars"
-msgstr ""
+msgstr "A legkorábbi megjelenési dátum használata a haladáshoz és a naptárakhoz"
 
 msgctxt "#30700"
 msgid "Interface fallback language"
-msgstr ""
+msgstr "A felület tartaléknyelve"
 
 msgctxt "#30701"
 msgid "English | en"
-msgstr ""
+msgstr "Angol | en"
 
 msgctxt "#30702"
 msgid "Reached daily limit for subtitles downloads"
-msgstr ""
+msgstr "Elérted a feliratletöltések napi korlátját"
 
 msgctxt "#30703"
 msgid "Can be used by search providers or [CR]for debugging"
-msgstr ""
+msgstr "Használhatják a keresőszolgáltatók, vagy [CR]hibakereséshez"
 
 msgctxt "#30704"
 msgid "TMDB API Key check failed, cannot use TMDB service"
-msgstr ""
+msgstr "A TMDB API kulcs ellenőrzése sikertelen, a TMDB szolgáltatás nem használható"
 
 msgctxt "#30705"
 msgid "TMDB API accessibility check failed, cannot use TMDB service"
-msgstr ""
+msgstr "A TMDB API elérhetőségének ellenőrzése sikertelen, a TMDB szolgáltatás nem használható"
 
 msgctxt "#30706"
 msgid "Transmission 4.05"
-msgstr ""
+msgstr "Transmission 4.05"
 
 msgctxt "#30707"
 msgid "qBittorrent 3.3.9"
-msgstr ""
+msgstr "qBittorrent 3.3.9"
 
 msgctxt "#30708"
 msgid "qBittorrent 4.6.4"
-msgstr ""
+msgstr "qBittorrent 4.6.4"
 
 msgctxt "#30709"
 msgid "Open [B]%s[/B]"
-msgstr ""
+msgstr "[B]%s[/B] megnyitása"
 
 msgctxt "#30710"
 msgid "BitTorrent ports"
-msgstr ""
+msgstr "BitTorrent portok"
 
 msgctxt "#30711"
 msgid "Delete torrent '%s'?"
-msgstr ""
+msgstr "Törlöd a(z) '%s' torrentet?"
 
 msgctxt "#30712"
 msgid "Force to always use proxy, can break download in some cases"
-msgstr ""
+msgstr "A proxy állandó használatának kényszerítése, egyes esetekben megszakíthatja a letöltést"
 
 msgctxt "#30713"
 msgid "Disable NATPMP"
-msgstr ""
+msgstr "NATPMP letiltása"
 
 msgctxt "#30714"
 msgid "Re-check torrent's data"
-msgstr ""
+msgstr "A torrent adatainak újraellenőrzése"
 
 msgctxt "#30715"
 msgid "Antizapret PAC file URL"
-msgstr ""
+msgstr "Az Antizapret PAC fájl URL-je"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "DNS over HTTPS kiszolgáló"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "Egyéni DNS over HTTPS kiszolgáló"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "Az OpenNIC DNS kiszolgálóinak használata"

--- a/resources/language/Italian/strings.po
+++ b/resources/language/Italian/strings.po
@@ -411,11 +411,11 @@ msgstr "Scraping dei trackers..."
 
 msgctxt "#30119"
 msgid "ID of selected userlist for movies"
-msgstr ""
+msgstr "ID della lista utente selezionata per i film"
 
 msgctxt "#30120"
 msgid "ID of selected userlist for shows"
-msgstr ""
+msgstr "ID della lista utente selezionata per le serie TV"
 
 msgctxt "#30141"
 msgid "Please support Elementum development by visiting[CR]https://elementum.surge.sh/donate/ or https://elementumorg.github.io/donate/"
@@ -712,7 +712,7 @@ msgstr "%s rimosso dalla libreria, vuoi pulire?[CR]Altrimenti puoi successivamen
 
 msgctxt "#30279"
 msgid "Video %s was previously removed from library.[CR]Force adding?"
-msgstr ""
+msgstr "Il video %s era stato rimosso in precedenza dalla libreria.[CR]Forzare l'aggiunta?"
 
 msgctxt "#30282"
 msgid "Nothing left to remove from Elementum"
@@ -1160,11 +1160,11 @@ msgstr "Percentuale di riproduzione da marcare come visto"
 
 msgctxt "#30417"
 msgid "Use name of production company as Studio for shows"
-msgstr ""
+msgstr "Usa il nome della casa di produzione come Studio per le serie TV"
 
 msgctxt "#30418"
 msgid "Calculate number of unwatched episodes in Shows/Seasons"
-msgstr ""
+msgstr "Calcola il numero di episodi non visti in Serie TV/Stagioni"
 
 msgctxt "#30421"
 msgid "Load torrents from torrents folder on startup"
@@ -1460,7 +1460,7 @@ msgstr "Disattivare se si utilizzano gli indirizzi Tor, o si desidera passare la
 
 msgctxt "#30497"
 msgid "Use Antizapret proxy (only for Russia)"
-msgstr ""
+msgstr "Usa il proxy Antizapret (solo per la Russia)"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"
@@ -1744,539 +1744,539 @@ msgstr "Timeout, secondi"
 
 msgctxt "#30576"
 msgid "Trakt authentication needs to be updated!"
-msgstr ""
+msgstr "L'autenticazione Trakt deve essere aggiornata!"
 
 msgctxt "#30577"
 msgid "End of file Buffer size, MB"
-msgstr ""
+msgstr "Dimensione del buffer di fine file, MB"
 
 msgctxt "#30578"
 msgid "Beginning of file Buffer size, MB"
-msgstr ""
+msgstr "Dimensione del buffer di inizio file, MB"
 
 msgctxt "#30579"
 msgid "Settings"
-msgstr ""
+msgstr "Impostazioni"
 
 msgctxt "#30580"
 msgid "Custom Trakt API Client ID"
-msgstr ""
+msgstr "Client ID personalizzato per l'API di Trakt"
 
 msgctxt "#30581"
 msgid "Custom Trakt API Client Secret"
-msgstr ""
+msgstr "Client Secret personalizzato per l'API di Trakt"
 
 msgctxt "#30582"
 msgid "Settings for %s provider"
-msgstr ""
+msgstr "Impostazioni del provider %s"
 
 msgctxt "#30583"
 msgid "Resolving magnet link"
-msgstr ""
+msgstr "Risoluzione del link magnet in corso"
 
 msgctxt "#30585"
 msgid "Enable library integration with Kodi"
-msgstr ""
+msgstr "Abilita l'integrazione con la libreria di Kodi"
 
 msgctxt "#30586"
 msgid "If disabled - Elementum will not get/insert items to Kodi library [CR]and skip watched management with Kodi."
-msgstr ""
+msgstr "Se disabilitato, Elementum non leggerà né inserirà elementi nella libreria di Kodi [CR]e non gestirà lo stato di visione con Kodi."
 
 msgctxt "#30587"
 msgid "Show welcome message on start"
-msgstr ""
+msgstr "Mostra il messaggio di benvenuto all'avvio"
 
 msgctxt "#30588"
 msgid "Pre-Play Buffering"
-msgstr ""
+msgstr "Buffering prima della riproduzione"
 
 msgctxt "#30589"
 msgid "Speed limiting"
-msgstr ""
+msgstr "Limitazione della velocità"
 
 msgctxt "#30590"
 msgid "Torrents autoload on addon startup"
-msgstr ""
+msgstr "Caricamento automatico dei torrent all'avvio dell'add-on"
 
 msgctxt "#30591"
 msgid "Limits for connections"
-msgstr ""
+msgstr "Limiti per le connessioni"
 
 msgctxt "#30592"
 msgid "Seeding"
-msgstr ""
+msgstr "Condivisione"
 
 msgctxt "#30593"
 msgid "Seed forever"
-msgstr ""
+msgstr "Condividi per sempre"
 
 msgctxt "#30594"
 msgid "Network"
-msgstr ""
+msgstr "Rete"
 
 msgctxt "#30595"
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Varie"
 
 msgctxt "#30597"
 msgid "Cache size, MB"
-msgstr ""
+msgstr "Dimensione della cache, MB"
 
 msgctxt "#30598"
 msgid "Enable caching if using File storage and have speed problems.[CR]Will use more memory, but can improve the speed."
-msgstr ""
+msgstr "Abilita la cache se usi l'archiviazione su File e hai problemi di velocità.[CR]Userà più memoria, ma può migliorare la velocità."
 
 msgctxt "#30599"
 msgid "Enable Kodi library synchronization"
-msgstr ""
+msgstr "Abilita la sincronizzazione con la libreria di Kodi"
 
 msgctxt "#30600"
 msgid "Enable Trakt synchronization"
-msgstr ""
+msgstr "Abilita la sincronizzazione con Trakt"
 
 msgctxt "#30601"
 msgid "Enable synchronization while playback"
-msgstr ""
+msgstr "Abilita la sincronizzazione durante la riproduzione"
 
 msgctxt "#30602"
 msgid "Retry requests to addon after timeout, seconds"
-msgstr ""
+msgstr "Riprova le richieste all'add-on dopo il timeout, secondi"
 
 msgctxt "#30603"
 msgid "Addon Startup"
-msgstr ""
+msgstr "Avvio dell'add-on"
 
 msgctxt "#30604"
 msgid "Clean all history"
-msgstr ""
+msgstr "Cancella tutta la cronologia"
 
 msgctxt "#30605"
 msgid "Cache downloaded torrent files after search"
-msgstr ""
+msgstr "Metti in cache i file torrent scaricati dopo la ricerca"
 
 msgctxt "#30606"
 msgid "Show watched state for torrent's files"
-msgstr ""
+msgstr "Mostra lo stato di visione per i file del torrent"
 
 msgctxt "#30607"
 msgid "Use earliest release date as basic for searching"
-msgstr ""
+msgstr "Usa la data di uscita più remota come base per la ricerca"
 
 msgctxt "#30608"
 msgid "Match found in your active torrents, play it?[CR]%s"
-msgstr ""
+msgstr "Trovata una corrispondenza nei tuoi torrent attivi, riprodurla?[CR]%s"
 
 msgctxt "#30609"
 msgid "Automatically start next episode if available"
-msgstr ""
+msgstr "Avvia automaticamente l'episodio successivo se disponibile"
 
 msgctxt "#30610"
 msgid "Magnet resolve timeout, seconds"
-msgstr ""
+msgstr "Timeout di risoluzione del magnet, secondi"
 
 msgctxt "#30611"
 msgid "Application platform type"
-msgstr ""
+msgstr "Tipo di piattaforma dell'applicazione"
 
 msgctxt "#30612"
 msgid "Select file to download"
-msgstr ""
+msgstr "Seleziona il file da scaricare"
 
 msgctxt "#30613"
 msgid "... for movie"
-msgstr ""
+msgstr "... per il film"
 
 msgctxt "#30614"
 msgid "... for tv show"
-msgstr ""
+msgstr "... per la serie TV"
 
 msgctxt "#30615"
 msgid "... for search"
-msgstr ""
+msgstr "... per la ricerca"
 
 msgctxt "#30616"
 msgid "Elementum | Trakt Account"
-msgstr ""
+msgstr "Elementum | Account Trakt"
 
 msgctxt "#30617"
 msgid "Your account is locked for API on Trakt.tv[CR]Please, contact Trakt Support at https://support.trakt.tv ."
-msgstr ""
+msgstr "Il tuo account è bloccato per l'API su Trakt.tv[CR]Contatta l'assistenza Trakt su https://support.trakt.tv ."
 
 msgctxt "#30618"
 msgid "%s is downloaded"
-msgstr ""
+msgstr "%s è stato scaricato"
 
 msgctxt "#30619"
 msgid "Return to [B]%s[/B]"
-msgstr ""
+msgstr "Torna a [B]%s[/B]"
 
 msgctxt "#30620"
 msgid "Restart Elementum addon"
-msgstr ""
+msgstr "Riavvia l'add-on Elementum"
 
 msgctxt "#30621"
 msgid "Queued"
-msgstr ""
+msgstr "In coda"
 
 msgctxt "#30622"
 msgid "Checking"
-msgstr ""
+msgstr "Verifica"
 
 msgctxt "#30623"
 msgid "Finding"
-msgstr ""
+msgstr "Ricerca"
 
 msgctxt "#30624"
 msgid "Downloading"
-msgstr ""
+msgstr "Download"
 
 msgctxt "#30625"
 msgid "Finished"
-msgstr ""
+msgstr "Completato"
 
 msgctxt "#30626"
 msgid "Seeding"
-msgstr ""
+msgstr "Condivisione"
 
 msgctxt "#30627"
 msgid "Allocating"
-msgstr ""
+msgstr "Allocazione"
 
 msgctxt "#30628"
 msgid "Stalled"
-msgstr ""
+msgstr "In stallo"
 
 msgctxt "#30629"
 msgid "Paused"
-msgstr ""
+msgstr "In pausa"
 
 msgctxt "#30630"
 msgid "Buffering"
-msgstr ""
+msgstr "Buffering"
 
 msgctxt "#30631"
 msgid "Playing"
-msgstr ""
+msgstr "In riproduzione"
 
 msgctxt "#30632"
 msgid "Yes (%s seconds)"
-msgstr ""
+msgstr "Sì (%s secondi)"
 
 msgctxt "#30633"
 msgid "No (%s seconds)"
-msgstr ""
+msgstr "No (%s secondi)"
 
 msgctxt "#30634"
 msgid "Log level"
-msgstr ""
+msgstr "Livello di log"
 
 msgctxt "#30635"
 msgid "None"
-msgstr ""
+msgstr "Nessuno"
 
 msgctxt "#30636"
 msgid "Error"
-msgstr ""
+msgstr "Errore"
 
 msgctxt "#30637"
 msgid "Info"
-msgstr ""
+msgstr "Info"
 
 msgctxt "#30638"
 msgid "Debug"
-msgstr ""
+msgstr "Debug"
 
 msgctxt "#30639"
 msgid "Show Specials in season listings"
-msgstr ""
+msgstr "Mostra gli speciali negli elenchi delle stagioni"
 
 msgctxt "#30640"
 msgid "Bitrate"
-msgstr ""
+msgstr "Bitrate"
 
 msgctxt "#30641"
 msgid "Playback"
-msgstr ""
+msgstr "Riproduzione"
 
 msgctxt "#30642"
 msgid "Force Resume options"
-msgstr ""
+msgstr "Forza le opzioni di ripresa"
 
 msgctxt "#30643"
 msgid "by Kodi"
-msgstr ""
+msgstr "da Kodi"
 
 msgctxt "#30644"
 msgid "by Elementum - Ask"
-msgstr ""
+msgstr "da Elementum - Chiedi"
 
 msgctxt "#30645"
 msgid "by Elementum - Force"
-msgstr ""
+msgstr "da Elementum - Forza"
 
 msgctxt "#30646"
 msgid "Authorize Elementum on Trakt.tv"
-msgstr ""
+msgstr "Autorizza Elementum su Trakt.tv"
 
 msgctxt "#30647"
 msgid "Cancel Authorization for Elementum on Trakt.tv"
-msgstr ""
+msgstr "Annulla l'autorizzazione di Elementum su Trakt.tv"
 
 msgctxt "#30648"
 msgid "Authorization"
-msgstr ""
+msgstr "Autorizzazione"
 
 msgctxt "#30649"
 msgid "To authorize addon for Trakt.tv you need to:[CR]1. Open [B]%s[/B][CR]2. Enter code: [B]%s[/B][CR]3. Wait for notification from Elementum."
-msgstr ""
+msgstr "Per autorizzare l'add-on su Trakt.tv devi:[CR]1. Aprire [B]%s[/B][CR]2. Inserire il codice: [B]%s[/B][CR]3. Attendere la notifica di Elementum."
 
 msgctxt "#30650"
 msgid "Successfully authorized for Trakt.tv"
-msgstr ""
+msgstr "Autorizzazione a Trakt.tv riuscita"
 
 msgctxt "#30651"
 msgid "Could not authorize for Trakt.tv"
-msgstr ""
+msgstr "Impossibile autorizzare su Trakt.tv"
 
 msgctxt "#30652"
 msgid "Successfully deauthorized for Trakt.tv"
-msgstr ""
+msgstr "Autorizzazione a Trakt.tv annullata correttamente"
 
 msgctxt "#30653"
 msgid "Which files to download"
-msgstr ""
+msgstr "Quali file scaricare"
 
 msgctxt "#30654"
 msgid "Only playback file"
-msgstr ""
+msgstr "Solo il file da riprodurre"
 
 msgctxt "#30655"
 msgid "Season files"
-msgstr ""
+msgstr "I file della stagione"
 
 msgctxt "#30656"
 msgid "All files"
-msgstr ""
+msgstr "Tutti i file"
 
 msgctxt "#30657"
 msgid "Disable LSD"
-msgstr ""
+msgstr "Disabilita LSD"
 
 msgctxt "#30658"
 msgid "Add extra trackers"
-msgstr ""
+msgstr "Aggiungi tracker extra"
 
 msgctxt "#30659"
 msgid "All known trackers"
-msgstr ""
+msgstr "Tutti i tracker conosciuti"
 
 msgctxt "#30660"
 msgid "Best trackers"
-msgstr ""
+msgstr "I tracker migliori"
 
 msgctxt "#30661"
 msgid "Minimum set"
-msgstr ""
+msgstr "Insieme minimo"
 
 msgctxt "#30662"
 msgid "Remove original trackers from torrent"
-msgstr ""
+msgstr "Rimuovi i tracker originali dal torrent"
 
 msgctxt "#30663"
 msgid "Show episodes on release day (w/o delay)"
-msgstr ""
+msgstr "Mostra gli episodi il giorno di uscita (senza ritardo)"
 
 msgctxt "#30664"
 msgid "Modify trackers in torrent"
-msgstr ""
+msgstr "Modifica i tracker nel torrent"
 
 msgctxt "#30665"
 msgid "At the time of adding"
-msgstr ""
+msgstr "Al momento dell'aggiunta"
 
 msgctxt "#30666"
 msgid "Every time"
-msgstr ""
+msgstr "Ogni volta"
 
 msgctxt "#30667"
 msgid "Mark as watched in Trakt"
-msgstr ""
+msgstr "Segna come visto su Trakt"
 
 msgctxt "#30668"
 msgid "Mark as unwatched in Trakt"
-msgstr ""
+msgstr "Segna come non visto su Trakt"
 
 msgctxt "#30669"
 msgid "Delay addon startup, seconds"
-msgstr ""
+msgstr "Ritarda l'avvio dell'add-on, secondi"
 
 msgctxt "#30670"
 msgid "Downloading required binary file for '%s'"
-msgstr ""
+msgstr "Download del file binario necessario per '%s'"
 
 msgctxt "#30671"
 msgid "List of Opennic DNS IPs"
-msgstr ""
+msgstr "Elenco degli IP dei DNS OpenNIC"
 
 msgctxt "#30672"
 msgid "Compact database"
-msgstr ""
+msgstr "Compatta il database"
 
 msgctxt "#30673"
 msgid "Compact cache database"
-msgstr ""
+msgstr "Compatta il database della cache"
 
 msgctxt "#30674"
 msgid "Database was compacted"
-msgstr ""
+msgstr "Il database è stato compattato"
 
 msgctxt "#30675"
 msgid "Remote host login"
-msgstr ""
+msgstr "Nome utente dell'host remoto"
 
 msgctxt "#30676"
 msgid "Remote host password"
-msgstr ""
+msgstr "Password dell'host remoto"
 
 msgctxt "#30677"
 msgid "Force start as a library"
-msgstr ""
+msgstr "Forza l'avvio come libreria"
 
 msgctxt "#30678"
 msgid "Remove from Kodi library, when movie is deleted from Trakt"
-msgstr ""
+msgstr "Rimuovi dalla libreria di Kodi quando il film viene eliminato da Trakt"
 
 msgctxt "#30679"
 msgid "Remove from Kodi library, when show is deleted from Trakt"
-msgstr ""
+msgstr "Rimuovi dalla libreria di Kodi quando la serie TV viene eliminata da Trakt"
 
 msgctxt "#30680"
 msgid "Remove Elementum duplicates from library"
-msgstr ""
+msgstr "Rimuovi i duplicati di Elementum dalla libreria"
 
 msgctxt "#30681"
 msgid "[B]Found duplicates in Kodi library:[/B][CR]Movies: [B]%s[/B], Shows: [B]%s[/B], Episodes: [B]%s[/B][CR]Proceed?"
-msgstr ""
+msgstr "[B]Trovati duplicati nella libreria di Kodi:[/B][CR]Film: [B]%s[/B], Serie TV: [B]%s[/B], Episodi: [B]%s[/B][CR]Procedere?"
 
 msgctxt "#30682"
 msgid "No duplicates were found in Kodi library"
-msgstr ""
+msgstr "Nessun duplicato trovato nella libreria di Kodi"
 
 msgctxt "#30683"
 msgid "Starting library duplicates removal"
-msgstr ""
+msgstr "Avvio della rimozione dei duplicati dalla libreria"
 
 msgctxt "#30684"
 msgid "Removed Movies: %s, Shows: %s, Episodes: %s"
-msgstr ""
+msgstr "Rimossi film: %s, serie TV: %s, episodi: %s"
 
 msgctxt "#30685"
 msgid "Remove movies from Elementum database"
-msgstr ""
+msgstr "Rimuovi i film dal database di Elementum"
 
 msgctxt "#30686"
 msgid "Remove shows from Elementum database"
-msgstr ""
+msgstr "Rimuovi le serie TV dal database di Elementum"
 
 msgctxt "#30687"
 msgid "In Elementum library"
-msgstr ""
+msgstr "Nella libreria di Elementum"
 
 msgctxt "#30688"
 msgid "Skip searching for installed Elementum repository"
-msgstr ""
+msgstr "Salta la ricerca del repository Elementum installato"
 
 msgctxt "#30689"
 msgid "Internal DNS client"
-msgstr ""
+msgstr "Client DNS interno"
 
 msgctxt "#30691"
 msgid "Hide watched"
-msgstr ""
+msgstr "Nascondi i visti"
 
 msgctxt "#30692"
 msgid "TMDB images quality (affects Kodi performance)"
-msgstr ""
+msgstr "Qualità delle immagini TMDB (influisce sulle prestazioni di Kodi)"
 
 msgctxt "#30693"
 msgid "Original"
-msgstr ""
+msgstr "Originale"
 
 msgctxt "#30694"
 msgid "High"
-msgstr ""
+msgstr "Alta"
 
 msgctxt "#30695"
 msgid "Medium"
-msgstr ""
+msgstr "Media"
 
 msgctxt "#30696"
 msgid "Low"
-msgstr ""
+msgstr "Bassa"
 
 msgctxt "#30697"
 msgid "Interface language"
-msgstr ""
+msgstr "Lingua dell'interfaccia"
 
 msgctxt "#30698"
 msgid "Kodi language"
-msgstr ""
+msgstr "Lingua di Kodi"
 
 msgctxt "#30699"
 msgid "Use earliest release date for progress and calendars"
-msgstr ""
+msgstr "Usa la data di uscita più remota per l'avanzamento e i calendari"
 
 msgctxt "#30700"
 msgid "Interface fallback language"
-msgstr ""
+msgstr "Lingua di riserva dell'interfaccia"
 
 msgctxt "#30701"
 msgid "English | en"
-msgstr ""
+msgstr "Inglese | en"
 
 msgctxt "#30702"
 msgid "Reached daily limit for subtitles downloads"
-msgstr ""
+msgstr "Raggiunto il limite giornaliero di download dei sottotitoli"
 
 msgctxt "#30703"
 msgid "Can be used by search providers or [CR]for debugging"
-msgstr ""
+msgstr "Può essere usato dai provider di ricerca o [CR]per il debug"
 
 msgctxt "#30704"
 msgid "TMDB API Key check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Verifica della chiave API di TMDB non riuscita, impossibile usare il servizio TMDB"
 
 msgctxt "#30705"
 msgid "TMDB API accessibility check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Verifica dell'accessibilità dell'API di TMDB non riuscita, impossibile usare il servizio TMDB"
 
 msgctxt "#30706"
 msgid "Transmission 4.05"
-msgstr ""
+msgstr "Transmission 4.05"
 
 msgctxt "#30707"
 msgid "qBittorrent 3.3.9"
-msgstr ""
+msgstr "qBittorrent 3.3.9"
 
 msgctxt "#30708"
 msgid "qBittorrent 4.6.4"
-msgstr ""
+msgstr "qBittorrent 4.6.4"
 
 msgctxt "#30709"
 msgid "Open [B]%s[/B]"
-msgstr ""
+msgstr "Apri [B]%s[/B]"
 
 msgctxt "#30710"
 msgid "BitTorrent ports"
-msgstr ""
+msgstr "Porte BitTorrent"
 
 msgctxt "#30711"
 msgid "Delete torrent '%s'?"
-msgstr ""
+msgstr "Eliminare il torrent '%s'?"
 
 msgctxt "#30712"
 msgid "Force to always use proxy, can break download in some cases"
-msgstr ""
+msgstr "Forza sempre l'uso del proxy, in alcuni casi può interrompere il download"
 
 msgctxt "#30713"
 msgid "Disable NATPMP"
@@ -2284,20 +2284,20 @@ msgstr "Disabilita NATPMP"
 
 msgctxt "#30714"
 msgid "Re-check torrent's data"
-msgstr ""
+msgstr "Ricontrolla i dati del torrent"
 
 msgctxt "#30715"
 msgid "Antizapret PAC file URL"
-msgstr ""
+msgstr "URL del file PAC di Antizapret"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "Server DNS over HTTPS"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "Server DNS over HTTPS personalizzato"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "Usa i server DNS OpenNIC"

--- a/resources/language/Portuguese (Brazil)/strings.po
+++ b/resources/language/Portuguese (Brazil)/strings.po
@@ -21,7 +21,7 @@ msgstr "Geral"
 
 msgctxt "#30001"
 msgid "Download path"
-msgstr ""
+msgstr "Caminho dos downloads"
 
 msgctxt "#30004"
 msgid "Max upload rate, kB/s"
@@ -97,7 +97,7 @@ msgstr "Escolher fonte automaticamente"
 
 msgctxt "#30025"
 msgid "Limit rates after initial buffering only"
-msgstr ""
+msgstr "Limitar as taxas apenas após a buffer inicial"
 
 msgctxt "#30026"
 msgid "Library path"
@@ -109,7 +109,7 @@ msgstr "Limite de conexões"
 
 msgctxt "#30028"
 msgid "Download after play was stopped"
-msgstr ""
+msgstr "Continuar a baixar após parar a reprodução"
 
 msgctxt "#30029"
 msgid "Session saving frequency, seconds"
@@ -253,19 +253,19 @@ msgstr "Tipo de Proxy"
 
 msgctxt "#30068"
 msgid "SOCKS4"
-msgstr ""
+msgstr "SOCKS4"
 
 msgctxt "#30069"
 msgid "SOCKS5"
-msgstr ""
+msgstr "SOCKS5"
 
 msgctxt "#30071"
 msgid "HTTP"
-msgstr ""
+msgstr "HTTP"
 
 msgctxt "#30073"
 msgid "i2p"
-msgstr ""
+msgstr "i2p"
 
 msgctxt "#30074"
 msgid "Spoof user agent (highly inadvisable)"
@@ -273,47 +273,47 @@ msgstr "Imitar outro agente (desaconselhável)"
 
 msgctxt "#30075"
 msgid "Default advisable (acceptable)"
-msgstr ""
+msgstr "Padrão aconselhável (aceitável)"
 
 msgctxt "#30076"
 msgid "libtorrent (Rasterbar) 1.1.0"
-msgstr ""
+msgstr "libtorrent (Rasterbar) 1.1.0"
 
 msgctxt "#30077"
 msgid "BitTorrent 7.5.0"
-msgstr ""
+msgstr "BitTorrent 7.5.0"
 
 msgctxt "#30078"
 msgid "BitTorrent 7.9.9"
-msgstr ""
+msgstr "BitTorrent 7.9.9"
 
 msgctxt "#30079"
 msgid "µTorrent 3.5.5"
-msgstr ""
+msgstr "µTorrent 3.5.5"
 
 msgctxt "#30080"
 msgid "µTorrent 3.6.0"
-msgstr ""
+msgstr "µTorrent 3.6.0"
 
 msgctxt "#30081"
 msgid "µTorrent 2.2.1"
-msgstr ""
+msgstr "µTorrent 2.2.1"
 
 msgctxt "#30082"
 msgid "Transmission 2.92"
-msgstr ""
+msgstr "Transmission 2.92"
 
 msgctxt "#30083"
 msgid "Deluge 1.3.6"
-msgstr ""
+msgstr "Deluge 1.3.6"
 
 msgctxt "#30084"
 msgid "Deluge 2.1.1"
-msgstr ""
+msgstr "Deluge 2.1.1"
 
 msgctxt "#30085"
 msgid "Vuze 5.7.3.0"
-msgstr ""
+msgstr "Vuze 5.7.3.0"
 
 msgctxt "#30086"
 msgid "Enable tuned storage settings"
@@ -325,15 +325,15 @@ msgstr "Limite de tempo para carregamento (segundos)"
 
 msgctxt "#30090"
 msgid "Listen interfaces"
-msgstr ""
+msgstr "Interfaces de escuta"
 
 msgctxt "#30091"
 msgid "Outgoing interfaces"
-msgstr ""
+msgstr "Interfaces de saída"
 
 msgctxt "#30092"
 msgid "Use fallback fanart if fanart wasn't found"
-msgstr ""
+msgstr "Usar fanart alternativo se não for encontrado nenhum"
 
 msgctxt "#30093"
 msgid "Disable notification sound"
@@ -354,7 +354,7 @@ msgstr "Este addon só pode ser executado pelo Elementum"
 
 msgctxt "#30103"
 msgid "Unable to find Elementum binary[CR]Required platform:"
-msgstr ""
+msgstr "Não foi possível encontrar o binário do Elementum[CR]Plataforma necessária:"
 
 msgctxt "#30104"
 msgid "Insert file or URL"
@@ -410,11 +410,11 @@ msgstr "Verificando trackers..."
 
 msgctxt "#30119"
 msgid "ID of selected userlist for movies"
-msgstr ""
+msgstr "ID da lista de usuário selecionada para filmes"
 
 msgctxt "#30120"
 msgid "ID of selected userlist for shows"
-msgstr ""
+msgstr "ID da lista de usuário selecionada para séries"
 
 msgctxt "#30141"
 msgid "Please support Elementum development by visiting[CR]https://elementum.surge.sh/donate/ or https://elementumorg.github.io/donate/"
@@ -454,7 +454,7 @@ msgstr "Usuario do Trakt não definido, veja suas configurações"
 
 msgctxt "#30199"
 msgid "No available JSON-RPC connection to Kodi.[CR]Enable both Application control options in Service settings / Control and restart Kodi."
-msgstr ""
+msgstr "Não há conexão JSON-RPC disponível para o Kodi.[CR]Ative as duas opções de controle do aplicativo em Configurações de serviços / Controle e reinicie o Kodi."
 
 # Elementum daemon
 msgctxt "#30200"
@@ -711,7 +711,7 @@ msgstr "%s removido da biblioteca, quer limpá-la?[CR]Você também pode usar o 
 
 msgctxt "#30279"
 msgid "Video %s was previously removed from library.[CR]Force adding?"
-msgstr ""
+msgstr "O vídeo %s tinha sido removido da biblioteca anteriormente.[CR]Forçar a adição?"
 
 msgctxt "#30282"
 msgid "Nothing left to remove from Elementum"
@@ -799,1483 +799,1483 @@ msgstr "Arquivos serão movidos quando a reprodução e tempo de semear terminar
 
 msgctxt "#30303"
 msgid "RAR archive detected. Download will need to be completed before playback can start and will require around twice the amount of space, continue?"
-msgstr ""
+msgstr "Arquivo RAR detectado. O download terá de ser concluído antes que a reprodução possa começar e exigirá cerca do dobro do espaço. Continuar?"
 
 msgctxt "#30304"
 msgid "Error creating output pipe for 'unrar' command"
-msgstr ""
+msgstr "Erro ao criar o canal de saída para o comando 'unrar'"
 
 msgctxt "#30305"
 msgid "Error starting 'unrar' command"
-msgstr ""
+msgstr "Erro ao iniciar o comando 'unrar'"
 
 msgctxt "#30306"
 msgid "Error waiting for 'unrar' command"
-msgstr ""
+msgstr "Erro ao aguardar pelo comando 'unrar'"
 
 msgctxt "#30307"
 msgid "Error reading from destination folder"
-msgstr ""
+msgstr "Erro ao ler da pasta de destino"
 
 msgctxt "#30308"
 msgid "Move completed"
-msgstr ""
+msgstr "Movimentação concluída"
 
 msgctxt "#30309"
 msgid "Keep"
-msgstr ""
+msgstr "Manter"
 
 msgctxt "#30310"
 msgid "Ask to delete"
-msgstr ""
+msgstr "Perguntar antes de eliminar"
 
 msgctxt "#30311"
 msgid "Delete"
-msgstr ""
+msgstr "Eliminar"
 
 msgctxt "#30312"
 msgid "Keep files for not finished video"
-msgstr ""
+msgstr "Manter os arquivos de vídeos não concluídos"
 
 msgctxt "#30313"
 msgid "Keep files for watched/downloaded video"
-msgstr ""
+msgstr "Manter os arquivos de vídeos vistos/baixados"
 
 msgctxt "#30314"
 msgid "Settings were not initialized.[CR]Save addon settings, then restart Kodi."
-msgstr ""
+msgstr "As configurações não foram inicializadas.[CR]Salve as configurações do add-on e reinicie o Kodi."
 
 msgctxt "#30315"
 msgid "Download storage type"
-msgstr ""
+msgstr "Tipo de armazenamento dos downloads"
 
 msgctxt "#30316"
 msgid "Use files"
-msgstr ""
+msgstr "Usar arquivos"
 
 msgctxt "#30317"
 msgid "Use memory"
-msgstr ""
+msgstr "Usar memória"
 
 msgctxt "#30318"
 msgid "Memory size to use for each torrent, Mb"
-msgstr ""
+msgstr "Memória a usar para cada torrent, MB"
 
 msgctxt "#30319"
 msgid "Continue"
-msgstr ""
+msgstr "Continuar"
 
 msgctxt "#30320"
 msgid "Ask to stop"
-msgstr ""
+msgstr "Perguntar antes de parar"
 
 msgctxt "#30321"
 msgid "Stop"
-msgstr ""
+msgstr "Parar"
 
 msgctxt "#30323"
 msgid "New search"
-msgstr ""
+msgstr "Nova pesquisa"
 
 msgctxt "#30324"
 msgid "Force stream auto-selection from settings"
-msgstr ""
+msgstr "Forçar a seleção automática de streams a partir das configurações"
 
 msgctxt "#30325"
 msgid "Download"
-msgstr ""
+msgstr "Download"
 
 msgctxt "#30326"
 msgid "Kodi library"
-msgstr ""
+msgstr "Biblioteca do Kodi"
 
 msgctxt "#30327"
 msgid "Storage"
-msgstr ""
+msgstr "Armazenamento"
 
 msgctxt "#30328"
 msgid "Disable TCP"
-msgstr ""
+msgstr "Desativar TCP"
 
 msgctxt "#30329"
 msgid "Disable UTP"
-msgstr ""
+msgstr "Desativar UTP"
 
 msgctxt "#30330"
 msgid "Update Trakt"
-msgstr ""
+msgstr "Atualizar o Trakt"
 
 msgctxt "#30332"
 msgid "Reloading configuration..."
-msgstr ""
+msgstr "Recarregando a configuração..."
 
 msgctxt "#30333"
 msgid "Try to find other episodes in the torrent"
-msgstr ""
+msgstr "Tentar encontrar outros episódios no torrent"
 
 msgctxt "#30347"
 msgid "Could not find binary for architecture '%s'![CR]Try to uninstall this addon, re-download and re-install it from the biggest zip."
-msgstr ""
+msgstr "Não foi possível encontrar o binário para a arquitetura '%s'![CR]Tente desinstalar este add-on, baixá-lo novamente e reinstalá-lo a partir do zip maior."
 
 msgctxt "#30348"
 msgid "Create usual files on the file system and write to them.[CR]Needs selected file's full size to be available on the disk!"
-msgstr ""
+msgstr "Cria arquivos normais no sistema de arquivos e escreve neles.[CR]Precisa que o tamanho total do arquivo selecionado esteja disponível no disco!"
 
 msgctxt "#30349"
 msgid "Using device's memory to download parts of the torrent.[CR]Disk is used only to download and save .torrent file,"
-msgstr ""
+msgstr "Usa a memória do dispositivo para baixar partes do torrent.[CR]O disco é usado apenas para baixar e guardar o arquivo .torrent,"
 
 msgctxt "#30350"
 msgid "so can be any storage. For 1gb memory devices[CR]100mb is enough for memory storage, 200-250mb for bigger devices."
-msgstr ""
+msgstr "por isso pode ser qualquer armazenamento. Para dispositivos com 1 GB[CR]bastam 100 MB, e 200-250 MB para dispositivos maiores."
 
 msgctxt "#30351"
 msgid "Same as for usual file storage, but splits file into many small files.[CR]Should be used on FAT-32 file-systems."
-msgstr ""
+msgstr "Igual ao armazenamento normal em arquivos, mas divide o arquivo em muitos arquivos pequenos.[CR]Deve ser usado em sistemas de arquivos FAT-32."
 
 msgctxt "#30352"
 msgid "Same as for usual file storage, but using memory[CR]to lower filesystem operations. Experimental storage!"
-msgstr ""
+msgstr "Igual ao armazenamento normal em arquivos, mas usa a memória[CR]para reduzir as operações no sistema de arquivos. Armazenamento experimental!"
 
 msgctxt "#30355"
 msgid "Changelog"
-msgstr ""
+msgstr "Registo de alterações"
 
 msgctxt "#30357"
 msgid "Use Trakt information in Trakt lists"
-msgstr ""
+msgstr "Usar a informação do Trakt nas listas do Trakt"
 
 msgctxt "#30358"
 msgid "Trakt update started"
-msgstr ""
+msgstr "Atualização do Trakt iniciada"
 
 msgctxt "#30359"
 msgid "Do not ask questions before playback"
-msgstr ""
+msgstr "Não fazer perguntas antes da reprodução"
 
 msgctxt "#30360"
 msgid "My Progress"
-msgstr ""
+msgstr "O meu progresso"
 
 msgctxt "#30361"
 msgid "My History"
-msgstr ""
+msgstr "O meu histórico"
 
 msgctxt "#30362"
 msgid "Synchronization"
-msgstr ""
+msgstr "Sincronização"
 
 msgctxt "#30363"
 msgid "Sync items from collections into Kodi library"
-msgstr ""
+msgstr "Sincronizar os itens das coleções para a biblioteca do Kodi"
 
 msgctxt "#30364"
 msgid "Sync items from watchlist into Kodi library"
-msgstr ""
+msgstr "Sincronizar os itens da lista de interesses para a biblioteca do Kodi"
 
 msgctxt "#30365"
 msgid "Sync items from user lists into Kodi library"
-msgstr ""
+msgstr "Sincronizar os itens das listas de usuário para a biblioteca do Kodi"
 
 msgctxt "#30366"
 msgid "Sync watched states from Trakt into Kodi library"
-msgstr ""
+msgstr "Sincronizar o estado de visto do Trakt para a biblioteca do Kodi"
 
 msgctxt "#30367"
 msgid "Sync back Kodi watched states into Trakt"
-msgstr ""
+msgstr "Sincronizar o estado de visto do Kodi de volta para o Trakt"
 
 msgctxt "#30369"
 msgid "Disable Upload"
-msgstr ""
+msgstr "Desativar o envio"
 
 msgctxt "#30370"
 msgid "Auto-assign network IP"
-msgstr ""
+msgstr "Atribuir automaticamente o IP de rede"
 
 msgctxt "#30371"
 msgid "Auto-assign network ports"
-msgstr ""
+msgstr "Atribuir automaticamente as portas de rede"
 
 msgctxt "#30373"
 msgid "Languages"
-msgstr ""
+msgstr "Idiomas"
 
 msgctxt "#30374"
 msgid "Countries"
-msgstr ""
+msgstr "Países"
 
 msgctxt "#30375"
 msgid "By size"
-msgstr ""
+msgstr "Por tamanho"
 
 msgctxt "#30376"
 msgid "Choose memory size automatically"
-msgstr ""
+msgstr "Escolher o tamanho da memória automaticamente"
 
 msgctxt "#30377"
 msgid "Size is chosen automatically, based on[CR]physical amount of memory"
-msgstr ""
+msgstr "O tamanho é escolhido automaticamente, com base na[CR]quantidade de memória física"
 
 msgctxt "#30378"
 msgid "Allow memory usage"
-msgstr ""
+msgstr "Permitir o uso de memória"
 
 msgctxt "#30379"
 msgid "Minimum - 40MB, Default - 8%, Maximum - 15%"
-msgstr ""
+msgstr "Mínimo - 40 MB, Padrão - 8%, Máximo - 15%"
 
 msgctxt "#30380"
 msgid "Minimum"
-msgstr ""
+msgstr "Mínimo"
 
 msgctxt "#30381"
 msgid "Default"
-msgstr ""
+msgstr "Padrão"
 
 msgctxt "#30382"
 msgid "Maximum"
-msgstr ""
+msgstr "Máximo"
 
 msgctxt "#30383"
 msgid "Use Kodi language for subtitles search"
-msgstr ""
+msgstr "Usar o idioma do Kodi na pesquisa de legendas"
 
 msgctxt "#30384"
 msgid "Language code for subtitles (example: en, it, es)"
-msgstr ""
+msgstr "Código de idioma das legendas (exemplo: en, it, es)"
 
 msgctxt "#30386"
 msgid "Disable background progress dialog on playback"
-msgstr ""
+msgstr "Desativar a janela de progresso em segundo plano durante a reprodução"
 
 msgctxt "#30387"
 msgid "Caching"
-msgstr ""
+msgstr "Cache"
 
 msgctxt "#30388"
 msgid "Cache stream selection"
-msgstr ""
+msgstr "Armazenar em cache a seleção de streams"
 
 msgctxt "#30389"
 msgid "Cache stream search results"
-msgstr ""
+msgstr "Armazenar em cache os resultados de pesquisa de streams"
 
 msgctxt "#30390"
 msgid "Cache search results duration, seconds"
-msgstr ""
+msgstr "Duração da cache dos resultados de pesquisa, segundos"
 
 msgctxt "#30393"
 msgid "Status"
-msgstr ""
+msgstr "Estado"
 
 msgctxt "#30394"
 msgid "Version"
-msgstr ""
+msgstr "Versão"
 
 msgctxt "#30395"
 msgid "IP address"
-msgstr ""
+msgstr "Endereço IP"
 
 msgctxt "#30396"
 msgid "Port"
-msgstr ""
+msgstr "Porta"
 
 msgctxt "#30397"
 msgid "Web UI"
-msgstr ""
+msgstr "Interface web"
 
 msgctxt "#30398"
 msgid "Debug information (with kodi.log)"
-msgstr ""
+msgstr "Informação de depuração (com kodi.log)"
 
 msgctxt "#30399"
 msgid "Addresses"
-msgstr ""
+msgstr "Endereços"
 
 msgctxt "#30400"
 msgid "Statistics"
-msgstr ""
+msgstr "Estatísticas"
 
 msgctxt "#30401"
 msgid "Torrent library status"
-msgstr ""
+msgstr "Estado da biblioteca de torrents"
 
 msgctxt "#30402"
 msgid "Size of cache.db"
-msgstr ""
+msgstr "Tamanho de cache.db"
 
 msgctxt "#30403"
 msgid "Size of app.db"
-msgstr ""
+msgstr "Tamanho de app.db"
 
 msgctxt "#30404"
 msgid "Assigned torrent files"
-msgstr ""
+msgstr "Arquivos torrent atribuídos"
 
 msgctxt "#30405"
 msgid "Search queries"
-msgstr ""
+msgstr "Pesquisas efetuadas"
 
 msgctxt "#30406"
 msgid "Remove from history"
-msgstr ""
+msgstr "Remover do histórico"
 
 msgctxt "#30408"
 msgid "Addon Connectivity"
-msgstr ""
+msgstr "Conexão do add-on"
 
 msgctxt "#30409"
 msgid "Local port"
-msgstr ""
+msgstr "Porta local"
 
 msgctxt "#30410"
 msgid "Remote port"
-msgstr ""
+msgstr "Porta remota"
 
 msgctxt "#30411"
 msgid "Remote host"
-msgstr ""
+msgstr "Host remoto"
 
 msgctxt "#30412"
 msgid "Do not start binary (client mode)"
-msgstr ""
+msgstr "Não iniciar o binário (modo cliente)"
 
 msgctxt "#30413"
 msgid "Yes"
-msgstr ""
+msgstr "Sim"
 
 msgctxt "#30414"
 msgid "No"
-msgstr ""
+msgstr "Não"
 
 msgctxt "#30415"
 msgid "Next page (%s)"
-msgstr ""
+msgstr "Página seguinte (%s)"
 
 msgctxt "#30416"
 msgid "Percents of playback to mark as watched"
-msgstr ""
+msgstr "Porcentagem de reprodução para marcar como visto"
 
 msgctxt "#30417"
 msgid "Use name of production company as Studio for shows"
-msgstr ""
+msgstr "Usar o nome da produtora como Estúdio nas séries"
 
 msgctxt "#30418"
 msgid "Calculate number of unwatched episodes in Shows/Seasons"
-msgstr ""
+msgstr "Calcular o número de episódios não vistos em Séries/Temporadas"
 
 msgctxt "#30421"
 msgid "Load torrents from torrents folder on startup"
-msgstr ""
+msgstr "Carregar os torrents da pasta de torrents no arranque"
 
 msgctxt "#30422"
 msgid "Popular lists"
-msgstr ""
+msgstr "Listas populares"
 
 msgctxt "#30423"
 msgid "Recommendations"
-msgstr ""
+msgstr "Recomendações"
 
 msgctxt "#30424"
 msgid "Progress"
-msgstr ""
+msgstr "Progresso"
 
 msgctxt "#30425"
 msgid "Color of an air date"
-msgstr ""
+msgstr "Cor da data de estreia"
 
 msgctxt "#30426"
 msgid "Color of a show name"
-msgstr ""
+msgstr "Cor do nome da série"
 
 msgctxt "#30427"
 msgid "Color of an episode name"
-msgstr ""
+msgstr "Cor do nome do episódio"
 
 msgctxt "#30428"
 msgid "Hide unaired episodes"
-msgstr ""
+msgstr "Ocultar episódios por estrear"
 
 msgctxt "#30429"
 msgid "Sort shows in the list"
-msgstr ""
+msgstr "Ordenar as séries na lista"
 
 msgctxt "#30430"
 msgid "By latest watched"
-msgstr ""
+msgstr "Por visualização mais recente"
 
 msgctxt "#30431"
 msgid "By show name"
-msgstr ""
+msgstr "Por nome da série"
 
 msgctxt "#30432"
 msgid "By air date (newer)"
-msgstr ""
+msgstr "Por data de estreia (mais recente)"
 
 msgctxt "#30433"
 msgid "By air date (older)"
-msgstr ""
+msgstr "Por data de estreia (mais antiga)"
 
 msgctxt "#30434"
 msgid "Date format"
-msgstr ""
+msgstr "Formato da data"
 
 msgctxt "#30436"
 msgid "Userlist"
-msgstr ""
+msgstr "Lista de usuário"
 
 msgctxt "#30438"
 msgid "Userlists"
-msgstr ""
+msgstr "Listas de usuário"
 
 msgctxt "#30439"
 msgid "Debug information (without kodi.log)"
-msgstr ""
+msgstr "Informação de depuração (sem kodi.log)"
 
 msgctxt "#30440"
 msgid "Color of an unaired episode name"
-msgstr ""
+msgstr "Cor do nome de um episódio por estrear"
 
 msgctxt "#30441"
 msgid "Select userlist for movies"
-msgstr ""
+msgstr "Selecionar a lista de usuário para filmes"
 
 msgctxt "#30442"
 msgid "Userlist for movies"
-msgstr ""
+msgstr "Lista de usuário para filmes"
 
 msgctxt "#30443"
 msgid "Selected userlist for movies"
-msgstr ""
+msgstr "Lista de usuário selecionada para filmes"
 
 msgctxt "#30444"
 msgid "Select userlist for shows"
-msgstr ""
+msgstr "Selecionar a lista de usuário para séries"
 
 msgctxt "#30445"
 msgid "Userlist for shows"
-msgstr ""
+msgstr "Lista de usuário para séries"
 
 msgctxt "#30446"
 msgid "Selected userlist for shows"
-msgstr ""
+msgstr "Lista de usuário selecionada para séries"
 
 msgctxt "#30447"
 msgid "Add to Trakt, when movie is added to Kodi library"
-msgstr ""
+msgstr "Adicionar ao Trakt quando um filme é adicionado à biblioteca do Kodi"
 
 msgctxt "#30448"
 msgid "Add to Trakt, when show is added to Kodi library"
-msgstr ""
+msgstr "Adicionar ao Trakt quando uma série é adicionada à biblioteca do Kodi"
 
 msgctxt "#30449"
 msgid "Remove from Trakt, when movie is deleted from Kodi library"
-msgstr ""
+msgstr "Remover do Trakt quando um filme é eliminado da biblioteca do Kodi"
 
 msgctxt "#30450"
 msgid "Remove from Trakt, when show is deleted from Kodi library"
-msgstr ""
+msgstr "Remover do Trakt quando uma série é eliminada da biblioteca do Kodi"
 
 msgctxt "#30451"
 msgid "Torrent files path"
-msgstr ""
+msgstr "Caminho dos arquivos torrent"
 
 msgctxt "#30452"
 msgid "Reset all paths"
-msgstr ""
+msgstr "Redefinir todos os caminhos"
 
 msgctxt "#30453"
 msgid "Upload /debug/bundle (with kodi.log) to pastebin"
-msgstr ""
+msgstr "Enviar /debug/bundle (com kodi.log) para o pastebin"
 
 msgctxt "#30454"
 msgid "Paste url:[CR]%s"
-msgstr ""
+msgstr "URL do paste:[CR]%s"
 
 msgctxt "#30455"
 msgid "Logging"
-msgstr ""
+msgstr "Registo"
 
 msgctxt "#30456"
 msgid "Upload /debug/all (no kodi.log) to pastebin"
-msgstr ""
+msgstr "Enviar /debug/all (sem kodi.log) para o pastebin"
 
 msgctxt "#30457"
 msgid "Uploading file to pastebin"
-msgstr ""
+msgstr "Enviando o arquivo para o pastebin"
 
 msgctxt "#30458"
 msgid "Deleted movies"
-msgstr ""
+msgstr "Filmes eliminados"
 
 msgctxt "#30459"
 msgid "Deleted shows"
-msgstr ""
+msgstr "Séries eliminadas"
 
 msgctxt "#30460"
 msgid "Database"
-msgstr ""
+msgstr "Banco de dados"
 
 msgctxt "#30461"
 msgid "Show information"
-msgstr ""
+msgstr "Mostrar informação"
 
 msgctxt "#30462"
 msgid "Clear deleted movies"
-msgstr ""
+msgstr "Limpar os filmes eliminados"
 
 msgctxt "#30463"
 msgid "Clear deleted shows"
-msgstr ""
+msgstr "Limpar as séries eliminadas"
 
 msgctxt "#30464"
 msgid "Clear torrents history"
-msgstr ""
+msgstr "Limpar o histórico de torrents"
 
 msgctxt "#30465"
 msgid "Clear search history"
-msgstr ""
+msgstr "Limpar o histórico de pesquisas"
 
 msgctxt "#30466"
 msgid "Clear the database"
-msgstr ""
+msgstr "Limpar o banco de dados"
 
 msgctxt "#30467"
 msgid "Cache"
-msgstr ""
+msgstr "Cache"
 
 msgctxt "#30468"
 msgid "Clear TMDB cache"
-msgstr ""
+msgstr "Limpar a cache do TMDB"
 
 msgctxt "#30469"
 msgid "Clear Trakt cache"
-msgstr ""
+msgstr "Limpar a cache do Trakt"
 
 msgctxt "#30470"
 msgid "Clear the cache"
-msgstr ""
+msgstr "Limpar a cache"
 
 msgctxt "#30471"
 msgid "Are you sure you want to do it?"
-msgstr ""
+msgstr "Tem certeza de que deseja fazer isso?"
 
 msgctxt "#30472"
 msgid "Database cleared"
-msgstr ""
+msgstr "Banco de dados limpo"
 
 msgctxt "#30473"
 msgid "Select network interface"
-msgstr ""
+msgstr "Selecionar a interface de rede"
 
 msgctxt "#30474"
 msgid "Network interfaces"
-msgstr ""
+msgstr "Interfaces de rede"
 
 msgctxt "#30475"
 msgid "Strm files language"
-msgstr ""
+msgstr "Idioma dos arquivos strm"
 
 msgctxt "#30476"
 msgid "Select language"
-msgstr ""
+msgstr "Selecionar idioma"
 
 msgctxt "#30477"
 msgid "Original language"
-msgstr ""
+msgstr "Idioma original"
 
 msgctxt "#30478"
 msgid "Searching"
-msgstr ""
+msgstr "Pesquisando"
 
 msgctxt "#30480"
 msgid "Run Kodi library update after add/delete"
-msgstr ""
+msgstr "Executar a atualização da biblioteca do Kodi após adicionar/eliminar"
 
 msgctxt "#30481"
 msgid "Automatically"
-msgstr ""
+msgstr "Automaticamente"
 
 msgctxt "#30482"
 msgid "Ask"
-msgstr ""
+msgstr "Perguntar"
 
 msgctxt "#30483"
 msgid "Create NFO files for Movie scrapers"
-msgstr ""
+msgstr "Criar arquivos NFO para os scrapers de filmes"
 
 msgctxt "#30484"
 msgid "Create NFO files for TV Show scrapers"
-msgstr ""
+msgstr "Criar arquivos NFO para os scrapers de séries"
 
 msgctxt "#30485"
 msgid "Concurrent connections limit per second"
-msgstr ""
+msgstr "Limite de conexões simultâneas por segundo"
 
 msgctxt "#30486"
 msgid "Automatic concurrent connections limit per second"
-msgstr ""
+msgstr "Limite automático de conexões simultâneas por segundo"
 
 msgctxt "#30487"
 msgid "Enable built-in HTTP proxy"
-msgstr ""
+msgstr "Ativar o proxy HTTP integrado"
 
 msgctxt "#30488"
 msgid "Internal Proxy Port"
-msgstr ""
+msgstr "Porta do proxy interno"
 
 msgctxt "#30489"
 msgid "Log Internal proxy requests"
-msgstr ""
+msgstr "Registar os pedidos do proxy interno"
 
 msgctxt "#30490"
 msgid "Internal HTTP proxy"
-msgstr ""
+msgstr "Proxy HTTP interno"
 
 msgctxt "#30491"
 msgid "Use Fanart.tv for posters/images"
-msgstr ""
+msgstr "Usar o Fanart.tv para cartazes/imagens"
 
 msgctxt "#30492"
 msgid "Use Proxy for downloading .torrent files"
-msgstr ""
+msgstr "Usar o proxy para baixar arquivos .torrent"
 
 msgctxt "#30493"
 msgid "Use Proxy for trackers"
-msgstr ""
+msgstr "Usar o proxy para os trackers"
 
 msgctxt "#30494"
 msgid "Use Proxy for torrent downloading"
-msgstr ""
+msgstr "Usar o proxy para baixar torrents"
 
 msgctxt "#30495"
 msgid "Use built-in DNS resolver"
-msgstr ""
+msgstr "Usar o resolvedor de DNS integrado"
 
 msgctxt "#30496"
 msgid "Turn off if you use Tor addresses, or you want [CR]to use DNS settings from OS"
-msgstr ""
+msgstr "Desative se você usa endereços Tor, ou se quiser [CR]usar as configurações de DNS do sistema operacional"
 
 msgctxt "#30497"
 msgid "Use Antizapret proxy (only for Russia)"
-msgstr ""
+msgstr "Usar o proxy Antizapret (apenas para a Rússia)"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"
-msgstr ""
+msgstr "Redefinir este caminho para '/'"
 
 msgctxt "#30499"
 msgid "Automatically adjust memory size[CR]for heavy torrents, if possible"
-msgstr ""
+msgstr "Ajustar automaticamente o tamanho da memória[CR]para torrents pesados, se possível"
 
 msgctxt "#30500"
 msgid "Automatically adjust buffer size[CR]for heavy torrents"
-msgstr ""
+msgstr "Ajustar automaticamente o tamanho da buffer[CR]para torrents pesados"
 
 msgctxt "#30502"
 msgid "Adjust buffer according to Kodi advancedsettings.xml, if set"
-msgstr ""
+msgstr "Ajustar a buffer de acordo com o advancedsettings.xml do Kodi, se definido"
 
 msgctxt "#30503"
 msgid "Use libtorrent.config to override torrent engine settings"
-msgstr ""
+msgstr "Usar o libtorrent.config para substituir as configurações do motor de torrents"
 
 msgctxt "#30504"
 msgid "Located at USERDATA/plugin.video.elementum/libtorrent.config file[CR]Settings apply automatically. Visit https://libtorrent.org for info."
-msgstr ""
+msgstr "Localizado no arquivo USERDATA/plugin.video.elementum/libtorrent.config[CR]As configurações são aplicadas automaticamente. Acesse https://libtorrent.org para mais informações."
 
 msgctxt "#30505"
 msgid "Add episode number to the title"
-msgstr ""
+msgstr "Adicionar o número do episódio ao título"
 
 msgctxt "#30506"
 msgid "Enable libtorrent logging"
-msgstr ""
+msgstr "Ativar o registo do libtorrent"
 
 msgctxt "#30511"
 msgid "Libtorrent settings profile"
-msgstr ""
+msgstr "Perfil de configurações do libtorrent"
 
 msgctxt "#30512"
 msgid "Default"
-msgstr ""
+msgstr "Padrão"
 
 msgctxt "#30513"
 msgid "Minimal memory"
-msgstr ""
+msgstr "Memória mínima"
 
 msgctxt "#30514"
 msgid "High speed"
-msgstr ""
+msgstr "Alta velocidade"
 
 msgctxt "#30515"
 msgid "Load torrents from torrents folder paused"
-msgstr ""
+msgstr "Carregar os torrents da pasta de torrents em pausa"
 
 msgctxt "#30516"
 msgid "... resume N seconds earlier"
-msgstr ""
+msgstr "... retomar N segundos antes"
 
 msgctxt "#30517"
 msgid "In Kodi library"
-msgstr ""
+msgstr "Na biblioteca do Kodi"
 
 msgctxt "#30518"
 msgid "Use libtorrent deadlines"
-msgstr ""
+msgstr "Usar os prazos do libtorrent"
 
 msgctxt "#30519"
 msgid "Use libtorrent pause/resume trick for added torrents"
-msgstr ""
+msgstr "Usar o truque de pausa/retoma do libtorrent para os torrents adicionados"
 
 msgctxt "#30520"
 msgid "Add item to start menu"
-msgstr ""
+msgstr "Adicionar item ao menu inicial"
 
 msgctxt "#30521"
 msgid "Delete item from start menu"
-msgstr ""
+msgstr "Remover item do menu inicial"
 
 msgctxt "#30522"
 msgid "Minimum file size"
-msgstr ""
+msgstr "Tamanho mínimo do arquivo"
 
 msgctxt "#30523"
 msgid "Minimum file size for Movies, MB"
-msgstr ""
+msgstr "Tamanho mínimo do arquivo para filmes, MB"
 
 msgctxt "#30524"
 msgid "Minimum file size for Shows, MB per minute"
-msgstr ""
+msgstr "Tamanho mínimo do arquivo para séries, MB por minuto"
 
 msgctxt "#30525"
 msgid "Automatically start downloading next episode"
-msgstr ""
+msgstr "Começar automaticamente a baixar o episódio seguinte"
 
 msgctxt "#30527"
 msgid "Donate"
-msgstr ""
+msgstr "Doar"
 
 msgctxt "#30528"
 msgid "Automatically load first found subtitles"
-msgstr ""
+msgstr "Carregar automaticamente as primeiras legendas encontradas"
 
 msgctxt "#30529"
 msgid "Number of subtitles to load automatically"
-msgstr ""
+msgstr "Número de legendas a carregar automaticamente"
 
 msgctxt "#30530"
 msgid "Delete autoloaded subtitles on player stop"
-msgstr ""
+msgstr "Eliminar as legendas carregadas automaticamente ao parar o reprodutor"
 
 msgctxt "#30531"
 msgid "Download all files from torrent"
-msgstr ""
+msgstr "Baixar todos os arquivos do torrent"
 
 msgctxt "#30532"
 msgid "Stop Downloading all files"
-msgstr ""
+msgstr "Parar o download de todos os arquivos"
 
 msgctxt "#30535"
 msgid "Continue playback from [B]%s[/B]?"
-msgstr ""
+msgstr "Continuar a reprodução a partir de [B]%s[/B]?"
 
 msgctxt "#30536"
 msgid "Skip IPv6 addresses resolving"
-msgstr ""
+msgstr "Ignorar a resolução de endereços IPv6"
 
 msgctxt "#30537"
 msgid "Torrents history"
-msgstr ""
+msgstr "Histórico de torrents"
 
 msgctxt "#30538"
 msgid "Use torrents history?"
-msgstr ""
+msgstr "Usar o histórico de torrents?"
 
 msgctxt "#30539"
 msgid "Store N torrents in history"
-msgstr ""
+msgstr "Armazenar N torrents no histórico"
 
 msgctxt "#30540"
 msgid "Subtitles"
-msgstr ""
+msgstr "Legendas"
 
 msgctxt "#30541"
 msgid "Automatic Subtitles Search"
-msgstr ""
+msgstr "Pesquisa automática de legendas"
 
 msgctxt "#30542"
 msgid "Disable if subtitles are available in player"
-msgstr ""
+msgstr "Desativar se as legendas estiverem disponíveis no reprodutor"
 
 msgctxt "#30543"
 msgid "Subtitles included in torrent"
-msgstr ""
+msgstr "Legendas incluídas no torrent"
 
 msgctxt "#30544"
 msgid "Automatic Scrape"
-msgstr ""
+msgstr "Recolha automática"
 
 msgctxt "#30545"
 msgid "Automatic scraping allows to scrape connected providers[CR]to find new movies, if there are results,"
-msgstr ""
+msgstr "A coleta automática permite pesquisar nos provedores conectados[CR]por filmes novos. Se houver resultados"
 
 msgctxt "#30546"
 msgid "Strategy"
-msgstr ""
+msgstr "Estratégia"
 
 msgctxt "#30547"
 msgid "Find in each provider"
-msgstr ""
+msgstr "Procurar em cada provedor"
 
 msgctxt "#30548"
 msgid "Find in overall"
-msgstr ""
+msgstr "Procurar no conjunto"
 
 msgctxt "#30549"
 msgid "Search is successful when found N results"
-msgstr ""
+msgstr "A pesquisa é bem-sucedida quando encontra N resultados"
 
 msgctxt "#30550"
 msgid "What to search"
-msgstr ""
+msgstr "O que pesquisar"
 
 msgctxt "#30551"
 msgid "How to search"
-msgstr ""
+msgstr "Como pesquisar"
 
 msgctxt "#30552"
 msgid "Search each N hours"
-msgstr ""
+msgstr "Pesquisar a cada N horas"
 
 msgctxt "#30553"
 msgid "Find 4K resolution"
-msgstr ""
+msgstr "Encontrar resolução 4K"
 
 msgctxt "#30554"
 msgid "Find 1080p resolution"
-msgstr ""
+msgstr "Encontrar resolução 1080p"
 
 msgctxt "#30555"
 msgid "and movie passes checks for number of results[CR]movie can be added to the library."
-msgstr ""
+msgstr "e o filme passar nas verificações do número de resultados,[CR]pode ser adicionado à biblioteca."
 
 msgctxt "#30556"
 msgid "Add to the library"
-msgstr ""
+msgstr "Adicionar à biblioteca"
 
 msgctxt "#30557"
 msgid "Number of popular movies to search"
-msgstr ""
+msgstr "Número de filmes populares a pesquisar"
 
 msgctxt "#30558"
 msgid "Latest available movies"
-msgstr ""
+msgstr "Filmes mais recentes disponíveis"
 
 msgctxt "#30559"
 msgid "Skip searching for installed providers"
-msgstr ""
+msgstr "Ignorar a pesquisa de provedores instalados"
 
 msgctxt "#30560"
 msgid "Files: %s"
-msgstr ""
+msgstr "Arquivos: %s"
 
 msgctxt "#30561"
 msgid "Interval between requests, seconds"
-msgstr ""
+msgstr "Intervalo entre pedidos, segundos"
 
 msgctxt "#30562"
 msgid "Open directory with Kodi file browser"
-msgstr ""
+msgstr "Abrir a pasta com o explorador de arquivos do Kodi"
 
 msgctxt "#30563"
 msgid "Synchronize frequency of Trakt, minutes"
-msgstr ""
+msgstr "Frequência de sincronização com o Trakt, minutos"
 
 msgctxt "#30564"
 msgid "Sync hidden items"
-msgstr ""
+msgstr "Sincronizar os itens ocultos"
 
 msgctxt "#30565"
 msgid "Sync playback progress into Kodi library"
-msgstr ""
+msgstr "Sincronizar o progresso de reprodução para a biblioteca do Kodi"
 
 msgctxt "#30566"
 msgid "Lists"
-msgstr ""
+msgstr "Listas"
 
 msgctxt "#30567"
 msgid "Show \"All seasons\" in shows"
-msgstr ""
+msgstr "Mostrar \"Todas as temporadas\" nas séries"
 
 msgctxt "#30568"
 msgid "Seasons order"
-msgstr ""
+msgstr "Ordem das temporadas"
 
 msgctxt "#30569"
 msgid "Ascending"
-msgstr ""
+msgstr "Ascendente"
 
 msgctxt "#30570"
 msgid "Descending"
-msgstr ""
+msgstr "Descendente"
 
 msgctxt "#30571"
 msgid "* All seasons"
-msgstr ""
+msgstr "* Todas as temporadas"
 
 msgctxt "#30572"
 msgid "Log server's response body"
-msgstr ""
+msgstr "Registar o corpo da resposta do servidor"
 
 msgctxt "#30573"
 msgid "Select file to play"
-msgstr ""
+msgstr "Selecionar o arquivo a reproduzir"
 
 msgctxt "#30574"
 msgid "Automatically answer Yes after timeout"
-msgstr ""
+msgstr "Responder Sim automaticamente após o tempo limite"
 
 msgctxt "#30575"
 msgid "Timeout, seconds"
-msgstr ""
+msgstr "Tempo limite, segundos"
 
 msgctxt "#30576"
 msgid "Trakt authentication needs to be updated!"
-msgstr ""
+msgstr "A autenticação do Trakt precisa ser atualizada!"
 
 msgctxt "#30577"
 msgid "End of file Buffer size, MB"
-msgstr ""
+msgstr "Tamanho da buffer no fim do arquivo, MB"
 
 msgctxt "#30578"
 msgid "Beginning of file Buffer size, MB"
-msgstr ""
+msgstr "Tamanho da buffer no início do arquivo, MB"
 
 msgctxt "#30579"
 msgid "Settings"
-msgstr ""
+msgstr "Configurações"
 
 msgctxt "#30580"
 msgid "Custom Trakt API Client ID"
-msgstr ""
+msgstr "Client ID personalizado da API do Trakt"
 
 msgctxt "#30581"
 msgid "Custom Trakt API Client Secret"
-msgstr ""
+msgstr "Client Secret personalizado da API do Trakt"
 
 msgctxt "#30582"
 msgid "Settings for %s provider"
-msgstr ""
+msgstr "Configurações do provedor %s"
 
 msgctxt "#30583"
 msgid "Resolving magnet link"
-msgstr ""
+msgstr "Resolvendo o link magnet"
 
 msgctxt "#30585"
 msgid "Enable library integration with Kodi"
-msgstr ""
+msgstr "Ativar a integração com a biblioteca do Kodi"
 
 msgctxt "#30586"
 msgid "If disabled - Elementum will not get/insert items to Kodi library [CR]and skip watched management with Kodi."
-msgstr ""
+msgstr "Se estiver desativado, o Elementum não obtém nem insere itens na biblioteca do Kodi [CR]e ignora a gestão do estado de visto com o Kodi."
 
 msgctxt "#30587"
 msgid "Show welcome message on start"
-msgstr ""
+msgstr "Mostrar a mensagem de boas-vindas no arranque"
 
 msgctxt "#30588"
 msgid "Pre-Play Buffering"
-msgstr ""
+msgstr "Buffer antes da reprodução"
 
 msgctxt "#30589"
 msgid "Speed limiting"
-msgstr ""
+msgstr "Limitação de velocidade"
 
 msgctxt "#30590"
 msgid "Torrents autoload on addon startup"
-msgstr ""
+msgstr "Carregamento automático de torrents no arranque do add-on"
 
 msgctxt "#30591"
 msgid "Limits for connections"
-msgstr ""
+msgstr "Limites das conexões"
 
 msgctxt "#30592"
 msgid "Seeding"
-msgstr ""
+msgstr "Semeadura"
 
 msgctxt "#30593"
 msgid "Seed forever"
-msgstr ""
+msgstr "Semear para sempre"
 
 msgctxt "#30594"
 msgid "Network"
-msgstr ""
+msgstr "Rede"
 
 msgctxt "#30595"
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Diversos"
 
 msgctxt "#30597"
 msgid "Cache size, MB"
-msgstr ""
+msgstr "Tamanho da cache, MB"
 
 msgctxt "#30598"
 msgid "Enable caching if using File storage and have speed problems.[CR]Will use more memory, but can improve the speed."
-msgstr ""
+msgstr "Ative o cache se você usa armazenamento em arquivos e tem problemas de velocidade.[CR]Usará mais memória, mas pode melhorar a velocidade."
 
 msgctxt "#30599"
 msgid "Enable Kodi library synchronization"
-msgstr ""
+msgstr "Ativar a sincronização com a biblioteca do Kodi"
 
 msgctxt "#30600"
 msgid "Enable Trakt synchronization"
-msgstr ""
+msgstr "Ativar a sincronização com o Trakt"
 
 msgctxt "#30601"
 msgid "Enable synchronization while playback"
-msgstr ""
+msgstr "Ativar a sincronização durante a reprodução"
 
 msgctxt "#30602"
 msgid "Retry requests to addon after timeout, seconds"
-msgstr ""
+msgstr "Repetir os pedidos ao add-on após o tempo limite, segundos"
 
 msgctxt "#30603"
 msgid "Addon Startup"
-msgstr ""
+msgstr "Arranque do add-on"
 
 msgctxt "#30604"
 msgid "Clean all history"
-msgstr ""
+msgstr "Limpar todo o histórico"
 
 msgctxt "#30605"
 msgid "Cache downloaded torrent files after search"
-msgstr ""
+msgstr "Armazenar em cache os arquivos torrent baixados após a pesquisa"
 
 msgctxt "#30606"
 msgid "Show watched state for torrent's files"
-msgstr ""
+msgstr "Mostrar o estado de visto dos arquivos do torrent"
 
 msgctxt "#30607"
 msgid "Use earliest release date as basic for searching"
-msgstr ""
+msgstr "Usar a data de lançamento mais antiga como base da pesquisa"
 
 msgctxt "#30608"
 msgid "Match found in your active torrents, play it?[CR]%s"
-msgstr ""
+msgstr "Foi encontrada uma correspondência nos seus torrents ativos, reproduzir?[CR]%s"
 
 msgctxt "#30609"
 msgid "Automatically start next episode if available"
-msgstr ""
+msgstr "Iniciar automaticamente o episódio seguinte, se disponível"
 
 msgctxt "#30610"
 msgid "Magnet resolve timeout, seconds"
-msgstr ""
+msgstr "Tempo limite para resolver o magnet, segundos"
 
 msgctxt "#30611"
 msgid "Application platform type"
-msgstr ""
+msgstr "Tipo de plataforma da aplicação"
 
 msgctxt "#30612"
 msgid "Select file to download"
-msgstr ""
+msgstr "Selecionar o arquivo a baixar"
 
 msgctxt "#30613"
 msgid "... for movie"
-msgstr ""
+msgstr "... para filme"
 
 msgctxt "#30614"
 msgid "... for tv show"
-msgstr ""
+msgstr "... para série"
 
 msgctxt "#30615"
 msgid "... for search"
-msgstr ""
+msgstr "... para pesquisa"
 
 msgctxt "#30616"
 msgid "Elementum | Trakt Account"
-msgstr ""
+msgstr "Elementum | Conta Trakt"
 
 msgctxt "#30617"
 msgid "Your account is locked for API on Trakt.tv[CR]Please, contact Trakt Support at https://support.trakt.tv ."
-msgstr ""
+msgstr "Sua conta está bloqueada para a API no Trakt.tv[CR]Por favor, entre em contato com o suporte do Trakt em https://support.trakt.tv ."
 
 msgctxt "#30618"
 msgid "%s is downloaded"
-msgstr ""
+msgstr "%s foi baixado"
 
 msgctxt "#30619"
 msgid "Return to [B]%s[/B]"
-msgstr ""
+msgstr "Voltar a [B]%s[/B]"
 
 msgctxt "#30620"
 msgid "Restart Elementum addon"
-msgstr ""
+msgstr "Reiniciar o add-on Elementum"
 
 msgctxt "#30621"
 msgid "Queued"
-msgstr ""
+msgstr "Em fila"
 
 msgctxt "#30622"
 msgid "Checking"
-msgstr ""
+msgstr "Verificando"
 
 msgctxt "#30623"
 msgid "Finding"
-msgstr ""
+msgstr "Procurando"
 
 msgctxt "#30624"
 msgid "Downloading"
-msgstr ""
+msgstr "Baixando"
 
 msgctxt "#30625"
 msgid "Finished"
-msgstr ""
+msgstr "Concluído"
 
 msgctxt "#30626"
 msgid "Seeding"
-msgstr ""
+msgstr "Semeando"
 
 msgctxt "#30627"
 msgid "Allocating"
-msgstr ""
+msgstr "Alocando"
 
 msgctxt "#30628"
 msgid "Stalled"
-msgstr ""
+msgstr "Travado"
 
 msgctxt "#30629"
 msgid "Paused"
-msgstr ""
+msgstr "Em pausa"
 
 msgctxt "#30630"
 msgid "Buffering"
-msgstr ""
+msgstr "Preenchendo o buffer"
 
 msgctxt "#30631"
 msgid "Playing"
-msgstr ""
+msgstr "Reproduzindo"
 
 msgctxt "#30632"
 msgid "Yes (%s seconds)"
-msgstr ""
+msgstr "Sim (%s segundos)"
 
 msgctxt "#30633"
 msgid "No (%s seconds)"
-msgstr ""
+msgstr "Não (%s segundos)"
 
 msgctxt "#30634"
 msgid "Log level"
-msgstr ""
+msgstr "Nível de registo"
 
 msgctxt "#30635"
 msgid "None"
-msgstr ""
+msgstr "Nenhum"
 
 msgctxt "#30636"
 msgid "Error"
-msgstr ""
+msgstr "Erro"
 
 msgctxt "#30637"
 msgid "Info"
-msgstr ""
+msgstr "Informação"
 
 msgctxt "#30638"
 msgid "Debug"
-msgstr ""
+msgstr "Depuração"
 
 msgctxt "#30639"
 msgid "Show Specials in season listings"
-msgstr ""
+msgstr "Mostrar os especiais nas listas de temporadas"
 
 msgctxt "#30640"
 msgid "Bitrate"
-msgstr ""
+msgstr "Taxa de bits"
 
 msgctxt "#30641"
 msgid "Playback"
-msgstr ""
+msgstr "Reprodução"
 
 msgctxt "#30642"
 msgid "Force Resume options"
-msgstr ""
+msgstr "Forçar as opções de retoma"
 
 msgctxt "#30643"
 msgid "by Kodi"
-msgstr ""
+msgstr "pelo Kodi"
 
 msgctxt "#30644"
 msgid "by Elementum - Ask"
-msgstr ""
+msgstr "pelo Elementum - Perguntar"
 
 msgctxt "#30645"
 msgid "by Elementum - Force"
-msgstr ""
+msgstr "pelo Elementum - Forçar"
 
 msgctxt "#30646"
 msgid "Authorize Elementum on Trakt.tv"
-msgstr ""
+msgstr "Autorizar o Elementum no Trakt.tv"
 
 msgctxt "#30647"
 msgid "Cancel Authorization for Elementum on Trakt.tv"
-msgstr ""
+msgstr "Cancelar a autorização do Elementum no Trakt.tv"
 
 msgctxt "#30648"
 msgid "Authorization"
-msgstr ""
+msgstr "Autorização"
 
 msgctxt "#30649"
 msgid "To authorize addon for Trakt.tv you need to:[CR]1. Open [B]%s[/B][CR]2. Enter code: [B]%s[/B][CR]3. Wait for notification from Elementum."
-msgstr ""
+msgstr "Para autorizar o add-on no Trakt.tv você precisa:[CR]1. Abrir [B]%s[/B][CR]2. Inserir o código: [B]%s[/B][CR]3. Aguardar a notificação do Elementum."
 
 msgctxt "#30650"
 msgid "Successfully authorized for Trakt.tv"
-msgstr ""
+msgstr "Autorizado no Trakt.tv com sucesso"
 
 msgctxt "#30651"
 msgid "Could not authorize for Trakt.tv"
-msgstr ""
+msgstr "Não foi possível autorizar no Trakt.tv"
 
 msgctxt "#30652"
 msgid "Successfully deauthorized for Trakt.tv"
-msgstr ""
+msgstr "Autorização no Trakt.tv cancelada com sucesso"
 
 msgctxt "#30653"
 msgid "Which files to download"
-msgstr ""
+msgstr "Que arquivos baixar"
 
 msgctxt "#30654"
 msgid "Only playback file"
-msgstr ""
+msgstr "Apenas o arquivo a reproduzir"
 
 msgctxt "#30655"
 msgid "Season files"
-msgstr ""
+msgstr "Os arquivos da temporada"
 
 msgctxt "#30656"
 msgid "All files"
-msgstr ""
+msgstr "Todos os arquivos"
 
 msgctxt "#30657"
 msgid "Disable LSD"
-msgstr ""
+msgstr "Desativar LSD"
 
 msgctxt "#30658"
 msgid "Add extra trackers"
-msgstr ""
+msgstr "Adicionar trackers extra"
 
 msgctxt "#30659"
 msgid "All known trackers"
-msgstr ""
+msgstr "Todos os trackers conhecidos"
 
 msgctxt "#30660"
 msgid "Best trackers"
-msgstr ""
+msgstr "Os melhores trackers"
 
 msgctxt "#30661"
 msgid "Minimum set"
-msgstr ""
+msgstr "Conjunto mínimo"
 
 msgctxt "#30662"
 msgid "Remove original trackers from torrent"
-msgstr ""
+msgstr "Remover os trackers originais do torrent"
 
 msgctxt "#30663"
 msgid "Show episodes on release day (w/o delay)"
-msgstr ""
+msgstr "Mostrar os episódios no dia de estreia (sem atraso)"
 
 msgctxt "#30664"
 msgid "Modify trackers in torrent"
-msgstr ""
+msgstr "Modificar os trackers no torrent"
 
 msgctxt "#30665"
 msgid "At the time of adding"
-msgstr ""
+msgstr "No momento de adicionar"
 
 msgctxt "#30666"
 msgid "Every time"
-msgstr ""
+msgstr "Sempre"
 
 msgctxt "#30667"
 msgid "Mark as watched in Trakt"
-msgstr ""
+msgstr "Marcar como visto no Trakt"
 
 msgctxt "#30668"
 msgid "Mark as unwatched in Trakt"
-msgstr ""
+msgstr "Marcar como não visto no Trakt"
 
 msgctxt "#30669"
 msgid "Delay addon startup, seconds"
-msgstr ""
+msgstr "Atrasar o arranque do add-on, segundos"
 
 msgctxt "#30670"
 msgid "Downloading required binary file for '%s'"
-msgstr ""
+msgstr "Baixando o arquivo binário necessário para '%s'"
 
 msgctxt "#30671"
 msgid "List of Opennic DNS IPs"
-msgstr ""
+msgstr "Lista de IPs dos DNS OpenNIC"
 
 msgctxt "#30672"
 msgid "Compact database"
-msgstr ""
+msgstr "Compactar o banco de dados"
 
 msgctxt "#30673"
 msgid "Compact cache database"
-msgstr ""
+msgstr "Compactar o banco de dados do cache"
 
 msgctxt "#30674"
 msgid "Database was compacted"
-msgstr ""
+msgstr "O banco de dados foi compactado"
 
 msgctxt "#30675"
 msgid "Remote host login"
-msgstr ""
+msgstr "Usuário do host remoto"
 
 msgctxt "#30676"
 msgid "Remote host password"
-msgstr ""
+msgstr "Senha do host remoto"
 
 msgctxt "#30677"
 msgid "Force start as a library"
-msgstr ""
+msgstr "Forçar o arranque como biblioteca"
 
 msgctxt "#30678"
 msgid "Remove from Kodi library, when movie is deleted from Trakt"
-msgstr ""
+msgstr "Remover da biblioteca do Kodi quando o filme é eliminado do Trakt"
 
 msgctxt "#30679"
 msgid "Remove from Kodi library, when show is deleted from Trakt"
-msgstr ""
+msgstr "Remover da biblioteca do Kodi quando a série é eliminada do Trakt"
 
 msgctxt "#30680"
 msgid "Remove Elementum duplicates from library"
-msgstr ""
+msgstr "Remover os duplicados do Elementum da biblioteca"
 
 msgctxt "#30681"
 msgid "[B]Found duplicates in Kodi library:[/B][CR]Movies: [B]%s[/B], Shows: [B]%s[/B], Episodes: [B]%s[/B][CR]Proceed?"
-msgstr ""
+msgstr "[B]Foram encontrados duplicados na biblioteca do Kodi:[/B][CR]Filmes: [B]%s[/B], Séries: [B]%s[/B], Episódios: [B]%s[/B][CR]Continuar?"
 
 msgctxt "#30682"
 msgid "No duplicates were found in Kodi library"
-msgstr ""
+msgstr "Não foram encontrados duplicados na biblioteca do Kodi"
 
 msgctxt "#30683"
 msgid "Starting library duplicates removal"
-msgstr ""
+msgstr "Iniciando a remoção de duplicados da biblioteca"
 
 msgctxt "#30684"
 msgid "Removed Movies: %s, Shows: %s, Episodes: %s"
-msgstr ""
+msgstr "Removidos - Filmes: %s, Séries: %s, Episódios: %s"
 
 msgctxt "#30685"
 msgid "Remove movies from Elementum database"
-msgstr ""
+msgstr "Remover os filmes do banco de dados do Elementum"
 
 msgctxt "#30686"
 msgid "Remove shows from Elementum database"
-msgstr ""
+msgstr "Remover as séries do banco de dados do Elementum"
 
 msgctxt "#30687"
 msgid "In Elementum library"
-msgstr ""
+msgstr "Na biblioteca do Elementum"
 
 msgctxt "#30688"
 msgid "Skip searching for installed Elementum repository"
-msgstr ""
+msgstr "Ignorar a procura do repositório Elementum instalado"
 
 msgctxt "#30689"
 msgid "Internal DNS client"
-msgstr ""
+msgstr "Cliente DNS interno"
 
 msgctxt "#30691"
 msgid "Hide watched"
-msgstr ""
+msgstr "Ocultar os vistos"
 
 msgctxt "#30692"
 msgid "TMDB images quality (affects Kodi performance)"
-msgstr ""
+msgstr "Qualidade das imagens do TMDB (afeta o desempenho do Kodi)"
 
 msgctxt "#30693"
 msgid "Original"
-msgstr ""
+msgstr "Original"
 
 msgctxt "#30694"
 msgid "High"
-msgstr ""
+msgstr "Alta"
 
 msgctxt "#30695"
 msgid "Medium"
-msgstr ""
+msgstr "Média"
 
 msgctxt "#30696"
 msgid "Low"
-msgstr ""
+msgstr "Baixa"
 
 msgctxt "#30697"
 msgid "Interface language"
-msgstr ""
+msgstr "Idioma da interface"
 
 msgctxt "#30698"
 msgid "Kodi language"
-msgstr ""
+msgstr "Idioma do Kodi"
 
 msgctxt "#30699"
 msgid "Use earliest release date for progress and calendars"
-msgstr ""
+msgstr "Usar a data de lançamento mais antiga para o progresso e os calendários"
 
 msgctxt "#30700"
 msgid "Interface fallback language"
-msgstr ""
+msgstr "Idioma alternativo da interface"
 
 msgctxt "#30701"
 msgid "English | en"
-msgstr ""
+msgstr "Inglês | en"
 
 msgctxt "#30702"
 msgid "Reached daily limit for subtitles downloads"
-msgstr ""
+msgstr "Foi atingido o limite diário de downloads de legendas"
 
 msgctxt "#30703"
 msgid "Can be used by search providers or [CR]for debugging"
-msgstr ""
+msgstr "Pode ser usado pelos provedores de pesquisa ou [CR]para depuração"
 
 msgctxt "#30704"
 msgid "TMDB API Key check failed, cannot use TMDB service"
-msgstr ""
+msgstr "A verificação da chave da API do TMDB falhou, não é possível usar o serviço TMDB"
 
 msgctxt "#30705"
 msgid "TMDB API accessibility check failed, cannot use TMDB service"
-msgstr ""
+msgstr "A verificação da acessibilidade da API do TMDB falhou, não é possível usar o serviço TMDB"
 
 msgctxt "#30706"
 msgid "Transmission 4.05"
-msgstr ""
+msgstr "Transmission 4.05"
 
 msgctxt "#30707"
 msgid "qBittorrent 3.3.9"
-msgstr ""
+msgstr "qBittorrent 3.3.9"
 
 msgctxt "#30708"
 msgid "qBittorrent 4.6.4"
-msgstr ""
+msgstr "qBittorrent 4.6.4"
 
 msgctxt "#30709"
 msgid "Open [B]%s[/B]"
-msgstr ""
+msgstr "Abrir [B]%s[/B]"
 
 msgctxt "#30710"
 msgid "BitTorrent ports"
-msgstr ""
+msgstr "Portas BitTorrent"
 
 msgctxt "#30711"
 msgid "Delete torrent '%s'?"
-msgstr ""
+msgstr "Eliminar o torrent '%s'?"
 
 msgctxt "#30712"
 msgid "Force to always use proxy, can break download in some cases"
-msgstr ""
+msgstr "Forçar sempre o uso do proxy, em alguns casos pode interromper o download"
 
 msgctxt "#30713"
 msgid "Disable NATPMP"
@@ -2283,20 +2283,20 @@ msgstr "Desabilitar NATPMP"
 
 msgctxt "#30714"
 msgid "Re-check torrent's data"
-msgstr ""
+msgstr "Verificar novamente os dados do torrent"
 
 msgctxt "#30715"
 msgid "Antizapret PAC file URL"
-msgstr ""
+msgstr "URL do arquivo PAC do Antizapret"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "Servidor DNS over HTTPS"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "Servidor DNS over HTTPS personalizado"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "Usar os servidores DNS OpenNIC"

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -21,7 +21,7 @@ msgstr "Geral"
 
 msgctxt "#30001"
 msgid "Download path"
-msgstr ""
+msgstr "Caminho das transferências"
 
 msgctxt "#30004"
 msgid "Max upload rate, kB/s"
@@ -97,7 +97,7 @@ msgstr "Escolher stream automaticamente"
 
 msgctxt "#30025"
 msgid "Limit rates after initial buffering only"
-msgstr ""
+msgstr "Limitar as taxas apenas após a memória intermédia inicial"
 
 msgctxt "#30026"
 msgid "Library path"
@@ -109,7 +109,7 @@ msgstr "Limite de conexões"
 
 msgctxt "#30028"
 msgid "Download after play was stopped"
-msgstr ""
+msgstr "Continuar a transferir após parar a reprodução"
 
 msgctxt "#30029"
 msgid "Session saving frequency, seconds"
@@ -273,7 +273,7 @@ msgstr "Identidade Falsa (altamente desaconselhável)"
 
 msgctxt "#30075"
 msgid "Default advisable (acceptable)"
-msgstr ""
+msgstr "Predefinição aconselhável (aceitável)"
 
 msgctxt "#30076"
 msgid "libtorrent (Rasterbar) 1.1.0"
@@ -325,23 +325,23 @@ msgstr "Timeout de buffering inicial (segundos)"
 
 msgctxt "#30090"
 msgid "Listen interfaces"
-msgstr ""
+msgstr "Interfaces de escuta"
 
 msgctxt "#30091"
 msgid "Outgoing interfaces"
-msgstr ""
+msgstr "Interfaces de saída"
 
 msgctxt "#30092"
 msgid "Use fallback fanart if fanart wasn't found"
-msgstr ""
+msgstr "Usar fanart alternativo se não for encontrado nenhum"
 
 msgctxt "#30093"
 msgid "Disable notification sound"
-msgstr ""
+msgstr "Desativar o som das notificações"
 
 msgctxt "#30094"
 msgid "Disable background progress dialog"
-msgstr ""
+msgstr "Desativar a janela de progresso em segundo plano"
 
 # Interface
 msgctxt "#30100"
@@ -354,7 +354,7 @@ msgstr "Este addon apenas pode ser corrido pelo Elementum"
 
 msgctxt "#30103"
 msgid "Unable to find Elementum binary[CR]Required platform:"
-msgstr ""
+msgstr "Não foi possível encontrar o binário do Elementum[CR]Plataforma necessária:"
 
 msgctxt "#30104"
 msgid "Insert file or URL"
@@ -398,63 +398,63 @@ msgstr "Pasta de transferência não foi definida, verifique as configurações"
 
 msgctxt "#30116"
 msgid "Looks like Elementum is still starting up, give it a few seconds..."
-msgstr ""
+msgstr "Parece que o Elementum ainda está a arrancar, dá-lhe uns segundos..."
 
 msgctxt "#30117"
 msgid "Resolving torrent files..."
-msgstr ""
+msgstr "A resolver os ficheiros torrent..."
 
 msgctxt "#30118"
 msgid "Scraping trackers..."
-msgstr ""
+msgstr "A consultar os trackers..."
 
 msgctxt "#30119"
 msgid "ID of selected userlist for movies"
-msgstr ""
+msgstr "ID da lista de utilizador selecionada para filmes"
 
 msgctxt "#30120"
 msgid "ID of selected userlist for shows"
-msgstr ""
+msgstr "ID da lista de utilizador selecionada para séries"
 
 msgctxt "#30141"
 msgid "Please support Elementum development by visiting[CR]https://elementum.surge.sh/donate/ or https://elementumorg.github.io/donate/"
-msgstr ""
+msgstr "Por favor, apoia o desenvolvimento do Elementum visitando[CR]https://elementum.surge.sh/donate/ ou https://elementumorg.github.io/donate/"
 
 msgctxt "#30142"
 msgid "Default view for menus in Movies"
-msgstr ""
+msgstr "Vista predefinida para os menus em Filmes"
 
 msgctxt "#30143"
 msgid "Default view for menus in TV Shows"
-msgstr ""
+msgstr "Vista predefinida para os menus em Séries"
 
 msgctxt "#30144"
 msgid "Default view for movie genres"
-msgstr ""
+msgstr "Vista predefinida para os géneros de filmes"
 
 msgctxt "#30145"
 msgid "Default view for TV show genres"
-msgstr ""
+msgstr "Vista predefinida para os géneros de séries"
 
 msgctxt "#30146"
 msgid "Keep downloading '%s'?"
-msgstr ""
+msgstr "Continuar a transferir '%s'?"
 
 msgctxt "#30147"
 msgid "Caches are still warming up, give it a minute or two..."
-msgstr ""
+msgstr "As caches ainda estão a aquecer, dá-lhes um minuto ou dois..."
 
 msgctxt "#30148"
 msgid "Caches warmed up"
-msgstr ""
+msgstr "Caches prontas"
 
 msgctxt "#30149"
 msgid "Trakt username not set, check your settings"
-msgstr ""
+msgstr "Nome de utilizador do Trakt não definido, verifica as tuas definições"
 
 msgctxt "#30199"
 msgid "No available JSON-RPC connection to Kodi.[CR]Enable both Application control options in Service settings / Control and restart Kodi."
-msgstr ""
+msgstr "Não há ligação JSON-RPC disponível para o Kodi.[CR]Ativa ambas as opções de controlo da aplicação em Definições de serviços / Controlo e reinicia o Kodi."
 
 # Elementum daemon
 msgctxt "#30200"
@@ -703,1579 +703,1579 @@ msgstr "Apagar torrent e ficheiros"
 
 msgctxt "#30277"
 msgid "%s added to library, do you want to rescan it?[CR]You can later use Kodi's 'Update library' feature instead."
-msgstr ""
+msgstr "%s foi adicionado à biblioteca, queres analisá-la de novo?[CR]Podes usar mais tarde a função 'Atualizar biblioteca' do Kodi."
 
 msgctxt "#30278"
 msgid "%s removed from library, do you want to clean it?[CR]You can later use Kodi's 'Clean library' feature instead."
-msgstr ""
+msgstr "%s foi removido da biblioteca, queres limpá-la?[CR]Podes usar mais tarde a função 'Limpar biblioteca' do Kodi."
 
 msgctxt "#30279"
 msgid "Video %s was previously removed from library.[CR]Force adding?"
-msgstr ""
+msgstr "O vídeo %s tinha sido removido da biblioteca anteriormente.[CR]Forçar a adição?"
 
 msgctxt "#30282"
 msgid "Nothing left to remove from Elementum"
-msgstr ""
+msgstr "Já não há nada para remover do Elementum"
 
 msgctxt "#30283"
 msgid "Merge to library"
-msgstr ""
+msgstr "Juntar à biblioteca"
 
 msgctxt "#30284"
 msgid "Show unaired seasons"
-msgstr ""
+msgstr "Mostrar temporadas por estrear"
 
 msgctxt "#30285"
 msgid "Show unaired episodes"
-msgstr ""
+msgstr "Mostrar episódios por estrear"
 
 msgctxt "#30286"
 msgid "%s merged to library, do you want to rescan it?[CR]You can later use Kodi's 'Update library' feature instead."
-msgstr ""
+msgstr "%s foi juntado à biblioteca, queres analisá-la de novo?[CR]Podes usar mais tarde a função 'Atualizar biblioteca' do Kodi."
 
 msgctxt "#30287"
 msgid "%s already in library"
-msgstr ""
+msgstr "%s já está na biblioteca"
 
 msgctxt "#30288"
 msgid "Library updated, do you want to rescan it?[CR]You can later use Kodi's 'Update library' feature instead."
-msgstr ""
+msgstr "Biblioteca atualizada, queres analisá-la de novo?[CR]Podes usar mais tarde a função 'Atualizar biblioteca' do Kodi."
 
 msgctxt "#30289"
 msgid "Genres"
-msgstr ""
+msgstr "Géneros"
 
 msgctxt "#30290"
 msgid "Calendars"
-msgstr ""
+msgstr "Calendários"
 
 msgctxt "#30291"
 msgid "My Movies"
-msgstr ""
+msgstr "Os meus filmes"
 
 msgctxt "#30292"
 msgid "My Releases"
-msgstr ""
+msgstr "Os meus lançamentos"
 
 msgctxt "#30293"
 msgid "All Movies"
-msgstr ""
+msgstr "Todos os filmes"
 
 msgctxt "#30294"
 msgid "All Releases"
-msgstr ""
+msgstr "Todos os lançamentos"
 
 msgctxt "#30295"
 msgid "My Shows"
-msgstr ""
+msgstr "As minhas séries"
 
 msgctxt "#30296"
 msgid "My New Shows"
-msgstr ""
+msgstr "As minhas séries novas"
 
 msgctxt "#30297"
 msgid "My Premieres"
-msgstr ""
+msgstr "As minhas estreias"
 
 msgctxt "#30298"
 msgid "All Shows"
-msgstr ""
+msgstr "Todas as séries"
 
 msgctxt "#30299"
 msgid "All New Shows"
-msgstr ""
+msgstr "Todas as séries novas"
 
 msgctxt "#30300"
 msgid "All Premieres"
-msgstr ""
+msgstr "Todas as estreias"
 
 msgctxt "#30301"
 msgid "Move finished downloads to separate folders"
-msgstr ""
+msgstr "Mover as transferências concluídas para pastas separadas"
 
 msgctxt "#30302"
 msgid "Files will only be moved after seeding is finished (see[CR]- BitTorrent settings), and will wait if currently playing"
-msgstr ""
+msgstr "Os ficheiros só serão movidos após terminar a semeadura (ver[CR]- definições de BitTorrent), e aguardarão se estiverem a ser reproduzidos"
 
 msgctxt "#30303"
 msgid "RAR archive detected. Download will need to be completed before playback can start and will require around twice the amount of space, continue?"
-msgstr ""
+msgstr "Arquivo RAR detetado. A transferência terá de estar concluída antes de a reprodução poder começar e exigirá cerca do dobro do espaço. Continuar?"
 
 msgctxt "#30304"
 msgid "Error creating output pipe for 'unrar' command"
-msgstr ""
+msgstr "Erro ao criar o canal de saída para o comando 'unrar'"
 
 msgctxt "#30305"
 msgid "Error starting 'unrar' command"
-msgstr ""
+msgstr "Erro ao iniciar o comando 'unrar'"
 
 msgctxt "#30306"
 msgid "Error waiting for 'unrar' command"
-msgstr ""
+msgstr "Erro ao aguardar pelo comando 'unrar'"
 
 msgctxt "#30307"
 msgid "Error reading from destination folder"
-msgstr ""
+msgstr "Erro ao ler da pasta de destino"
 
 msgctxt "#30308"
 msgid "Move completed"
-msgstr ""
+msgstr "Movimentação concluída"
 
 msgctxt "#30309"
 msgid "Keep"
-msgstr ""
+msgstr "Manter"
 
 msgctxt "#30310"
 msgid "Ask to delete"
-msgstr ""
+msgstr "Perguntar antes de eliminar"
 
 msgctxt "#30311"
 msgid "Delete"
-msgstr ""
+msgstr "Eliminar"
 
 msgctxt "#30312"
 msgid "Keep files for not finished video"
-msgstr ""
+msgstr "Manter os ficheiros de vídeos não concluídos"
 
 msgctxt "#30313"
 msgid "Keep files for watched/downloaded video"
-msgstr ""
+msgstr "Manter os ficheiros de vídeos vistos/transferidos"
 
 msgctxt "#30314"
 msgid "Settings were not initialized.[CR]Save addon settings, then restart Kodi."
-msgstr ""
+msgstr "As definições não foram inicializadas.[CR]Guarda as definições do add-on e reinicia o Kodi."
 
 msgctxt "#30315"
 msgid "Download storage type"
-msgstr ""
+msgstr "Tipo de armazenamento das transferências"
 
 msgctxt "#30316"
 msgid "Use files"
-msgstr ""
+msgstr "Usar ficheiros"
 
 msgctxt "#30317"
 msgid "Use memory"
-msgstr ""
+msgstr "Usar memória"
 
 msgctxt "#30318"
 msgid "Memory size to use for each torrent, Mb"
-msgstr ""
+msgstr "Memória a usar para cada torrent, MB"
 
 msgctxt "#30319"
 msgid "Continue"
-msgstr ""
+msgstr "Continuar"
 
 msgctxt "#30320"
 msgid "Ask to stop"
-msgstr ""
+msgstr "Perguntar antes de parar"
 
 msgctxt "#30321"
 msgid "Stop"
-msgstr ""
+msgstr "Parar"
 
 msgctxt "#30323"
 msgid "New search"
-msgstr ""
+msgstr "Nova pesquisa"
 
 msgctxt "#30324"
 msgid "Force stream auto-selection from settings"
-msgstr ""
+msgstr "Forçar a seleção automática de streams a partir das definições"
 
 msgctxt "#30325"
 msgid "Download"
-msgstr ""
+msgstr "Transferência"
 
 msgctxt "#30326"
 msgid "Kodi library"
-msgstr ""
+msgstr "Biblioteca do Kodi"
 
 msgctxt "#30327"
 msgid "Storage"
-msgstr ""
+msgstr "Armazenamento"
 
 msgctxt "#30328"
 msgid "Disable TCP"
-msgstr ""
+msgstr "Desativar TCP"
 
 msgctxt "#30329"
 msgid "Disable UTP"
-msgstr ""
+msgstr "Desativar UTP"
 
 msgctxt "#30330"
 msgid "Update Trakt"
-msgstr ""
+msgstr "Atualizar o Trakt"
 
 msgctxt "#30332"
 msgid "Reloading configuration..."
-msgstr ""
+msgstr "A recarregar a configuração..."
 
 msgctxt "#30333"
 msgid "Try to find other episodes in the torrent"
-msgstr ""
+msgstr "Tentar encontrar outros episódios no torrent"
 
 msgctxt "#30347"
 msgid "Could not find binary for architecture '%s'![CR]Try to uninstall this addon, re-download and re-install it from the biggest zip."
-msgstr ""
+msgstr "Não foi possível encontrar o binário para a arquitetura '%s'![CR]Tenta desinstalar este add-on, transferi-lo de novo e reinstalá-lo a partir do zip maior."
 
 msgctxt "#30348"
 msgid "Create usual files on the file system and write to them.[CR]Needs selected file's full size to be available on the disk!"
-msgstr ""
+msgstr "Cria ficheiros normais no sistema de ficheiros e escreve neles.[CR]Precisa que o tamanho total do ficheiro selecionado esteja disponível no disco!"
 
 msgctxt "#30349"
 msgid "Using device's memory to download parts of the torrent.[CR]Disk is used only to download and save .torrent file,"
-msgstr ""
+msgstr "Usa a memória do dispositivo para transferir partes do torrent.[CR]O disco é usado apenas para transferir e guardar o ficheiro .torrent,"
 
 msgctxt "#30350"
 msgid "so can be any storage. For 1gb memory devices[CR]100mb is enough for memory storage, 200-250mb for bigger devices."
-msgstr ""
+msgstr "por isso pode ser qualquer armazenamento. Para dispositivos com 1 GB[CR]bastam 100 MB, e 200-250 MB para dispositivos maiores."
 
 msgctxt "#30351"
 msgid "Same as for usual file storage, but splits file into many small files.[CR]Should be used on FAT-32 file-systems."
-msgstr ""
+msgstr "Igual ao armazenamento normal em ficheiros, mas divide o ficheiro em muitos ficheiros pequenos.[CR]Deve ser usado em sistemas de ficheiros FAT-32."
 
 msgctxt "#30352"
 msgid "Same as for usual file storage, but using memory[CR]to lower filesystem operations. Experimental storage!"
-msgstr ""
+msgstr "Igual ao armazenamento normal em ficheiros, mas usa a memória[CR]para reduzir as operações no sistema de ficheiros. Armazenamento experimental!"
 
 msgctxt "#30355"
 msgid "Changelog"
-msgstr ""
+msgstr "Registo de alterações"
 
 msgctxt "#30357"
 msgid "Use Trakt information in Trakt lists"
-msgstr ""
+msgstr "Usar a informação do Trakt nas listas do Trakt"
 
 msgctxt "#30358"
 msgid "Trakt update started"
-msgstr ""
+msgstr "Atualização do Trakt iniciada"
 
 msgctxt "#30359"
 msgid "Do not ask questions before playback"
-msgstr ""
+msgstr "Não fazer perguntas antes da reprodução"
 
 msgctxt "#30360"
 msgid "My Progress"
-msgstr ""
+msgstr "O meu progresso"
 
 msgctxt "#30361"
 msgid "My History"
-msgstr ""
+msgstr "O meu histórico"
 
 msgctxt "#30362"
 msgid "Synchronization"
-msgstr ""
+msgstr "Sincronização"
 
 msgctxt "#30363"
 msgid "Sync items from collections into Kodi library"
-msgstr ""
+msgstr "Sincronizar os itens das coleções para a biblioteca do Kodi"
 
 msgctxt "#30364"
 msgid "Sync items from watchlist into Kodi library"
-msgstr ""
+msgstr "Sincronizar os itens da lista de interesses para a biblioteca do Kodi"
 
 msgctxt "#30365"
 msgid "Sync items from user lists into Kodi library"
-msgstr ""
+msgstr "Sincronizar os itens das listas de utilizador para a biblioteca do Kodi"
 
 msgctxt "#30366"
 msgid "Sync watched states from Trakt into Kodi library"
-msgstr ""
+msgstr "Sincronizar o estado de visto do Trakt para a biblioteca do Kodi"
 
 msgctxt "#30367"
 msgid "Sync back Kodi watched states into Trakt"
-msgstr ""
+msgstr "Sincronizar o estado de visto do Kodi de volta para o Trakt"
 
 msgctxt "#30369"
 msgid "Disable Upload"
-msgstr ""
+msgstr "Desativar o envio"
 
 msgctxt "#30370"
 msgid "Auto-assign network IP"
-msgstr ""
+msgstr "Atribuir automaticamente o IP de rede"
 
 msgctxt "#30371"
 msgid "Auto-assign network ports"
-msgstr ""
+msgstr "Atribuir automaticamente as portas de rede"
 
 msgctxt "#30373"
 msgid "Languages"
-msgstr ""
+msgstr "Idiomas"
 
 msgctxt "#30374"
 msgid "Countries"
-msgstr ""
+msgstr "Países"
 
 msgctxt "#30375"
 msgid "By size"
-msgstr ""
+msgstr "Por tamanho"
 
 msgctxt "#30376"
 msgid "Choose memory size automatically"
-msgstr ""
+msgstr "Escolher o tamanho da memória automaticamente"
 
 msgctxt "#30377"
 msgid "Size is chosen automatically, based on[CR]physical amount of memory"
-msgstr ""
+msgstr "O tamanho é escolhido automaticamente, com base na[CR]quantidade de memória física"
 
 msgctxt "#30378"
 msgid "Allow memory usage"
-msgstr ""
+msgstr "Permitir o uso de memória"
 
 msgctxt "#30379"
 msgid "Minimum - 40MB, Default - 8%, Maximum - 15%"
-msgstr ""
+msgstr "Mínimo - 40 MB, Predefinido - 8%, Máximo - 15%"
 
 msgctxt "#30380"
 msgid "Minimum"
-msgstr ""
+msgstr "Mínimo"
 
 msgctxt "#30381"
 msgid "Default"
-msgstr ""
+msgstr "Predefinido"
 
 msgctxt "#30382"
 msgid "Maximum"
-msgstr ""
+msgstr "Máximo"
 
 msgctxt "#30383"
 msgid "Use Kodi language for subtitles search"
-msgstr ""
+msgstr "Usar o idioma do Kodi na pesquisa de legendas"
 
 msgctxt "#30384"
 msgid "Language code for subtitles (example: en, it, es)"
-msgstr ""
+msgstr "Código de idioma das legendas (exemplo: en, it, es)"
 
 msgctxt "#30386"
 msgid "Disable background progress dialog on playback"
-msgstr ""
+msgstr "Desativar a janela de progresso em segundo plano durante a reprodução"
 
 msgctxt "#30387"
 msgid "Caching"
-msgstr ""
+msgstr "Cache"
 
 msgctxt "#30388"
 msgid "Cache stream selection"
-msgstr ""
+msgstr "Guardar em cache a seleção de streams"
 
 msgctxt "#30389"
 msgid "Cache stream search results"
-msgstr ""
+msgstr "Guardar em cache os resultados de pesquisa de streams"
 
 msgctxt "#30390"
 msgid "Cache search results duration, seconds"
-msgstr ""
+msgstr "Duração da cache dos resultados de pesquisa, segundos"
 
 msgctxt "#30393"
 msgid "Status"
-msgstr ""
+msgstr "Estado"
 
 msgctxt "#30394"
 msgid "Version"
-msgstr ""
+msgstr "Versão"
 
 msgctxt "#30395"
 msgid "IP address"
-msgstr ""
+msgstr "Endereço IP"
 
 msgctxt "#30396"
 msgid "Port"
-msgstr ""
+msgstr "Porta"
 
 msgctxt "#30397"
 msgid "Web UI"
-msgstr ""
+msgstr "Interface web"
 
 msgctxt "#30398"
 msgid "Debug information (with kodi.log)"
-msgstr ""
+msgstr "Informação de depuração (com kodi.log)"
 
 msgctxt "#30399"
 msgid "Addresses"
-msgstr ""
+msgstr "Endereços"
 
 msgctxt "#30400"
 msgid "Statistics"
-msgstr ""
+msgstr "Estatísticas"
 
 msgctxt "#30401"
 msgid "Torrent library status"
-msgstr ""
+msgstr "Estado da biblioteca de torrents"
 
 msgctxt "#30402"
 msgid "Size of cache.db"
-msgstr ""
+msgstr "Tamanho de cache.db"
 
 msgctxt "#30403"
 msgid "Size of app.db"
-msgstr ""
+msgstr "Tamanho de app.db"
 
 msgctxt "#30404"
 msgid "Assigned torrent files"
-msgstr ""
+msgstr "Ficheiros torrent atribuídos"
 
 msgctxt "#30405"
 msgid "Search queries"
-msgstr ""
+msgstr "Pesquisas efetuadas"
 
 msgctxt "#30406"
 msgid "Remove from history"
-msgstr ""
+msgstr "Remover do histórico"
 
 msgctxt "#30408"
 msgid "Addon Connectivity"
-msgstr ""
+msgstr "Ligação do add-on"
 
 msgctxt "#30409"
 msgid "Local port"
-msgstr ""
+msgstr "Porta local"
 
 msgctxt "#30410"
 msgid "Remote port"
-msgstr ""
+msgstr "Porta remota"
 
 msgctxt "#30411"
 msgid "Remote host"
-msgstr ""
+msgstr "Anfitrião remoto"
 
 msgctxt "#30412"
 msgid "Do not start binary (client mode)"
-msgstr ""
+msgstr "Não iniciar o binário (modo cliente)"
 
 msgctxt "#30413"
 msgid "Yes"
-msgstr ""
+msgstr "Sim"
 
 msgctxt "#30414"
 msgid "No"
-msgstr ""
+msgstr "Não"
 
 msgctxt "#30415"
 msgid "Next page (%s)"
-msgstr ""
+msgstr "Página seguinte (%s)"
 
 msgctxt "#30416"
 msgid "Percents of playback to mark as watched"
-msgstr ""
+msgstr "Percentagem de reprodução para marcar como visto"
 
 msgctxt "#30417"
 msgid "Use name of production company as Studio for shows"
-msgstr ""
+msgstr "Usar o nome da produtora como Estúdio nas séries"
 
 msgctxt "#30418"
 msgid "Calculate number of unwatched episodes in Shows/Seasons"
-msgstr ""
+msgstr "Calcular o número de episódios não vistos em Séries/Temporadas"
 
 msgctxt "#30421"
 msgid "Load torrents from torrents folder on startup"
-msgstr ""
+msgstr "Carregar os torrents da pasta de torrents no arranque"
 
 msgctxt "#30422"
 msgid "Popular lists"
-msgstr ""
+msgstr "Listas populares"
 
 msgctxt "#30423"
 msgid "Recommendations"
-msgstr ""
+msgstr "Recomendações"
 
 msgctxt "#30424"
 msgid "Progress"
-msgstr ""
+msgstr "Progresso"
 
 msgctxt "#30425"
 msgid "Color of an air date"
-msgstr ""
+msgstr "Cor da data de estreia"
 
 msgctxt "#30426"
 msgid "Color of a show name"
-msgstr ""
+msgstr "Cor do nome da série"
 
 msgctxt "#30427"
 msgid "Color of an episode name"
-msgstr ""
+msgstr "Cor do nome do episódio"
 
 msgctxt "#30428"
 msgid "Hide unaired episodes"
-msgstr ""
+msgstr "Ocultar episódios por estrear"
 
 msgctxt "#30429"
 msgid "Sort shows in the list"
-msgstr ""
+msgstr "Ordenar as séries na lista"
 
 msgctxt "#30430"
 msgid "By latest watched"
-msgstr ""
+msgstr "Por visualização mais recente"
 
 msgctxt "#30431"
 msgid "By show name"
-msgstr ""
+msgstr "Por nome da série"
 
 msgctxt "#30432"
 msgid "By air date (newer)"
-msgstr ""
+msgstr "Por data de estreia (mais recente)"
 
 msgctxt "#30433"
 msgid "By air date (older)"
-msgstr ""
+msgstr "Por data de estreia (mais antiga)"
 
 msgctxt "#30434"
 msgid "Date format"
-msgstr ""
+msgstr "Formato da data"
 
 msgctxt "#30436"
 msgid "Userlist"
-msgstr ""
+msgstr "Lista de utilizador"
 
 msgctxt "#30438"
 msgid "Userlists"
-msgstr ""
+msgstr "Listas de utilizador"
 
 msgctxt "#30439"
 msgid "Debug information (without kodi.log)"
-msgstr ""
+msgstr "Informação de depuração (sem kodi.log)"
 
 msgctxt "#30440"
 msgid "Color of an unaired episode name"
-msgstr ""
+msgstr "Cor do nome de um episódio por estrear"
 
 msgctxt "#30441"
 msgid "Select userlist for movies"
-msgstr ""
+msgstr "Selecionar a lista de utilizador para filmes"
 
 msgctxt "#30442"
 msgid "Userlist for movies"
-msgstr ""
+msgstr "Lista de utilizador para filmes"
 
 msgctxt "#30443"
 msgid "Selected userlist for movies"
-msgstr ""
+msgstr "Lista de utilizador selecionada para filmes"
 
 msgctxt "#30444"
 msgid "Select userlist for shows"
-msgstr ""
+msgstr "Selecionar a lista de utilizador para séries"
 
 msgctxt "#30445"
 msgid "Userlist for shows"
-msgstr ""
+msgstr "Lista de utilizador para séries"
 
 msgctxt "#30446"
 msgid "Selected userlist for shows"
-msgstr ""
+msgstr "Lista de utilizador selecionada para séries"
 
 msgctxt "#30447"
 msgid "Add to Trakt, when movie is added to Kodi library"
-msgstr ""
+msgstr "Adicionar ao Trakt quando um filme é adicionado à biblioteca do Kodi"
 
 msgctxt "#30448"
 msgid "Add to Trakt, when show is added to Kodi library"
-msgstr ""
+msgstr "Adicionar ao Trakt quando uma série é adicionada à biblioteca do Kodi"
 
 msgctxt "#30449"
 msgid "Remove from Trakt, when movie is deleted from Kodi library"
-msgstr ""
+msgstr "Remover do Trakt quando um filme é eliminado da biblioteca do Kodi"
 
 msgctxt "#30450"
 msgid "Remove from Trakt, when show is deleted from Kodi library"
-msgstr ""
+msgstr "Remover do Trakt quando uma série é eliminada da biblioteca do Kodi"
 
 msgctxt "#30451"
 msgid "Torrent files path"
-msgstr ""
+msgstr "Caminho dos ficheiros torrent"
 
 msgctxt "#30452"
 msgid "Reset all paths"
-msgstr ""
+msgstr "Repor todos os caminhos"
 
 msgctxt "#30453"
 msgid "Upload /debug/bundle (with kodi.log) to pastebin"
-msgstr ""
+msgstr "Enviar /debug/bundle (com kodi.log) para o pastebin"
 
 msgctxt "#30454"
 msgid "Paste url:[CR]%s"
-msgstr ""
+msgstr "URL do paste:[CR]%s"
 
 msgctxt "#30455"
 msgid "Logging"
-msgstr ""
+msgstr "Registo"
 
 msgctxt "#30456"
 msgid "Upload /debug/all (no kodi.log) to pastebin"
-msgstr ""
+msgstr "Enviar /debug/all (sem kodi.log) para o pastebin"
 
 msgctxt "#30457"
 msgid "Uploading file to pastebin"
-msgstr ""
+msgstr "A enviar o ficheiro para o pastebin"
 
 msgctxt "#30458"
 msgid "Deleted movies"
-msgstr ""
+msgstr "Filmes eliminados"
 
 msgctxt "#30459"
 msgid "Deleted shows"
-msgstr ""
+msgstr "Séries eliminadas"
 
 msgctxt "#30460"
 msgid "Database"
-msgstr ""
+msgstr "Base de dados"
 
 msgctxt "#30461"
 msgid "Show information"
-msgstr ""
+msgstr "Mostrar informação"
 
 msgctxt "#30462"
 msgid "Clear deleted movies"
-msgstr ""
+msgstr "Limpar os filmes eliminados"
 
 msgctxt "#30463"
 msgid "Clear deleted shows"
-msgstr ""
+msgstr "Limpar as séries eliminadas"
 
 msgctxt "#30464"
 msgid "Clear torrents history"
-msgstr ""
+msgstr "Limpar o histórico de torrents"
 
 msgctxt "#30465"
 msgid "Clear search history"
-msgstr ""
+msgstr "Limpar o histórico de pesquisas"
 
 msgctxt "#30466"
 msgid "Clear the database"
-msgstr ""
+msgstr "Limpar a base de dados"
 
 msgctxt "#30467"
 msgid "Cache"
-msgstr ""
+msgstr "Cache"
 
 msgctxt "#30468"
 msgid "Clear TMDB cache"
-msgstr ""
+msgstr "Limpar a cache do TMDB"
 
 msgctxt "#30469"
 msgid "Clear Trakt cache"
-msgstr ""
+msgstr "Limpar a cache do Trakt"
 
 msgctxt "#30470"
 msgid "Clear the cache"
-msgstr ""
+msgstr "Limpar a cache"
 
 msgctxt "#30471"
 msgid "Are you sure you want to do it?"
-msgstr ""
+msgstr "Tens a certeza de que queres fazer isto?"
 
 msgctxt "#30472"
 msgid "Database cleared"
-msgstr ""
+msgstr "Base de dados limpa"
 
 msgctxt "#30473"
 msgid "Select network interface"
-msgstr ""
+msgstr "Selecionar a interface de rede"
 
 msgctxt "#30474"
 msgid "Network interfaces"
-msgstr ""
+msgstr "Interfaces de rede"
 
 msgctxt "#30475"
 msgid "Strm files language"
-msgstr ""
+msgstr "Idioma dos ficheiros strm"
 
 msgctxt "#30476"
 msgid "Select language"
-msgstr ""
+msgstr "Selecionar idioma"
 
 msgctxt "#30477"
 msgid "Original language"
-msgstr ""
+msgstr "Idioma original"
 
 msgctxt "#30478"
 msgid "Searching"
-msgstr ""
+msgstr "A pesquisar"
 
 msgctxt "#30480"
 msgid "Run Kodi library update after add/delete"
-msgstr ""
+msgstr "Executar a atualização da biblioteca do Kodi após adicionar/eliminar"
 
 msgctxt "#30481"
 msgid "Automatically"
-msgstr ""
+msgstr "Automaticamente"
 
 msgctxt "#30482"
 msgid "Ask"
-msgstr ""
+msgstr "Perguntar"
 
 msgctxt "#30483"
 msgid "Create NFO files for Movie scrapers"
-msgstr ""
+msgstr "Criar ficheiros NFO para os scrapers de filmes"
 
 msgctxt "#30484"
 msgid "Create NFO files for TV Show scrapers"
-msgstr ""
+msgstr "Criar ficheiros NFO para os scrapers de séries"
 
 msgctxt "#30485"
 msgid "Concurrent connections limit per second"
-msgstr ""
+msgstr "Limite de ligações simultâneas por segundo"
 
 msgctxt "#30486"
 msgid "Automatic concurrent connections limit per second"
-msgstr ""
+msgstr "Limite automático de ligações simultâneas por segundo"
 
 msgctxt "#30487"
 msgid "Enable built-in HTTP proxy"
-msgstr ""
+msgstr "Ativar o proxy HTTP integrado"
 
 msgctxt "#30488"
 msgid "Internal Proxy Port"
-msgstr ""
+msgstr "Porta do proxy interno"
 
 msgctxt "#30489"
 msgid "Log Internal proxy requests"
-msgstr ""
+msgstr "Registar os pedidos do proxy interno"
 
 msgctxt "#30490"
 msgid "Internal HTTP proxy"
-msgstr ""
+msgstr "Proxy HTTP interno"
 
 msgctxt "#30491"
 msgid "Use Fanart.tv for posters/images"
-msgstr ""
+msgstr "Usar o Fanart.tv para cartazes/imagens"
 
 msgctxt "#30492"
 msgid "Use Proxy for downloading .torrent files"
-msgstr ""
+msgstr "Usar o proxy para transferir ficheiros .torrent"
 
 msgctxt "#30493"
 msgid "Use Proxy for trackers"
-msgstr ""
+msgstr "Usar o proxy para os trackers"
 
 msgctxt "#30494"
 msgid "Use Proxy for torrent downloading"
-msgstr ""
+msgstr "Usar o proxy para transferir torrents"
 
 msgctxt "#30495"
 msgid "Use built-in DNS resolver"
-msgstr ""
+msgstr "Usar o resolvedor de DNS integrado"
 
 msgctxt "#30496"
 msgid "Turn off if you use Tor addresses, or you want [CR]to use DNS settings from OS"
-msgstr ""
+msgstr "Desliga se usares endereços Tor, ou se quiseres [CR]usar as definições de DNS do sistema operativo"
 
 msgctxt "#30497"
 msgid "Use Antizapret proxy (only for Russia)"
-msgstr ""
+msgstr "Usar o proxy Antizapret (apenas para a Rússia)"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"
-msgstr ""
+msgstr "Repor este caminho para '/'"
 
 msgctxt "#30499"
 msgid "Automatically adjust memory size[CR]for heavy torrents, if possible"
-msgstr ""
+msgstr "Ajustar automaticamente o tamanho da memória[CR]para torrents pesados, se possível"
 
 msgctxt "#30500"
 msgid "Automatically adjust buffer size[CR]for heavy torrents"
-msgstr ""
+msgstr "Ajustar automaticamente o tamanho da memória intermédia[CR]para torrents pesados"
 
 msgctxt "#30502"
 msgid "Adjust buffer according to Kodi advancedsettings.xml, if set"
-msgstr ""
+msgstr "Ajustar a memória intermédia de acordo com o advancedsettings.xml do Kodi, se definido"
 
 msgctxt "#30503"
 msgid "Use libtorrent.config to override torrent engine settings"
-msgstr ""
+msgstr "Usar o libtorrent.config para substituir as definições do motor de torrents"
 
 msgctxt "#30504"
 msgid "Located at USERDATA/plugin.video.elementum/libtorrent.config file[CR]Settings apply automatically. Visit https://libtorrent.org for info."
-msgstr ""
+msgstr "Localizado no ficheiro USERDATA/plugin.video.elementum/libtorrent.config[CR]As definições aplicam-se automaticamente. Visita https://libtorrent.org para mais informação."
 
 msgctxt "#30505"
 msgid "Add episode number to the title"
-msgstr ""
+msgstr "Adicionar o número do episódio ao título"
 
 msgctxt "#30506"
 msgid "Enable libtorrent logging"
-msgstr ""
+msgstr "Ativar o registo do libtorrent"
 
 msgctxt "#30511"
 msgid "Libtorrent settings profile"
-msgstr ""
+msgstr "Perfil de definições do libtorrent"
 
 msgctxt "#30512"
 msgid "Default"
-msgstr ""
+msgstr "Predefinido"
 
 msgctxt "#30513"
 msgid "Minimal memory"
-msgstr ""
+msgstr "Memória mínima"
 
 msgctxt "#30514"
 msgid "High speed"
-msgstr ""
+msgstr "Alta velocidade"
 
 msgctxt "#30515"
 msgid "Load torrents from torrents folder paused"
-msgstr ""
+msgstr "Carregar os torrents da pasta de torrents em pausa"
 
 msgctxt "#30516"
 msgid "... resume N seconds earlier"
-msgstr ""
+msgstr "... retomar N segundos antes"
 
 msgctxt "#30517"
 msgid "In Kodi library"
-msgstr ""
+msgstr "Na biblioteca do Kodi"
 
 msgctxt "#30518"
 msgid "Use libtorrent deadlines"
-msgstr ""
+msgstr "Usar os prazos do libtorrent"
 
 msgctxt "#30519"
 msgid "Use libtorrent pause/resume trick for added torrents"
-msgstr ""
+msgstr "Usar o truque de pausa/retoma do libtorrent para os torrents adicionados"
 
 msgctxt "#30520"
 msgid "Add item to start menu"
-msgstr ""
+msgstr "Adicionar item ao menu inicial"
 
 msgctxt "#30521"
 msgid "Delete item from start menu"
-msgstr ""
+msgstr "Remover item do menu inicial"
 
 msgctxt "#30522"
 msgid "Minimum file size"
-msgstr ""
+msgstr "Tamanho mínimo do ficheiro"
 
 msgctxt "#30523"
 msgid "Minimum file size for Movies, MB"
-msgstr ""
+msgstr "Tamanho mínimo do ficheiro para filmes, MB"
 
 msgctxt "#30524"
 msgid "Minimum file size for Shows, MB per minute"
-msgstr ""
+msgstr "Tamanho mínimo do ficheiro para séries, MB por minuto"
 
 msgctxt "#30525"
 msgid "Automatically start downloading next episode"
-msgstr ""
+msgstr "Começar automaticamente a transferir o episódio seguinte"
 
 msgctxt "#30527"
 msgid "Donate"
-msgstr ""
+msgstr "Doar"
 
 msgctxt "#30528"
 msgid "Automatically load first found subtitles"
-msgstr ""
+msgstr "Carregar automaticamente as primeiras legendas encontradas"
 
 msgctxt "#30529"
 msgid "Number of subtitles to load automatically"
-msgstr ""
+msgstr "Número de legendas a carregar automaticamente"
 
 msgctxt "#30530"
 msgid "Delete autoloaded subtitles on player stop"
-msgstr ""
+msgstr "Eliminar as legendas carregadas automaticamente ao parar o reprodutor"
 
 msgctxt "#30531"
 msgid "Download all files from torrent"
-msgstr ""
+msgstr "Transferir todos os ficheiros do torrent"
 
 msgctxt "#30532"
 msgid "Stop Downloading all files"
-msgstr ""
+msgstr "Parar a transferência de todos os ficheiros"
 
 msgctxt "#30535"
 msgid "Continue playback from [B]%s[/B]?"
-msgstr ""
+msgstr "Continuar a reprodução a partir de [B]%s[/B]?"
 
 msgctxt "#30536"
 msgid "Skip IPv6 addresses resolving"
-msgstr ""
+msgstr "Ignorar a resolução de endereços IPv6"
 
 msgctxt "#30537"
 msgid "Torrents history"
-msgstr ""
+msgstr "Histórico de torrents"
 
 msgctxt "#30538"
 msgid "Use torrents history?"
-msgstr ""
+msgstr "Usar o histórico de torrents?"
 
 msgctxt "#30539"
 msgid "Store N torrents in history"
-msgstr ""
+msgstr "Guardar N torrents no histórico"
 
 msgctxt "#30540"
 msgid "Subtitles"
-msgstr ""
+msgstr "Legendas"
 
 msgctxt "#30541"
 msgid "Automatic Subtitles Search"
-msgstr ""
+msgstr "Pesquisa automática de legendas"
 
 msgctxt "#30542"
 msgid "Disable if subtitles are available in player"
-msgstr ""
+msgstr "Desativar se as legendas estiverem disponíveis no reprodutor"
 
 msgctxt "#30543"
 msgid "Subtitles included in torrent"
-msgstr ""
+msgstr "Legendas incluídas no torrent"
 
 msgctxt "#30544"
 msgid "Automatic Scrape"
-msgstr ""
+msgstr "Recolha automática"
 
 msgctxt "#30545"
 msgid "Automatic scraping allows to scrape connected providers[CR]to find new movies, if there are results,"
-msgstr ""
+msgstr "A recolha automática permite pesquisar nos fornecedores ligados[CR]por filmes novos. Se houver resultados"
 
 msgctxt "#30546"
 msgid "Strategy"
-msgstr ""
+msgstr "Estratégia"
 
 msgctxt "#30547"
 msgid "Find in each provider"
-msgstr ""
+msgstr "Procurar em cada fornecedor"
 
 msgctxt "#30548"
 msgid "Find in overall"
-msgstr ""
+msgstr "Procurar no conjunto"
 
 msgctxt "#30549"
 msgid "Search is successful when found N results"
-msgstr ""
+msgstr "A pesquisa tem êxito quando encontra N resultados"
 
 msgctxt "#30550"
 msgid "What to search"
-msgstr ""
+msgstr "O que pesquisar"
 
 msgctxt "#30551"
 msgid "How to search"
-msgstr ""
+msgstr "Como pesquisar"
 
 msgctxt "#30552"
 msgid "Search each N hours"
-msgstr ""
+msgstr "Pesquisar a cada N horas"
 
 msgctxt "#30553"
 msgid "Find 4K resolution"
-msgstr ""
+msgstr "Encontrar resolução 4K"
 
 msgctxt "#30554"
 msgid "Find 1080p resolution"
-msgstr ""
+msgstr "Encontrar resolução 1080p"
 
 msgctxt "#30555"
 msgid "and movie passes checks for number of results[CR]movie can be added to the library."
-msgstr ""
+msgstr "e o filme passar nas verificações do número de resultados,[CR]pode ser adicionado à biblioteca."
 
 msgctxt "#30556"
 msgid "Add to the library"
-msgstr ""
+msgstr "Adicionar à biblioteca"
 
 msgctxt "#30557"
 msgid "Number of popular movies to search"
-msgstr ""
+msgstr "Número de filmes populares a pesquisar"
 
 msgctxt "#30558"
 msgid "Latest available movies"
-msgstr ""
+msgstr "Filmes mais recentes disponíveis"
 
 msgctxt "#30559"
 msgid "Skip searching for installed providers"
-msgstr ""
+msgstr "Ignorar a pesquisa de fornecedores instalados"
 
 msgctxt "#30560"
 msgid "Files: %s"
-msgstr ""
+msgstr "Ficheiros: %s"
 
 msgctxt "#30561"
 msgid "Interval between requests, seconds"
-msgstr ""
+msgstr "Intervalo entre pedidos, segundos"
 
 msgctxt "#30562"
 msgid "Open directory with Kodi file browser"
-msgstr ""
+msgstr "Abrir a pasta com o explorador de ficheiros do Kodi"
 
 msgctxt "#30563"
 msgid "Synchronize frequency of Trakt, minutes"
-msgstr ""
+msgstr "Frequência de sincronização com o Trakt, minutos"
 
 msgctxt "#30564"
 msgid "Sync hidden items"
-msgstr ""
+msgstr "Sincronizar os itens ocultos"
 
 msgctxt "#30565"
 msgid "Sync playback progress into Kodi library"
-msgstr ""
+msgstr "Sincronizar o progresso de reprodução para a biblioteca do Kodi"
 
 msgctxt "#30566"
 msgid "Lists"
-msgstr ""
+msgstr "Listas"
 
 msgctxt "#30567"
 msgid "Show \"All seasons\" in shows"
-msgstr ""
+msgstr "Mostrar \"Todas as temporadas\" nas séries"
 
 msgctxt "#30568"
 msgid "Seasons order"
-msgstr ""
+msgstr "Ordem das temporadas"
 
 msgctxt "#30569"
 msgid "Ascending"
-msgstr ""
+msgstr "Ascendente"
 
 msgctxt "#30570"
 msgid "Descending"
-msgstr ""
+msgstr "Descendente"
 
 msgctxt "#30571"
 msgid "* All seasons"
-msgstr ""
+msgstr "* Todas as temporadas"
 
 msgctxt "#30572"
 msgid "Log server's response body"
-msgstr ""
+msgstr "Registar o corpo da resposta do servidor"
 
 msgctxt "#30573"
 msgid "Select file to play"
-msgstr ""
+msgstr "Selecionar o ficheiro a reproduzir"
 
 msgctxt "#30574"
 msgid "Automatically answer Yes after timeout"
-msgstr ""
+msgstr "Responder Sim automaticamente após o tempo limite"
 
 msgctxt "#30575"
 msgid "Timeout, seconds"
-msgstr ""
+msgstr "Tempo limite, segundos"
 
 msgctxt "#30576"
 msgid "Trakt authentication needs to be updated!"
-msgstr ""
+msgstr "A autenticação do Trakt precisa de ser atualizada!"
 
 msgctxt "#30577"
 msgid "End of file Buffer size, MB"
-msgstr ""
+msgstr "Tamanho da memória intermédia no fim do ficheiro, MB"
 
 msgctxt "#30578"
 msgid "Beginning of file Buffer size, MB"
-msgstr ""
+msgstr "Tamanho da memória intermédia no início do ficheiro, MB"
 
 msgctxt "#30579"
 msgid "Settings"
-msgstr ""
+msgstr "Definições"
 
 msgctxt "#30580"
 msgid "Custom Trakt API Client ID"
-msgstr ""
+msgstr "Client ID personalizado da API do Trakt"
 
 msgctxt "#30581"
 msgid "Custom Trakt API Client Secret"
-msgstr ""
+msgstr "Client Secret personalizado da API do Trakt"
 
 msgctxt "#30582"
 msgid "Settings for %s provider"
-msgstr ""
+msgstr "Definições do fornecedor %s"
 
 msgctxt "#30583"
 msgid "Resolving magnet link"
-msgstr ""
+msgstr "A resolver a ligação magnet"
 
 msgctxt "#30585"
 msgid "Enable library integration with Kodi"
-msgstr ""
+msgstr "Ativar a integração com a biblioteca do Kodi"
 
 msgctxt "#30586"
 msgid "If disabled - Elementum will not get/insert items to Kodi library [CR]and skip watched management with Kodi."
-msgstr ""
+msgstr "Se estiver desativado, o Elementum não obtém nem insere itens na biblioteca do Kodi [CR]e ignora a gestão do estado de visto com o Kodi."
 
 msgctxt "#30587"
 msgid "Show welcome message on start"
-msgstr ""
+msgstr "Mostrar a mensagem de boas-vindas no arranque"
 
 msgctxt "#30588"
 msgid "Pre-Play Buffering"
-msgstr ""
+msgstr "Memória intermédia antes da reprodução"
 
 msgctxt "#30589"
 msgid "Speed limiting"
-msgstr ""
+msgstr "Limitação de velocidade"
 
 msgctxt "#30590"
 msgid "Torrents autoload on addon startup"
-msgstr ""
+msgstr "Carregamento automático de torrents no arranque do add-on"
 
 msgctxt "#30591"
 msgid "Limits for connections"
-msgstr ""
+msgstr "Limites das ligações"
 
 msgctxt "#30592"
 msgid "Seeding"
-msgstr ""
+msgstr "Semeadura"
 
 msgctxt "#30593"
 msgid "Seed forever"
-msgstr ""
+msgstr "Semear para sempre"
 
 msgctxt "#30594"
 msgid "Network"
-msgstr ""
+msgstr "Rede"
 
 msgctxt "#30595"
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Diversos"
 
 msgctxt "#30597"
 msgid "Cache size, MB"
-msgstr ""
+msgstr "Tamanho da cache, MB"
 
 msgctxt "#30598"
 msgid "Enable caching if using File storage and have speed problems.[CR]Will use more memory, but can improve the speed."
-msgstr ""
+msgstr "Ativa a cache se usares armazenamento em ficheiros e tiveres problemas de velocidade.[CR]Usará mais memória, mas pode melhorar a velocidade."
 
 msgctxt "#30599"
 msgid "Enable Kodi library synchronization"
-msgstr ""
+msgstr "Ativar a sincronização com a biblioteca do Kodi"
 
 msgctxt "#30600"
 msgid "Enable Trakt synchronization"
-msgstr ""
+msgstr "Ativar a sincronização com o Trakt"
 
 msgctxt "#30601"
 msgid "Enable synchronization while playback"
-msgstr ""
+msgstr "Ativar a sincronização durante a reprodução"
 
 msgctxt "#30602"
 msgid "Retry requests to addon after timeout, seconds"
-msgstr ""
+msgstr "Repetir os pedidos ao add-on após o tempo limite, segundos"
 
 msgctxt "#30603"
 msgid "Addon Startup"
-msgstr ""
+msgstr "Arranque do add-on"
 
 msgctxt "#30604"
 msgid "Clean all history"
-msgstr ""
+msgstr "Limpar todo o histórico"
 
 msgctxt "#30605"
 msgid "Cache downloaded torrent files after search"
-msgstr ""
+msgstr "Guardar em cache os ficheiros torrent transferidos após a pesquisa"
 
 msgctxt "#30606"
 msgid "Show watched state for torrent's files"
-msgstr ""
+msgstr "Mostrar o estado de visto dos ficheiros do torrent"
 
 msgctxt "#30607"
 msgid "Use earliest release date as basic for searching"
-msgstr ""
+msgstr "Usar a data de lançamento mais antiga como base da pesquisa"
 
 msgctxt "#30608"
 msgid "Match found in your active torrents, play it?[CR]%s"
-msgstr ""
+msgstr "Foi encontrada uma correspondência nos teus torrents ativos, reproduzir?[CR]%s"
 
 msgctxt "#30609"
 msgid "Automatically start next episode if available"
-msgstr ""
+msgstr "Iniciar automaticamente o episódio seguinte, se disponível"
 
 msgctxt "#30610"
 msgid "Magnet resolve timeout, seconds"
-msgstr ""
+msgstr "Tempo limite para resolver o magnet, segundos"
 
 msgctxt "#30611"
 msgid "Application platform type"
-msgstr ""
+msgstr "Tipo de plataforma da aplicação"
 
 msgctxt "#30612"
 msgid "Select file to download"
-msgstr ""
+msgstr "Selecionar o ficheiro a transferir"
 
 msgctxt "#30613"
 msgid "... for movie"
-msgstr ""
+msgstr "... para filme"
 
 msgctxt "#30614"
 msgid "... for tv show"
-msgstr ""
+msgstr "... para série"
 
 msgctxt "#30615"
 msgid "... for search"
-msgstr ""
+msgstr "... para pesquisa"
 
 msgctxt "#30616"
 msgid "Elementum | Trakt Account"
-msgstr ""
+msgstr "Elementum | Conta Trakt"
 
 msgctxt "#30617"
 msgid "Your account is locked for API on Trakt.tv[CR]Please, contact Trakt Support at https://support.trakt.tv ."
-msgstr ""
+msgstr "A tua conta está bloqueada para a API no Trakt.tv[CR]Por favor, contacta o suporte do Trakt em https://support.trakt.tv ."
 
 msgctxt "#30618"
 msgid "%s is downloaded"
-msgstr ""
+msgstr "%s foi transferido"
 
 msgctxt "#30619"
 msgid "Return to [B]%s[/B]"
-msgstr ""
+msgstr "Voltar a [B]%s[/B]"
 
 msgctxt "#30620"
 msgid "Restart Elementum addon"
-msgstr ""
+msgstr "Reiniciar o add-on Elementum"
 
 msgctxt "#30621"
 msgid "Queued"
-msgstr ""
+msgstr "Em fila"
 
 msgctxt "#30622"
 msgid "Checking"
-msgstr ""
+msgstr "A verificar"
 
 msgctxt "#30623"
 msgid "Finding"
-msgstr ""
+msgstr "A procurar"
 
 msgctxt "#30624"
 msgid "Downloading"
-msgstr ""
+msgstr "A transferir"
 
 msgctxt "#30625"
 msgid "Finished"
-msgstr ""
+msgstr "Concluído"
 
 msgctxt "#30626"
 msgid "Seeding"
-msgstr ""
+msgstr "A semear"
 
 msgctxt "#30627"
 msgid "Allocating"
-msgstr ""
+msgstr "A alocar"
 
 msgctxt "#30628"
 msgid "Stalled"
-msgstr ""
+msgstr "Parado"
 
 msgctxt "#30629"
 msgid "Paused"
-msgstr ""
+msgstr "Em pausa"
 
 msgctxt "#30630"
 msgid "Buffering"
-msgstr ""
+msgstr "A carregar a memória intermédia"
 
 msgctxt "#30631"
 msgid "Playing"
-msgstr ""
+msgstr "A reproduzir"
 
 msgctxt "#30632"
 msgid "Yes (%s seconds)"
-msgstr ""
+msgstr "Sim (%s segundos)"
 
 msgctxt "#30633"
 msgid "No (%s seconds)"
-msgstr ""
+msgstr "Não (%s segundos)"
 
 msgctxt "#30634"
 msgid "Log level"
-msgstr ""
+msgstr "Nível de registo"
 
 msgctxt "#30635"
 msgid "None"
-msgstr ""
+msgstr "Nenhum"
 
 msgctxt "#30636"
 msgid "Error"
-msgstr ""
+msgstr "Erro"
 
 msgctxt "#30637"
 msgid "Info"
-msgstr ""
+msgstr "Informação"
 
 msgctxt "#30638"
 msgid "Debug"
-msgstr ""
+msgstr "Depuração"
 
 msgctxt "#30639"
 msgid "Show Specials in season listings"
-msgstr ""
+msgstr "Mostrar os especiais nas listas de temporadas"
 
 msgctxt "#30640"
 msgid "Bitrate"
-msgstr ""
+msgstr "Taxa de bits"
 
 msgctxt "#30641"
 msgid "Playback"
-msgstr ""
+msgstr "Reprodução"
 
 msgctxt "#30642"
 msgid "Force Resume options"
-msgstr ""
+msgstr "Forçar as opções de retoma"
 
 msgctxt "#30643"
 msgid "by Kodi"
-msgstr ""
+msgstr "pelo Kodi"
 
 msgctxt "#30644"
 msgid "by Elementum - Ask"
-msgstr ""
+msgstr "pelo Elementum - Perguntar"
 
 msgctxt "#30645"
 msgid "by Elementum - Force"
-msgstr ""
+msgstr "pelo Elementum - Forçar"
 
 msgctxt "#30646"
 msgid "Authorize Elementum on Trakt.tv"
-msgstr ""
+msgstr "Autorizar o Elementum no Trakt.tv"
 
 msgctxt "#30647"
 msgid "Cancel Authorization for Elementum on Trakt.tv"
-msgstr ""
+msgstr "Cancelar a autorização do Elementum no Trakt.tv"
 
 msgctxt "#30648"
 msgid "Authorization"
-msgstr ""
+msgstr "Autorização"
 
 msgctxt "#30649"
 msgid "To authorize addon for Trakt.tv you need to:[CR]1. Open [B]%s[/B][CR]2. Enter code: [B]%s[/B][CR]3. Wait for notification from Elementum."
-msgstr ""
+msgstr "Para autorizares o add-on no Trakt.tv precisas de:[CR]1. Abrir [B]%s[/B][CR]2. Introduzir o código: [B]%s[/B][CR]3. Aguardar a notificação do Elementum."
 
 msgctxt "#30650"
 msgid "Successfully authorized for Trakt.tv"
-msgstr ""
+msgstr "Autorizado no Trakt.tv com sucesso"
 
 msgctxt "#30651"
 msgid "Could not authorize for Trakt.tv"
-msgstr ""
+msgstr "Não foi possível autorizar no Trakt.tv"
 
 msgctxt "#30652"
 msgid "Successfully deauthorized for Trakt.tv"
-msgstr ""
+msgstr "Autorização no Trakt.tv cancelada com sucesso"
 
 msgctxt "#30653"
 msgid "Which files to download"
-msgstr ""
+msgstr "Que ficheiros transferir"
 
 msgctxt "#30654"
 msgid "Only playback file"
-msgstr ""
+msgstr "Apenas o ficheiro a reproduzir"
 
 msgctxt "#30655"
 msgid "Season files"
-msgstr ""
+msgstr "Os ficheiros da temporada"
 
 msgctxt "#30656"
 msgid "All files"
-msgstr ""
+msgstr "Todos os ficheiros"
 
 msgctxt "#30657"
 msgid "Disable LSD"
-msgstr ""
+msgstr "Desativar LSD"
 
 msgctxt "#30658"
 msgid "Add extra trackers"
-msgstr ""
+msgstr "Adicionar trackers extra"
 
 msgctxt "#30659"
 msgid "All known trackers"
-msgstr ""
+msgstr "Todos os trackers conhecidos"
 
 msgctxt "#30660"
 msgid "Best trackers"
-msgstr ""
+msgstr "Os melhores trackers"
 
 msgctxt "#30661"
 msgid "Minimum set"
-msgstr ""
+msgstr "Conjunto mínimo"
 
 msgctxt "#30662"
 msgid "Remove original trackers from torrent"
-msgstr ""
+msgstr "Remover os trackers originais do torrent"
 
 msgctxt "#30663"
 msgid "Show episodes on release day (w/o delay)"
-msgstr ""
+msgstr "Mostrar os episódios no dia de estreia (sem atraso)"
 
 msgctxt "#30664"
 msgid "Modify trackers in torrent"
-msgstr ""
+msgstr "Modificar os trackers no torrent"
 
 msgctxt "#30665"
 msgid "At the time of adding"
-msgstr ""
+msgstr "No momento de adicionar"
 
 msgctxt "#30666"
 msgid "Every time"
-msgstr ""
+msgstr "Sempre"
 
 msgctxt "#30667"
 msgid "Mark as watched in Trakt"
-msgstr ""
+msgstr "Marcar como visto no Trakt"
 
 msgctxt "#30668"
 msgid "Mark as unwatched in Trakt"
-msgstr ""
+msgstr "Marcar como não visto no Trakt"
 
 msgctxt "#30669"
 msgid "Delay addon startup, seconds"
-msgstr ""
+msgstr "Atrasar o arranque do add-on, segundos"
 
 msgctxt "#30670"
 msgid "Downloading required binary file for '%s'"
-msgstr ""
+msgstr "A transferir o ficheiro binário necessário para '%s'"
 
 msgctxt "#30671"
 msgid "List of Opennic DNS IPs"
-msgstr ""
+msgstr "Lista de IPs dos DNS OpenNIC"
 
 msgctxt "#30672"
 msgid "Compact database"
-msgstr ""
+msgstr "Compactar a base de dados"
 
 msgctxt "#30673"
 msgid "Compact cache database"
-msgstr ""
+msgstr "Compactar a base de dados da cache"
 
 msgctxt "#30674"
 msgid "Database was compacted"
-msgstr ""
+msgstr "A base de dados foi compactada"
 
 msgctxt "#30675"
 msgid "Remote host login"
-msgstr ""
+msgstr "Utilizador do anfitrião remoto"
 
 msgctxt "#30676"
 msgid "Remote host password"
-msgstr ""
+msgstr "Palavra-passe do anfitrião remoto"
 
 msgctxt "#30677"
 msgid "Force start as a library"
-msgstr ""
+msgstr "Forçar o arranque como biblioteca"
 
 msgctxt "#30678"
 msgid "Remove from Kodi library, when movie is deleted from Trakt"
-msgstr ""
+msgstr "Remover da biblioteca do Kodi quando o filme é eliminado do Trakt"
 
 msgctxt "#30679"
 msgid "Remove from Kodi library, when show is deleted from Trakt"
-msgstr ""
+msgstr "Remover da biblioteca do Kodi quando a série é eliminada do Trakt"
 
 msgctxt "#30680"
 msgid "Remove Elementum duplicates from library"
-msgstr ""
+msgstr "Remover os duplicados do Elementum da biblioteca"
 
 msgctxt "#30681"
 msgid "[B]Found duplicates in Kodi library:[/B][CR]Movies: [B]%s[/B], Shows: [B]%s[/B], Episodes: [B]%s[/B][CR]Proceed?"
-msgstr ""
+msgstr "[B]Foram encontrados duplicados na biblioteca do Kodi:[/B][CR]Filmes: [B]%s[/B], Séries: [B]%s[/B], Episódios: [B]%s[/B][CR]Continuar?"
 
 msgctxt "#30682"
 msgid "No duplicates were found in Kodi library"
-msgstr ""
+msgstr "Não foram encontrados duplicados na biblioteca do Kodi"
 
 msgctxt "#30683"
 msgid "Starting library duplicates removal"
-msgstr ""
+msgstr "A iniciar a remoção de duplicados da biblioteca"
 
 msgctxt "#30684"
 msgid "Removed Movies: %s, Shows: %s, Episodes: %s"
-msgstr ""
+msgstr "Removidos - Filmes: %s, Séries: %s, Episódios: %s"
 
 msgctxt "#30685"
 msgid "Remove movies from Elementum database"
-msgstr ""
+msgstr "Remover os filmes da base de dados do Elementum"
 
 msgctxt "#30686"
 msgid "Remove shows from Elementum database"
-msgstr ""
+msgstr "Remover as séries da base de dados do Elementum"
 
 msgctxt "#30687"
 msgid "In Elementum library"
-msgstr ""
+msgstr "Na biblioteca do Elementum"
 
 msgctxt "#30688"
 msgid "Skip searching for installed Elementum repository"
-msgstr ""
+msgstr "Ignorar a procura do repositório Elementum instalado"
 
 msgctxt "#30689"
 msgid "Internal DNS client"
-msgstr ""
+msgstr "Cliente DNS interno"
 
 msgctxt "#30691"
 msgid "Hide watched"
-msgstr ""
+msgstr "Ocultar os vistos"
 
 msgctxt "#30692"
 msgid "TMDB images quality (affects Kodi performance)"
-msgstr ""
+msgstr "Qualidade das imagens do TMDB (afeta o desempenho do Kodi)"
 
 msgctxt "#30693"
 msgid "Original"
-msgstr ""
+msgstr "Original"
 
 msgctxt "#30694"
 msgid "High"
-msgstr ""
+msgstr "Alta"
 
 msgctxt "#30695"
 msgid "Medium"
-msgstr ""
+msgstr "Média"
 
 msgctxt "#30696"
 msgid "Low"
-msgstr ""
+msgstr "Baixa"
 
 msgctxt "#30697"
 msgid "Interface language"
-msgstr ""
+msgstr "Idioma da interface"
 
 msgctxt "#30698"
 msgid "Kodi language"
-msgstr ""
+msgstr "Idioma do Kodi"
 
 msgctxt "#30699"
 msgid "Use earliest release date for progress and calendars"
-msgstr ""
+msgstr "Usar a data de lançamento mais antiga para o progresso e os calendários"
 
 msgctxt "#30700"
 msgid "Interface fallback language"
-msgstr ""
+msgstr "Idioma alternativo da interface"
 
 msgctxt "#30701"
 msgid "English | en"
-msgstr ""
+msgstr "Inglês | en"
 
 msgctxt "#30702"
 msgid "Reached daily limit for subtitles downloads"
-msgstr ""
+msgstr "Foi atingido o limite diário de transferências de legendas"
 
 msgctxt "#30703"
 msgid "Can be used by search providers or [CR]for debugging"
-msgstr ""
+msgstr "Pode ser usado pelos fornecedores de pesquisa ou [CR]para depuração"
 
 msgctxt "#30704"
 msgid "TMDB API Key check failed, cannot use TMDB service"
-msgstr ""
+msgstr "A verificação da chave da API do TMDB falhou, não é possível usar o serviço TMDB"
 
 msgctxt "#30705"
 msgid "TMDB API accessibility check failed, cannot use TMDB service"
-msgstr ""
+msgstr "A verificação da acessibilidade da API do TMDB falhou, não é possível usar o serviço TMDB"
 
 msgctxt "#30706"
 msgid "Transmission 4.05"
-msgstr ""
+msgstr "Transmission 4.05"
 
 msgctxt "#30707"
 msgid "qBittorrent 3.3.9"
-msgstr ""
+msgstr "qBittorrent 3.3.9"
 
 msgctxt "#30708"
 msgid "qBittorrent 4.6.4"
-msgstr ""
+msgstr "qBittorrent 4.6.4"
 
 msgctxt "#30709"
 msgid "Open [B]%s[/B]"
-msgstr ""
+msgstr "Abrir [B]%s[/B]"
 
 msgctxt "#30710"
 msgid "BitTorrent ports"
-msgstr ""
+msgstr "Portas BitTorrent"
 
 msgctxt "#30711"
 msgid "Delete torrent '%s'?"
-msgstr ""
+msgstr "Eliminar o torrent '%s'?"
 
 msgctxt "#30712"
 msgid "Force to always use proxy, can break download in some cases"
-msgstr ""
+msgstr "Forçar sempre o uso do proxy, em alguns casos pode interromper a transferência"
 
 msgctxt "#30713"
 msgid "Disable NATPMP"
@@ -2283,20 +2283,20 @@ msgstr "Desativar NATPMP"
 
 msgctxt "#30714"
 msgid "Re-check torrent's data"
-msgstr ""
+msgstr "Verificar novamente os dados do torrent"
 
 msgctxt "#30715"
 msgid "Antizapret PAC file URL"
-msgstr ""
+msgstr "URL do ficheiro PAC do Antizapret"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "Servidor DNS over HTTPS"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "Servidor DNS over HTTPS personalizado"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "Usar os servidores DNS OpenNIC"

--- a/resources/language/Romanian/strings.po
+++ b/resources/language/Romanian/strings.po
@@ -25,7 +25,7 @@ msgstr "General"
 
 msgctxt "#30001"
 msgid "Download path"
-msgstr ""
+msgstr "Calea de descărcare"
 
 msgctxt "#30004"
 msgid "Max upload rate, kB/s"
@@ -101,7 +101,7 @@ msgstr "Selectați fluxul automat"
 
 msgctxt "#30025"
 msgid "Limit rates after initial buffering only"
-msgstr ""
+msgstr "Limitează ratele doar după memorarea inițială în tampon"
 
 msgctxt "#30026"
 msgid "Library path"
@@ -113,7 +113,7 @@ msgstr "Limita conexiunilor"
 
 msgctxt "#30028"
 msgid "Download after play was stopped"
-msgstr ""
+msgstr "Continuă descărcarea după oprirea redării"
 
 msgctxt "#30029"
 msgid "Session saving frequency, seconds"
@@ -277,7 +277,7 @@ msgstr "Păcălește user agent-ul (nu este recomandat)"
 
 msgctxt "#30075"
 msgid "Default advisable (acceptable)"
-msgstr ""
+msgstr "Implicit recomandat (acceptabil)"
 
 msgctxt "#30076"
 msgid "libtorrent (Rasterbar) 1.1.0"
@@ -329,23 +329,23 @@ msgstr "Timp răspuns în secunde"
 
 msgctxt "#30090"
 msgid "Listen interfaces"
-msgstr ""
+msgstr "Interfețe de ascultare"
 
 msgctxt "#30091"
 msgid "Outgoing interfaces"
-msgstr ""
+msgstr "Interfețe de ieșire"
 
 msgctxt "#30092"
 msgid "Use fallback fanart if fanart wasn't found"
-msgstr ""
+msgstr "Folosește fanart de rezervă dacă nu a fost găsit niciunul"
 
 msgctxt "#30093"
 msgid "Disable notification sound"
-msgstr ""
+msgstr "Dezactivează sunetul notificărilor"
 
 msgctxt "#30094"
 msgid "Disable background progress dialog"
-msgstr ""
+msgstr "Dezactivează dialogul de progres din fundal"
 
 # Interface
 msgctxt "#30100"
@@ -358,7 +358,7 @@ msgstr "Acesta extensie poate fi rulată doar din Elementum"
 
 msgctxt "#30103"
 msgid "Unable to find Elementum binary[CR]Required platform:"
-msgstr ""
+msgstr "Nu s-a putut găsi fișierul binar Elementum[CR]Platformă necesară:"
 
 msgctxt "#30104"
 msgid "Insert file or URL"
@@ -402,63 +402,63 @@ msgstr "Calea pentru descărcare nu a fost setata, verificați setările"
 
 msgctxt "#30116"
 msgid "Looks like Elementum is still starting up, give it a few seconds..."
-msgstr ""
+msgstr "Se pare că Elementum încă pornește, mai așteaptă câteva secunde..."
 
 msgctxt "#30117"
 msgid "Resolving torrent files..."
-msgstr ""
+msgstr "Se rezolvă fișierele torrent..."
 
 msgctxt "#30118"
 msgid "Scraping trackers..."
-msgstr ""
+msgstr "Se interoghează trackerele..."
 
 msgctxt "#30119"
 msgid "ID of selected userlist for movies"
-msgstr ""
+msgstr "ID-ul listei de utilizator selectate pentru filme"
 
 msgctxt "#30120"
 msgid "ID of selected userlist for shows"
-msgstr ""
+msgstr "ID-ul listei de utilizator selectate pentru seriale"
 
 msgctxt "#30141"
 msgid "Please support Elementum development by visiting[CR]https://elementum.surge.sh/donate/ or https://elementumorg.github.io/donate/"
-msgstr ""
+msgstr "Te rugăm să susții dezvoltarea Elementum vizitând[CR]https://elementum.surge.sh/donate/ sau https://elementumorg.github.io/donate/"
 
 msgctxt "#30142"
 msgid "Default view for menus in Movies"
-msgstr ""
+msgstr "Vizualizarea implicită pentru meniurile din Filme"
 
 msgctxt "#30143"
 msgid "Default view for menus in TV Shows"
-msgstr ""
+msgstr "Vizualizarea implicită pentru meniurile din Seriale"
 
 msgctxt "#30144"
 msgid "Default view for movie genres"
-msgstr ""
+msgstr "Vizualizarea implicită pentru genurile de filme"
 
 msgctxt "#30145"
 msgid "Default view for TV show genres"
-msgstr ""
+msgstr "Vizualizarea implicită pentru genurile de seriale"
 
 msgctxt "#30146"
 msgid "Keep downloading '%s'?"
-msgstr ""
+msgstr "Continui descărcarea '%s'?"
 
 msgctxt "#30147"
 msgid "Caches are still warming up, give it a minute or two..."
-msgstr ""
+msgstr "Memoriile cache încă se pregătesc, mai așteaptă un minut sau două..."
 
 msgctxt "#30148"
 msgid "Caches warmed up"
-msgstr ""
+msgstr "Memoriile cache sunt gata"
 
 msgctxt "#30149"
 msgid "Trakt username not set, check your settings"
-msgstr ""
+msgstr "Numele de utilizator Trakt nu este setat, verifică setările"
 
 msgctxt "#30199"
 msgid "No available JSON-RPC connection to Kodi.[CR]Enable both Application control options in Service settings / Control and restart Kodi."
-msgstr ""
+msgstr "Nu există o conexiune JSON-RPC disponibilă către Kodi.[CR]Activează ambele opțiuni de control al aplicației din Setări servicii / Control și repornește Kodi."
 
 # Elementum daemon
 msgctxt "#30200"
@@ -707,1579 +707,1579 @@ msgstr "Șterge torentele si fișierele"
 
 msgctxt "#30277"
 msgid "%s added to library, do you want to rescan it?[CR]You can later use Kodi's 'Update library' feature instead."
-msgstr ""
+msgstr "%s a fost adăugat în bibliotecă, vrei să o scanezi din nou?[CR]Poți folosi mai târziu funcția 'Actualizează biblioteca' din Kodi."
 
 msgctxt "#30278"
 msgid "%s removed from library, do you want to clean it?[CR]You can later use Kodi's 'Clean library' feature instead."
-msgstr ""
+msgstr "%s a fost eliminat din bibliotecă, vrei să o cureți?[CR]Poți folosi mai târziu funcția 'Curăță biblioteca' din Kodi."
 
 msgctxt "#30279"
 msgid "Video %s was previously removed from library.[CR]Force adding?"
-msgstr ""
+msgstr "Videoclipul %s a fost eliminat anterior din bibliotecă.[CR]Forțezi adăugarea?"
 
 msgctxt "#30282"
 msgid "Nothing left to remove from Elementum"
-msgstr ""
+msgstr "Nu mai există nimic de eliminat din Elementum"
 
 msgctxt "#30283"
 msgid "Merge to library"
-msgstr ""
+msgstr "Îmbină în bibliotecă"
 
 msgctxt "#30284"
 msgid "Show unaired seasons"
-msgstr ""
+msgstr "Arată sezoanele needifuzate"
 
 msgctxt "#30285"
 msgid "Show unaired episodes"
-msgstr ""
+msgstr "Arată episoadele needifuzate"
 
 msgctxt "#30286"
 msgid "%s merged to library, do you want to rescan it?[CR]You can later use Kodi's 'Update library' feature instead."
-msgstr ""
+msgstr "%s a fost îmbinat în bibliotecă, vrei să o scanezi din nou?[CR]Poți folosi mai târziu funcția 'Actualizează biblioteca' din Kodi."
 
 msgctxt "#30287"
 msgid "%s already in library"
-msgstr ""
+msgstr "%s este deja în bibliotecă"
 
 msgctxt "#30288"
 msgid "Library updated, do you want to rescan it?[CR]You can later use Kodi's 'Update library' feature instead."
-msgstr ""
+msgstr "Biblioteca a fost actualizată, vrei să o scanezi din nou?[CR]Poți folosi mai târziu funcția 'Actualizează biblioteca' din Kodi."
 
 msgctxt "#30289"
 msgid "Genres"
-msgstr ""
+msgstr "Genuri"
 
 msgctxt "#30290"
 msgid "Calendars"
-msgstr ""
+msgstr "Calendare"
 
 msgctxt "#30291"
 msgid "My Movies"
-msgstr ""
+msgstr "Filmele mele"
 
 msgctxt "#30292"
 msgid "My Releases"
-msgstr ""
+msgstr "Lansările mele"
 
 msgctxt "#30293"
 msgid "All Movies"
-msgstr ""
+msgstr "Toate filmele"
 
 msgctxt "#30294"
 msgid "All Releases"
-msgstr ""
+msgstr "Toate lansările"
 
 msgctxt "#30295"
 msgid "My Shows"
-msgstr ""
+msgstr "Serialele mele"
 
 msgctxt "#30296"
 msgid "My New Shows"
-msgstr ""
+msgstr "Serialele mele noi"
 
 msgctxt "#30297"
 msgid "My Premieres"
-msgstr ""
+msgstr "Premierele mele"
 
 msgctxt "#30298"
 msgid "All Shows"
-msgstr ""
+msgstr "Toate serialele"
 
 msgctxt "#30299"
 msgid "All New Shows"
-msgstr ""
+msgstr "Toate serialele noi"
 
 msgctxt "#30300"
 msgid "All Premieres"
-msgstr ""
+msgstr "Toate premierele"
 
 msgctxt "#30301"
 msgid "Move finished downloads to separate folders"
-msgstr ""
+msgstr "Mută descărcările finalizate în dosare separate"
 
 msgctxt "#30302"
 msgid "Files will only be moved after seeding is finished (see[CR]- BitTorrent settings), and will wait if currently playing"
-msgstr ""
+msgstr "Fișierele vor fi mutate abia după terminarea partajării (vezi[CR]- setările BitTorrent) și vor aștepta dacă sunt în redare"
 
 msgctxt "#30303"
 msgid "RAR archive detected. Download will need to be completed before playback can start and will require around twice the amount of space, continue?"
-msgstr ""
+msgstr "A fost detectată o arhivă RAR. Descărcarea trebuie finalizată înainte ca redarea să poată începe și va necesita aproximativ dublul spațiului. Continui?"
 
 msgctxt "#30304"
 msgid "Error creating output pipe for 'unrar' command"
-msgstr ""
+msgstr "Eroare la crearea canalului de ieșire pentru comanda 'unrar'"
 
 msgctxt "#30305"
 msgid "Error starting 'unrar' command"
-msgstr ""
+msgstr "Eroare la pornirea comenzii 'unrar'"
 
 msgctxt "#30306"
 msgid "Error waiting for 'unrar' command"
-msgstr ""
+msgstr "Eroare la așteptarea comenzii 'unrar'"
 
 msgctxt "#30307"
 msgid "Error reading from destination folder"
-msgstr ""
+msgstr "Eroare la citirea din dosarul de destinație"
 
 msgctxt "#30308"
 msgid "Move completed"
-msgstr ""
+msgstr "Mutare finalizată"
 
 msgctxt "#30309"
 msgid "Keep"
-msgstr ""
+msgstr "Păstrează"
 
 msgctxt "#30310"
 msgid "Ask to delete"
-msgstr ""
+msgstr "Întreabă înainte de ștergere"
 
 msgctxt "#30311"
 msgid "Delete"
-msgstr ""
+msgstr "Șterge"
 
 msgctxt "#30312"
 msgid "Keep files for not finished video"
-msgstr ""
+msgstr "Păstrează fișierele videoclipurilor nefinalizate"
 
 msgctxt "#30313"
 msgid "Keep files for watched/downloaded video"
-msgstr ""
+msgstr "Păstrează fișierele videoclipurilor vizionate/descărcate"
 
 msgctxt "#30314"
 msgid "Settings were not initialized.[CR]Save addon settings, then restart Kodi."
-msgstr ""
+msgstr "Setările nu au fost inițializate.[CR]Salvează setările suplimentului, apoi repornește Kodi."
 
 msgctxt "#30315"
 msgid "Download storage type"
-msgstr ""
+msgstr "Tipul de stocare pentru descărcări"
 
 msgctxt "#30316"
 msgid "Use files"
-msgstr ""
+msgstr "Folosește fișiere"
 
 msgctxt "#30317"
 msgid "Use memory"
-msgstr ""
+msgstr "Folosește memoria"
 
 msgctxt "#30318"
 msgid "Memory size to use for each torrent, Mb"
-msgstr ""
+msgstr "Memoria folosită pentru fiecare torrent, MB"
 
 msgctxt "#30319"
 msgid "Continue"
-msgstr ""
+msgstr "Continuă"
 
 msgctxt "#30320"
 msgid "Ask to stop"
-msgstr ""
+msgstr "Întreabă înainte de oprire"
 
 msgctxt "#30321"
 msgid "Stop"
-msgstr ""
+msgstr "Oprește"
 
 msgctxt "#30323"
 msgid "New search"
-msgstr ""
+msgstr "Căutare nouă"
 
 msgctxt "#30324"
 msgid "Force stream auto-selection from settings"
-msgstr ""
+msgstr "Forțează selecția automată a fluxului din setări"
 
 msgctxt "#30325"
 msgid "Download"
-msgstr ""
+msgstr "Descărcare"
 
 msgctxt "#30326"
 msgid "Kodi library"
-msgstr ""
+msgstr "Biblioteca Kodi"
 
 msgctxt "#30327"
 msgid "Storage"
-msgstr ""
+msgstr "Stocare"
 
 msgctxt "#30328"
 msgid "Disable TCP"
-msgstr ""
+msgstr "Dezactivează TCP"
 
 msgctxt "#30329"
 msgid "Disable UTP"
-msgstr ""
+msgstr "Dezactivează UTP"
 
 msgctxt "#30330"
 msgid "Update Trakt"
-msgstr ""
+msgstr "Actualizează Trakt"
 
 msgctxt "#30332"
 msgid "Reloading configuration..."
-msgstr ""
+msgstr "Se reîncarcă configurația..."
 
 msgctxt "#30333"
 msgid "Try to find other episodes in the torrent"
-msgstr ""
+msgstr "Încearcă să găsești alte episoade în torrent"
 
 msgctxt "#30347"
 msgid "Could not find binary for architecture '%s'![CR]Try to uninstall this addon, re-download and re-install it from the biggest zip."
-msgstr ""
+msgstr "Nu s-a găsit fișierul binar pentru arhitectura '%s'![CR]Încearcă să dezinstalezi acest supliment, să îl descarci din nou și să îl reinstalezi din arhiva zip cea mai mare."
 
 msgctxt "#30348"
 msgid "Create usual files on the file system and write to them.[CR]Needs selected file's full size to be available on the disk!"
-msgstr ""
+msgstr "Creează fișiere obișnuite în sistemul de fișiere și scrie în ele.[CR]Necesită ca dimensiunea completă a fișierului selectat să fie disponibilă pe disc!"
 
 msgctxt "#30349"
 msgid "Using device's memory to download parts of the torrent.[CR]Disk is used only to download and save .torrent file,"
-msgstr ""
+msgstr "Folosește memoria dispozitivului pentru a descărca părți din torrent.[CR]Discul este folosit doar pentru a descărca și salva fișierul .torrent,"
 
 msgctxt "#30350"
 msgid "so can be any storage. For 1gb memory devices[CR]100mb is enough for memory storage, 200-250mb for bigger devices."
-msgstr ""
+msgstr "deci poate fi orice stocare. Pentru dispozitive cu 1 GB de memorie[CR]100 MB sunt suficienți, 200-250 MB pentru dispozitive mai mari."
 
 msgctxt "#30351"
 msgid "Same as for usual file storage, but splits file into many small files.[CR]Should be used on FAT-32 file-systems."
-msgstr ""
+msgstr "La fel ca stocarea obișnuită în fișiere, dar împarte fișierul în multe fișiere mici.[CR]Ar trebui folosită pe sisteme de fișiere FAT-32."
 
 msgctxt "#30352"
 msgid "Same as for usual file storage, but using memory[CR]to lower filesystem operations. Experimental storage!"
-msgstr ""
+msgstr "La fel ca stocarea obișnuită în fișiere, dar folosește memoria[CR]pentru a reduce operațiile pe sistemul de fișiere. Stocare experimentală!"
 
 msgctxt "#30355"
 msgid "Changelog"
-msgstr ""
+msgstr "Jurnal de modificări"
 
 msgctxt "#30357"
 msgid "Use Trakt information in Trakt lists"
-msgstr ""
+msgstr "Folosește informațiile Trakt în listele Trakt"
 
 msgctxt "#30358"
 msgid "Trakt update started"
-msgstr ""
+msgstr "Actualizarea Trakt a început"
 
 msgctxt "#30359"
 msgid "Do not ask questions before playback"
-msgstr ""
+msgstr "Nu pune întrebări înainte de redare"
 
 msgctxt "#30360"
 msgid "My Progress"
-msgstr ""
+msgstr "Progresul meu"
 
 msgctxt "#30361"
 msgid "My History"
-msgstr ""
+msgstr "Istoricul meu"
 
 msgctxt "#30362"
 msgid "Synchronization"
-msgstr ""
+msgstr "Sincronizare"
 
 msgctxt "#30363"
 msgid "Sync items from collections into Kodi library"
-msgstr ""
+msgstr "Sincronizează elementele din colecții în biblioteca Kodi"
 
 msgctxt "#30364"
 msgid "Sync items from watchlist into Kodi library"
-msgstr ""
+msgstr "Sincronizează elementele din lista de urmărire în biblioteca Kodi"
 
 msgctxt "#30365"
 msgid "Sync items from user lists into Kodi library"
-msgstr ""
+msgstr "Sincronizează elementele din listele de utilizator în biblioteca Kodi"
 
 msgctxt "#30366"
 msgid "Sync watched states from Trakt into Kodi library"
-msgstr ""
+msgstr "Sincronizează starea de vizionat din Trakt în biblioteca Kodi"
 
 msgctxt "#30367"
 msgid "Sync back Kodi watched states into Trakt"
-msgstr ""
+msgstr "Sincronizează înapoi starea de vizionat din Kodi în Trakt"
 
 msgctxt "#30369"
 msgid "Disable Upload"
-msgstr ""
+msgstr "Dezactivează încărcarea"
 
 msgctxt "#30370"
 msgid "Auto-assign network IP"
-msgstr ""
+msgstr "Atribuie automat IP-ul de rețea"
 
 msgctxt "#30371"
 msgid "Auto-assign network ports"
-msgstr ""
+msgstr "Atribuie automat porturile de rețea"
 
 msgctxt "#30373"
 msgid "Languages"
-msgstr ""
+msgstr "Limbi"
 
 msgctxt "#30374"
 msgid "Countries"
-msgstr ""
+msgstr "Țări"
 
 msgctxt "#30375"
 msgid "By size"
-msgstr ""
+msgstr "După dimensiune"
 
 msgctxt "#30376"
 msgid "Choose memory size automatically"
-msgstr ""
+msgstr "Alege automat dimensiunea memoriei"
 
 msgctxt "#30377"
 msgid "Size is chosen automatically, based on[CR]physical amount of memory"
-msgstr ""
+msgstr "Dimensiunea este aleasă automat, în funcție de[CR]cantitatea de memorie fizică"
 
 msgctxt "#30378"
 msgid "Allow memory usage"
-msgstr ""
+msgstr "Permite utilizarea memoriei"
 
 msgctxt "#30379"
 msgid "Minimum - 40MB, Default - 8%, Maximum - 15%"
-msgstr ""
+msgstr "Minim - 40 MB, Implicit - 8%, Maxim - 15%"
 
 msgctxt "#30380"
 msgid "Minimum"
-msgstr ""
+msgstr "Minim"
 
 msgctxt "#30381"
 msgid "Default"
-msgstr ""
+msgstr "Implicit"
 
 msgctxt "#30382"
 msgid "Maximum"
-msgstr ""
+msgstr "Maxim"
 
 msgctxt "#30383"
 msgid "Use Kodi language for subtitles search"
-msgstr ""
+msgstr "Folosește limba Kodi pentru căutarea subtitrărilor"
 
 msgctxt "#30384"
 msgid "Language code for subtitles (example: en, it, es)"
-msgstr ""
+msgstr "Codul de limbă pentru subtitrări (exemplu: en, it, es)"
 
 msgctxt "#30386"
 msgid "Disable background progress dialog on playback"
-msgstr ""
+msgstr "Dezactivează dialogul de progres din fundal în timpul redării"
 
 msgctxt "#30387"
 msgid "Caching"
-msgstr ""
+msgstr "Memorare în cache"
 
 msgctxt "#30388"
 msgid "Cache stream selection"
-msgstr ""
+msgstr "Memorează în cache selecția fluxului"
 
 msgctxt "#30389"
 msgid "Cache stream search results"
-msgstr ""
+msgstr "Memorează în cache rezultatele căutării fluxurilor"
 
 msgctxt "#30390"
 msgid "Cache search results duration, seconds"
-msgstr ""
+msgstr "Durata memorării în cache a rezultatelor căutării, secunde"
 
 msgctxt "#30393"
 msgid "Status"
-msgstr ""
+msgstr "Stare"
 
 msgctxt "#30394"
 msgid "Version"
-msgstr ""
+msgstr "Versiune"
 
 msgctxt "#30395"
 msgid "IP address"
-msgstr ""
+msgstr "Adresă IP"
 
 msgctxt "#30396"
 msgid "Port"
-msgstr ""
+msgstr "Port"
 
 msgctxt "#30397"
 msgid "Web UI"
-msgstr ""
+msgstr "Interfață web"
 
 msgctxt "#30398"
 msgid "Debug information (with kodi.log)"
-msgstr ""
+msgstr "Informații de depanare (cu kodi.log)"
 
 msgctxt "#30399"
 msgid "Addresses"
-msgstr ""
+msgstr "Adrese"
 
 msgctxt "#30400"
 msgid "Statistics"
-msgstr ""
+msgstr "Statistici"
 
 msgctxt "#30401"
 msgid "Torrent library status"
-msgstr ""
+msgstr "Starea bibliotecii de torrente"
 
 msgctxt "#30402"
 msgid "Size of cache.db"
-msgstr ""
+msgstr "Dimensiunea cache.db"
 
 msgctxt "#30403"
 msgid "Size of app.db"
-msgstr ""
+msgstr "Dimensiunea app.db"
 
 msgctxt "#30404"
 msgid "Assigned torrent files"
-msgstr ""
+msgstr "Fișiere torrent atribuite"
 
 msgctxt "#30405"
 msgid "Search queries"
-msgstr ""
+msgstr "Interogări de căutare"
 
 msgctxt "#30406"
 msgid "Remove from history"
-msgstr ""
+msgstr "Elimină din istoric"
 
 msgctxt "#30408"
 msgid "Addon Connectivity"
-msgstr ""
+msgstr "Conectivitatea suplimentului"
 
 msgctxt "#30409"
 msgid "Local port"
-msgstr ""
+msgstr "Port local"
 
 msgctxt "#30410"
 msgid "Remote port"
-msgstr ""
+msgstr "Port la distanță"
 
 msgctxt "#30411"
 msgid "Remote host"
-msgstr ""
+msgstr "Gazdă la distanță"
 
 msgctxt "#30412"
 msgid "Do not start binary (client mode)"
-msgstr ""
+msgstr "Nu porni fișierul binar (mod client)"
 
 msgctxt "#30413"
 msgid "Yes"
-msgstr ""
+msgstr "Da"
 
 msgctxt "#30414"
 msgid "No"
-msgstr ""
+msgstr "Nu"
 
 msgctxt "#30415"
 msgid "Next page (%s)"
-msgstr ""
+msgstr "Pagina următoare (%s)"
 
 msgctxt "#30416"
 msgid "Percents of playback to mark as watched"
-msgstr ""
+msgstr "Procentul de redare pentru a marca drept vizionat"
 
 msgctxt "#30417"
 msgid "Use name of production company as Studio for shows"
-msgstr ""
+msgstr "Folosește numele casei de producție ca Studio pentru seriale"
 
 msgctxt "#30418"
 msgid "Calculate number of unwatched episodes in Shows/Seasons"
-msgstr ""
+msgstr "Calculează numărul de episoade nevizionate în Seriale/Sezoane"
 
 msgctxt "#30421"
 msgid "Load torrents from torrents folder on startup"
-msgstr ""
+msgstr "Încarcă torrentele din dosarul de torrente la pornire"
 
 msgctxt "#30422"
 msgid "Popular lists"
-msgstr ""
+msgstr "Liste populare"
 
 msgctxt "#30423"
 msgid "Recommendations"
-msgstr ""
+msgstr "Recomandări"
 
 msgctxt "#30424"
 msgid "Progress"
-msgstr ""
+msgstr "Progres"
 
 msgctxt "#30425"
 msgid "Color of an air date"
-msgstr ""
+msgstr "Culoarea datei de difuzare"
 
 msgctxt "#30426"
 msgid "Color of a show name"
-msgstr ""
+msgstr "Culoarea numelui serialului"
 
 msgctxt "#30427"
 msgid "Color of an episode name"
-msgstr ""
+msgstr "Culoarea numelui episodului"
 
 msgctxt "#30428"
 msgid "Hide unaired episodes"
-msgstr ""
+msgstr "Ascunde episoadele needifuzate"
 
 msgctxt "#30429"
 msgid "Sort shows in the list"
-msgstr ""
+msgstr "Sortează serialele din listă"
 
 msgctxt "#30430"
 msgid "By latest watched"
-msgstr ""
+msgstr "După ultima vizionare"
 
 msgctxt "#30431"
 msgid "By show name"
-msgstr ""
+msgstr "După numele serialului"
 
 msgctxt "#30432"
 msgid "By air date (newer)"
-msgstr ""
+msgstr "După data de difuzare (mai nouă)"
 
 msgctxt "#30433"
 msgid "By air date (older)"
-msgstr ""
+msgstr "După data de difuzare (mai veche)"
 
 msgctxt "#30434"
 msgid "Date format"
-msgstr ""
+msgstr "Formatul datei"
 
 msgctxt "#30436"
 msgid "Userlist"
-msgstr ""
+msgstr "Listă de utilizator"
 
 msgctxt "#30438"
 msgid "Userlists"
-msgstr ""
+msgstr "Liste de utilizator"
 
 msgctxt "#30439"
 msgid "Debug information (without kodi.log)"
-msgstr ""
+msgstr "Informații de depanare (fără kodi.log)"
 
 msgctxt "#30440"
 msgid "Color of an unaired episode name"
-msgstr ""
+msgstr "Culoarea numelui unui episod needifuzat"
 
 msgctxt "#30441"
 msgid "Select userlist for movies"
-msgstr ""
+msgstr "Selectează lista de utilizator pentru filme"
 
 msgctxt "#30442"
 msgid "Userlist for movies"
-msgstr ""
+msgstr "Lista de utilizator pentru filme"
 
 msgctxt "#30443"
 msgid "Selected userlist for movies"
-msgstr ""
+msgstr "Lista de utilizator selectată pentru filme"
 
 msgctxt "#30444"
 msgid "Select userlist for shows"
-msgstr ""
+msgstr "Selectează lista de utilizator pentru seriale"
 
 msgctxt "#30445"
 msgid "Userlist for shows"
-msgstr ""
+msgstr "Lista de utilizator pentru seriale"
 
 msgctxt "#30446"
 msgid "Selected userlist for shows"
-msgstr ""
+msgstr "Lista de utilizator selectată pentru seriale"
 
 msgctxt "#30447"
 msgid "Add to Trakt, when movie is added to Kodi library"
-msgstr ""
+msgstr "Adaugă în Trakt când un film este adăugat în biblioteca Kodi"
 
 msgctxt "#30448"
 msgid "Add to Trakt, when show is added to Kodi library"
-msgstr ""
+msgstr "Adaugă în Trakt când un serial este adăugat în biblioteca Kodi"
 
 msgctxt "#30449"
 msgid "Remove from Trakt, when movie is deleted from Kodi library"
-msgstr ""
+msgstr "Elimină din Trakt când un film este șters din biblioteca Kodi"
 
 msgctxt "#30450"
 msgid "Remove from Trakt, when show is deleted from Kodi library"
-msgstr ""
+msgstr "Elimină din Trakt când un serial este șters din biblioteca Kodi"
 
 msgctxt "#30451"
 msgid "Torrent files path"
-msgstr ""
+msgstr "Calea fișierelor torrent"
 
 msgctxt "#30452"
 msgid "Reset all paths"
-msgstr ""
+msgstr "Resetează toate căile"
 
 msgctxt "#30453"
 msgid "Upload /debug/bundle (with kodi.log) to pastebin"
-msgstr ""
+msgstr "Încarcă /debug/bundle (cu kodi.log) pe pastebin"
 
 msgctxt "#30454"
 msgid "Paste url:[CR]%s"
-msgstr ""
+msgstr "URL-ul paste:[CR]%s"
 
 msgctxt "#30455"
 msgid "Logging"
-msgstr ""
+msgstr "Jurnalizare"
 
 msgctxt "#30456"
 msgid "Upload /debug/all (no kodi.log) to pastebin"
-msgstr ""
+msgstr "Încarcă /debug/all (fără kodi.log) pe pastebin"
 
 msgctxt "#30457"
 msgid "Uploading file to pastebin"
-msgstr ""
+msgstr "Se încarcă fișierul pe pastebin"
 
 msgctxt "#30458"
 msgid "Deleted movies"
-msgstr ""
+msgstr "Filme șterse"
 
 msgctxt "#30459"
 msgid "Deleted shows"
-msgstr ""
+msgstr "Seriale șterse"
 
 msgctxt "#30460"
 msgid "Database"
-msgstr ""
+msgstr "Bază de date"
 
 msgctxt "#30461"
 msgid "Show information"
-msgstr ""
+msgstr "Arată informațiile"
 
 msgctxt "#30462"
 msgid "Clear deleted movies"
-msgstr ""
+msgstr "Curăță filmele șterse"
 
 msgctxt "#30463"
 msgid "Clear deleted shows"
-msgstr ""
+msgstr "Curăță serialele șterse"
 
 msgctxt "#30464"
 msgid "Clear torrents history"
-msgstr ""
+msgstr "Șterge istoricul torrentelor"
 
 msgctxt "#30465"
 msgid "Clear search history"
-msgstr ""
+msgstr "Șterge istoricul căutărilor"
 
 msgctxt "#30466"
 msgid "Clear the database"
-msgstr ""
+msgstr "Șterge baza de date"
 
 msgctxt "#30467"
 msgid "Cache"
-msgstr ""
+msgstr "Cache"
 
 msgctxt "#30468"
 msgid "Clear TMDB cache"
-msgstr ""
+msgstr "Golește cache-ul TMDB"
 
 msgctxt "#30469"
 msgid "Clear Trakt cache"
-msgstr ""
+msgstr "Golește cache-ul Trakt"
 
 msgctxt "#30470"
 msgid "Clear the cache"
-msgstr ""
+msgstr "Golește cache-ul"
 
 msgctxt "#30471"
 msgid "Are you sure you want to do it?"
-msgstr ""
+msgstr "Sigur vrei să faci asta?"
 
 msgctxt "#30472"
 msgid "Database cleared"
-msgstr ""
+msgstr "Baza de date a fost golită"
 
 msgctxt "#30473"
 msgid "Select network interface"
-msgstr ""
+msgstr "Selectează interfața de rețea"
 
 msgctxt "#30474"
 msgid "Network interfaces"
-msgstr ""
+msgstr "Interfețe de rețea"
 
 msgctxt "#30475"
 msgid "Strm files language"
-msgstr ""
+msgstr "Limba fișierelor strm"
 
 msgctxt "#30476"
 msgid "Select language"
-msgstr ""
+msgstr "Selectează limba"
 
 msgctxt "#30477"
 msgid "Original language"
-msgstr ""
+msgstr "Limba originală"
 
 msgctxt "#30478"
 msgid "Searching"
-msgstr ""
+msgstr "Se caută"
 
 msgctxt "#30480"
 msgid "Run Kodi library update after add/delete"
-msgstr ""
+msgstr "Rulează actualizarea bibliotecii Kodi după adăugare/ștergere"
 
 msgctxt "#30481"
 msgid "Automatically"
-msgstr ""
+msgstr "Automat"
 
 msgctxt "#30482"
 msgid "Ask"
-msgstr ""
+msgstr "Întreabă"
 
 msgctxt "#30483"
 msgid "Create NFO files for Movie scrapers"
-msgstr ""
+msgstr "Creează fișiere NFO pentru scraperele de filme"
 
 msgctxt "#30484"
 msgid "Create NFO files for TV Show scrapers"
-msgstr ""
+msgstr "Creează fișiere NFO pentru scraperele de seriale"
 
 msgctxt "#30485"
 msgid "Concurrent connections limit per second"
-msgstr ""
+msgstr "Limita de conexiuni simultane pe secundă"
 
 msgctxt "#30486"
 msgid "Automatic concurrent connections limit per second"
-msgstr ""
+msgstr "Limită automată de conexiuni simultane pe secundă"
 
 msgctxt "#30487"
 msgid "Enable built-in HTTP proxy"
-msgstr ""
+msgstr "Activează proxy-ul HTTP încorporat"
 
 msgctxt "#30488"
 msgid "Internal Proxy Port"
-msgstr ""
+msgstr "Portul proxy-ului intern"
 
 msgctxt "#30489"
 msgid "Log Internal proxy requests"
-msgstr ""
+msgstr "Jurnalizează cererile proxy-ului intern"
 
 msgctxt "#30490"
 msgid "Internal HTTP proxy"
-msgstr ""
+msgstr "Proxy HTTP intern"
 
 msgctxt "#30491"
 msgid "Use Fanart.tv for posters/images"
-msgstr ""
+msgstr "Folosește Fanart.tv pentru afișe/imagini"
 
 msgctxt "#30492"
 msgid "Use Proxy for downloading .torrent files"
-msgstr ""
+msgstr "Folosește proxy pentru descărcarea fișierelor .torrent"
 
 msgctxt "#30493"
 msgid "Use Proxy for trackers"
-msgstr ""
+msgstr "Folosește proxy pentru trackere"
 
 msgctxt "#30494"
 msgid "Use Proxy for torrent downloading"
-msgstr ""
+msgstr "Folosește proxy pentru descărcarea torrentelor"
 
 msgctxt "#30495"
 msgid "Use built-in DNS resolver"
-msgstr ""
+msgstr "Folosește rezolvatorul DNS încorporat"
 
 msgctxt "#30496"
 msgid "Turn off if you use Tor addresses, or you want [CR]to use DNS settings from OS"
-msgstr ""
+msgstr "Dezactivează dacă folosești adrese Tor sau dacă vrei [CR]să folosești setările DNS ale sistemului de operare"
 
 msgctxt "#30497"
 msgid "Use Antizapret proxy (only for Russia)"
-msgstr ""
+msgstr "Folosește proxy-ul Antizapret (doar pentru Rusia)"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"
-msgstr ""
+msgstr "Resetează această cale la '/'"
 
 msgctxt "#30499"
 msgid "Automatically adjust memory size[CR]for heavy torrents, if possible"
-msgstr ""
+msgstr "Ajustează automat dimensiunea memoriei[CR]pentru torrente mari, dacă este posibil"
 
 msgctxt "#30500"
 msgid "Automatically adjust buffer size[CR]for heavy torrents"
-msgstr ""
+msgstr "Ajustează automat dimensiunea tamponului[CR]pentru torrente mari"
 
 msgctxt "#30502"
 msgid "Adjust buffer according to Kodi advancedsettings.xml, if set"
-msgstr ""
+msgstr "Ajustează tamponul conform advancedsettings.xml din Kodi, dacă este setat"
 
 msgctxt "#30503"
 msgid "Use libtorrent.config to override torrent engine settings"
-msgstr ""
+msgstr "Folosește libtorrent.config pentru a suprascrie setările motorului torrent"
 
 msgctxt "#30504"
 msgid "Located at USERDATA/plugin.video.elementum/libtorrent.config file[CR]Settings apply automatically. Visit https://libtorrent.org for info."
-msgstr ""
+msgstr "Se află în fișierul USERDATA/plugin.video.elementum/libtorrent.config[CR]Setările se aplică automat. Vizitează https://libtorrent.org pentru informații."
 
 msgctxt "#30505"
 msgid "Add episode number to the title"
-msgstr ""
+msgstr "Adaugă numărul episodului la titlu"
 
 msgctxt "#30506"
 msgid "Enable libtorrent logging"
-msgstr ""
+msgstr "Activează jurnalizarea libtorrent"
 
 msgctxt "#30511"
 msgid "Libtorrent settings profile"
-msgstr ""
+msgstr "Profilul de setări libtorrent"
 
 msgctxt "#30512"
 msgid "Default"
-msgstr ""
+msgstr "Implicit"
 
 msgctxt "#30513"
 msgid "Minimal memory"
-msgstr ""
+msgstr "Memorie minimă"
 
 msgctxt "#30514"
 msgid "High speed"
-msgstr ""
+msgstr "Viteză mare"
 
 msgctxt "#30515"
 msgid "Load torrents from torrents folder paused"
-msgstr ""
+msgstr "Încarcă torrentele din dosarul de torrente în pauză"
 
 msgctxt "#30516"
 msgid "... resume N seconds earlier"
-msgstr ""
+msgstr "... reia cu N secunde mai devreme"
 
 msgctxt "#30517"
 msgid "In Kodi library"
-msgstr ""
+msgstr "În biblioteca Kodi"
 
 msgctxt "#30518"
 msgid "Use libtorrent deadlines"
-msgstr ""
+msgstr "Folosește termenele limită libtorrent"
 
 msgctxt "#30519"
 msgid "Use libtorrent pause/resume trick for added torrents"
-msgstr ""
+msgstr "Folosește trucul de pauză/reluare libtorrent pentru torrentele adăugate"
 
 msgctxt "#30520"
 msgid "Add item to start menu"
-msgstr ""
+msgstr "Adaugă elementul în meniul de start"
 
 msgctxt "#30521"
 msgid "Delete item from start menu"
-msgstr ""
+msgstr "Șterge elementul din meniul de start"
 
 msgctxt "#30522"
 msgid "Minimum file size"
-msgstr ""
+msgstr "Dimensiunea minimă a fișierului"
 
 msgctxt "#30523"
 msgid "Minimum file size for Movies, MB"
-msgstr ""
+msgstr "Dimensiunea minimă a fișierului pentru filme, MB"
 
 msgctxt "#30524"
 msgid "Minimum file size for Shows, MB per minute"
-msgstr ""
+msgstr "Dimensiunea minimă a fișierului pentru seriale, MB pe minut"
 
 msgctxt "#30525"
 msgid "Automatically start downloading next episode"
-msgstr ""
+msgstr "Începe automat descărcarea episodului următor"
 
 msgctxt "#30527"
 msgid "Donate"
-msgstr ""
+msgstr "Donează"
 
 msgctxt "#30528"
 msgid "Automatically load first found subtitles"
-msgstr ""
+msgstr "Încarcă automat primele subtitrări găsite"
 
 msgctxt "#30529"
 msgid "Number of subtitles to load automatically"
-msgstr ""
+msgstr "Numărul de subtitrări încărcate automat"
 
 msgctxt "#30530"
 msgid "Delete autoloaded subtitles on player stop"
-msgstr ""
+msgstr "Șterge subtitrările încărcate automat la oprirea playerului"
 
 msgctxt "#30531"
 msgid "Download all files from torrent"
-msgstr ""
+msgstr "Descarcă toate fișierele din torrent"
 
 msgctxt "#30532"
 msgid "Stop Downloading all files"
-msgstr ""
+msgstr "Oprește descărcarea tuturor fișierelor"
 
 msgctxt "#30535"
 msgid "Continue playback from [B]%s[/B]?"
-msgstr ""
+msgstr "Continui redarea de la [B]%s[/B]?"
 
 msgctxt "#30536"
 msgid "Skip IPv6 addresses resolving"
-msgstr ""
+msgstr "Omite rezolvarea adreselor IPv6"
 
 msgctxt "#30537"
 msgid "Torrents history"
-msgstr ""
+msgstr "Istoricul torrentelor"
 
 msgctxt "#30538"
 msgid "Use torrents history?"
-msgstr ""
+msgstr "Folosești istoricul torrentelor?"
 
 msgctxt "#30539"
 msgid "Store N torrents in history"
-msgstr ""
+msgstr "Păstrează N torrente în istoric"
 
 msgctxt "#30540"
 msgid "Subtitles"
-msgstr ""
+msgstr "Subtitrări"
 
 msgctxt "#30541"
 msgid "Automatic Subtitles Search"
-msgstr ""
+msgstr "Căutare automată a subtitrărilor"
 
 msgctxt "#30542"
 msgid "Disable if subtitles are available in player"
-msgstr ""
+msgstr "Dezactivează dacă subtitrările sunt disponibile în player"
 
 msgctxt "#30543"
 msgid "Subtitles included in torrent"
-msgstr ""
+msgstr "Subtitrări incluse în torrent"
 
 msgctxt "#30544"
 msgid "Automatic Scrape"
-msgstr ""
+msgstr "Colectare automată"
 
 msgctxt "#30545"
 msgid "Automatic scraping allows to scrape connected providers[CR]to find new movies, if there are results,"
-msgstr ""
+msgstr "Colectarea automată permite căutarea la furnizorii conectați[CR]pentru filme noi. Dacă există rezultate"
 
 msgctxt "#30546"
 msgid "Strategy"
-msgstr ""
+msgstr "Strategie"
 
 msgctxt "#30547"
 msgid "Find in each provider"
-msgstr ""
+msgstr "Caută la fiecare furnizor"
 
 msgctxt "#30548"
 msgid "Find in overall"
-msgstr ""
+msgstr "Caută în ansamblu"
 
 msgctxt "#30549"
 msgid "Search is successful when found N results"
-msgstr ""
+msgstr "Căutarea reușește când sunt găsite N rezultate"
 
 msgctxt "#30550"
 msgid "What to search"
-msgstr ""
+msgstr "Ce se caută"
 
 msgctxt "#30551"
 msgid "How to search"
-msgstr ""
+msgstr "Cum se caută"
 
 msgctxt "#30552"
 msgid "Search each N hours"
-msgstr ""
+msgstr "Caută la fiecare N ore"
 
 msgctxt "#30553"
 msgid "Find 4K resolution"
-msgstr ""
+msgstr "Găsește rezoluția 4K"
 
 msgctxt "#30554"
 msgid "Find 1080p resolution"
-msgstr ""
+msgstr "Găsește rezoluția 1080p"
 
 msgctxt "#30555"
 msgid "and movie passes checks for number of results[CR]movie can be added to the library."
-msgstr ""
+msgstr "și filmul trece de verificarea numărului de rezultate,[CR]poate fi adăugat în bibliotecă."
 
 msgctxt "#30556"
 msgid "Add to the library"
-msgstr ""
+msgstr "Adaugă în bibliotecă"
 
 msgctxt "#30557"
 msgid "Number of popular movies to search"
-msgstr ""
+msgstr "Numărul de filme populare de căutat"
 
 msgctxt "#30558"
 msgid "Latest available movies"
-msgstr ""
+msgstr "Cele mai recente filme disponibile"
 
 msgctxt "#30559"
 msgid "Skip searching for installed providers"
-msgstr ""
+msgstr "Omite căutarea furnizorilor instalați"
 
 msgctxt "#30560"
 msgid "Files: %s"
-msgstr ""
+msgstr "Fișiere: %s"
 
 msgctxt "#30561"
 msgid "Interval between requests, seconds"
-msgstr ""
+msgstr "Intervalul dintre cereri, secunde"
 
 msgctxt "#30562"
 msgid "Open directory with Kodi file browser"
-msgstr ""
+msgstr "Deschide dosarul cu exploratorul de fișiere Kodi"
 
 msgctxt "#30563"
 msgid "Synchronize frequency of Trakt, minutes"
-msgstr ""
+msgstr "Frecvența sincronizării cu Trakt, minute"
 
 msgctxt "#30564"
 msgid "Sync hidden items"
-msgstr ""
+msgstr "Sincronizează elementele ascunse"
 
 msgctxt "#30565"
 msgid "Sync playback progress into Kodi library"
-msgstr ""
+msgstr "Sincronizează progresul redării în biblioteca Kodi"
 
 msgctxt "#30566"
 msgid "Lists"
-msgstr ""
+msgstr "Liste"
 
 msgctxt "#30567"
 msgid "Show \"All seasons\" in shows"
-msgstr ""
+msgstr "Arată \"Toate sezoanele\" în seriale"
 
 msgctxt "#30568"
 msgid "Seasons order"
-msgstr ""
+msgstr "Ordinea sezoanelor"
 
 msgctxt "#30569"
 msgid "Ascending"
-msgstr ""
+msgstr "Crescător"
 
 msgctxt "#30570"
 msgid "Descending"
-msgstr ""
+msgstr "Descrescător"
 
 msgctxt "#30571"
 msgid "* All seasons"
-msgstr ""
+msgstr "* Toate sezoanele"
 
 msgctxt "#30572"
 msgid "Log server's response body"
-msgstr ""
+msgstr "Jurnalizează corpul răspunsului serverului"
 
 msgctxt "#30573"
 msgid "Select file to play"
-msgstr ""
+msgstr "Selectează fișierul de redat"
 
 msgctxt "#30574"
 msgid "Automatically answer Yes after timeout"
-msgstr ""
+msgstr "Răspunde automat Da după expirare"
 
 msgctxt "#30575"
 msgid "Timeout, seconds"
-msgstr ""
+msgstr "Timp de expirare, secunde"
 
 msgctxt "#30576"
 msgid "Trakt authentication needs to be updated!"
-msgstr ""
+msgstr "Autentificarea Trakt trebuie actualizată!"
 
 msgctxt "#30577"
 msgid "End of file Buffer size, MB"
-msgstr ""
+msgstr "Dimensiunea tamponului la sfârșitul fișierului, MB"
 
 msgctxt "#30578"
 msgid "Beginning of file Buffer size, MB"
-msgstr ""
+msgstr "Dimensiunea tamponului la începutul fișierului, MB"
 
 msgctxt "#30579"
 msgid "Settings"
-msgstr ""
+msgstr "Setări"
 
 msgctxt "#30580"
 msgid "Custom Trakt API Client ID"
-msgstr ""
+msgstr "Client ID personalizat pentru API-ul Trakt"
 
 msgctxt "#30581"
 msgid "Custom Trakt API Client Secret"
-msgstr ""
+msgstr "Client Secret personalizat pentru API-ul Trakt"
 
 msgctxt "#30582"
 msgid "Settings for %s provider"
-msgstr ""
+msgstr "Setări pentru furnizorul %s"
 
 msgctxt "#30583"
 msgid "Resolving magnet link"
-msgstr ""
+msgstr "Se rezolvă linkul magnet"
 
 msgctxt "#30585"
 msgid "Enable library integration with Kodi"
-msgstr ""
+msgstr "Activează integrarea cu biblioteca Kodi"
 
 msgctxt "#30586"
 msgid "If disabled - Elementum will not get/insert items to Kodi library [CR]and skip watched management with Kodi."
-msgstr ""
+msgstr "Dacă este dezactivat, Elementum nu va prelua și nu va introduce elemente în biblioteca Kodi [CR]și va omite gestionarea stării de vizionat cu Kodi."
 
 msgctxt "#30587"
 msgid "Show welcome message on start"
-msgstr ""
+msgstr "Arată mesajul de bun venit la pornire"
 
 msgctxt "#30588"
 msgid "Pre-Play Buffering"
-msgstr ""
+msgstr "Memorare în tampon înainte de redare"
 
 msgctxt "#30589"
 msgid "Speed limiting"
-msgstr ""
+msgstr "Limitarea vitezei"
 
 msgctxt "#30590"
 msgid "Torrents autoload on addon startup"
-msgstr ""
+msgstr "Încărcarea automată a torrentelor la pornirea suplimentului"
 
 msgctxt "#30591"
 msgid "Limits for connections"
-msgstr ""
+msgstr "Limite pentru conexiuni"
 
 msgctxt "#30592"
 msgid "Seeding"
-msgstr ""
+msgstr "Partajare"
 
 msgctxt "#30593"
 msgid "Seed forever"
-msgstr ""
+msgstr "Partajează la nesfârșit"
 
 msgctxt "#30594"
 msgid "Network"
-msgstr ""
+msgstr "Rețea"
 
 msgctxt "#30595"
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Diverse"
 
 msgctxt "#30597"
 msgid "Cache size, MB"
-msgstr ""
+msgstr "Dimensiunea cache-ului, MB"
 
 msgctxt "#30598"
 msgid "Enable caching if using File storage and have speed problems.[CR]Will use more memory, but can improve the speed."
-msgstr ""
+msgstr "Activează memorarea în cache dacă folosești stocarea în fișiere și ai probleme de viteză.[CR]Va folosi mai multă memorie, dar poate îmbunătăți viteza."
 
 msgctxt "#30599"
 msgid "Enable Kodi library synchronization"
-msgstr ""
+msgstr "Activează sincronizarea cu biblioteca Kodi"
 
 msgctxt "#30600"
 msgid "Enable Trakt synchronization"
-msgstr ""
+msgstr "Activează sincronizarea cu Trakt"
 
 msgctxt "#30601"
 msgid "Enable synchronization while playback"
-msgstr ""
+msgstr "Activează sincronizarea în timpul redării"
 
 msgctxt "#30602"
 msgid "Retry requests to addon after timeout, seconds"
-msgstr ""
+msgstr "Reîncearcă cererile către supliment după expirare, secunde"
 
 msgctxt "#30603"
 msgid "Addon Startup"
-msgstr ""
+msgstr "Pornirea suplimentului"
 
 msgctxt "#30604"
 msgid "Clean all history"
-msgstr ""
+msgstr "Curăță tot istoricul"
 
 msgctxt "#30605"
 msgid "Cache downloaded torrent files after search"
-msgstr ""
+msgstr "Memorează în cache fișierele torrent descărcate după căutare"
 
 msgctxt "#30606"
 msgid "Show watched state for torrent's files"
-msgstr ""
+msgstr "Arată starea de vizionat pentru fișierele torrentului"
 
 msgctxt "#30607"
 msgid "Use earliest release date as basic for searching"
-msgstr ""
+msgstr "Folosește cea mai veche dată de lansare ca bază pentru căutare"
 
 msgctxt "#30608"
 msgid "Match found in your active torrents, play it?[CR]%s"
-msgstr ""
+msgstr "S-a găsit o potrivire în torrentele tale active, o redai?[CR]%s"
 
 msgctxt "#30609"
 msgid "Automatically start next episode if available"
-msgstr ""
+msgstr "Pornește automat episodul următor dacă este disponibil"
 
 msgctxt "#30610"
 msgid "Magnet resolve timeout, seconds"
-msgstr ""
+msgstr "Timp de expirare pentru rezolvarea magnet, secunde"
 
 msgctxt "#30611"
 msgid "Application platform type"
-msgstr ""
+msgstr "Tipul de platformă al aplicației"
 
 msgctxt "#30612"
 msgid "Select file to download"
-msgstr ""
+msgstr "Selectează fișierul de descărcat"
 
 msgctxt "#30613"
 msgid "... for movie"
-msgstr ""
+msgstr "... pentru film"
 
 msgctxt "#30614"
 msgid "... for tv show"
-msgstr ""
+msgstr "... pentru serial"
 
 msgctxt "#30615"
 msgid "... for search"
-msgstr ""
+msgstr "... pentru căutare"
 
 msgctxt "#30616"
 msgid "Elementum | Trakt Account"
-msgstr ""
+msgstr "Elementum | Cont Trakt"
 
 msgctxt "#30617"
 msgid "Your account is locked for API on Trakt.tv[CR]Please, contact Trakt Support at https://support.trakt.tv ."
-msgstr ""
+msgstr "Contul tău este blocat pentru API pe Trakt.tv[CR]Te rugăm să contactezi asistența Trakt la https://support.trakt.tv ."
 
 msgctxt "#30618"
 msgid "%s is downloaded"
-msgstr ""
+msgstr "%s a fost descărcat"
 
 msgctxt "#30619"
 msgid "Return to [B]%s[/B]"
-msgstr ""
+msgstr "Înapoi la [B]%s[/B]"
 
 msgctxt "#30620"
 msgid "Restart Elementum addon"
-msgstr ""
+msgstr "Repornește suplimentul Elementum"
 
 msgctxt "#30621"
 msgid "Queued"
-msgstr ""
+msgstr "În așteptare"
 
 msgctxt "#30622"
 msgid "Checking"
-msgstr ""
+msgstr "Se verifică"
 
 msgctxt "#30623"
 msgid "Finding"
-msgstr ""
+msgstr "Se caută"
 
 msgctxt "#30624"
 msgid "Downloading"
-msgstr ""
+msgstr "Se descarcă"
 
 msgctxt "#30625"
 msgid "Finished"
-msgstr ""
+msgstr "Finalizat"
 
 msgctxt "#30626"
 msgid "Seeding"
-msgstr ""
+msgstr "Se partajează"
 
 msgctxt "#30627"
 msgid "Allocating"
-msgstr ""
+msgstr "Se alocă"
 
 msgctxt "#30628"
 msgid "Stalled"
-msgstr ""
+msgstr "Blocat"
 
 msgctxt "#30629"
 msgid "Paused"
-msgstr ""
+msgstr "În pauză"
 
 msgctxt "#30630"
 msgid "Buffering"
-msgstr ""
+msgstr "Se memorează în tampon"
 
 msgctxt "#30631"
 msgid "Playing"
-msgstr ""
+msgstr "Se redă"
 
 msgctxt "#30632"
 msgid "Yes (%s seconds)"
-msgstr ""
+msgstr "Da (%s secunde)"
 
 msgctxt "#30633"
 msgid "No (%s seconds)"
-msgstr ""
+msgstr "Nu (%s secunde)"
 
 msgctxt "#30634"
 msgid "Log level"
-msgstr ""
+msgstr "Nivelul de jurnalizare"
 
 msgctxt "#30635"
 msgid "None"
-msgstr ""
+msgstr "Niciunul"
 
 msgctxt "#30636"
 msgid "Error"
-msgstr ""
+msgstr "Eroare"
 
 msgctxt "#30637"
 msgid "Info"
-msgstr ""
+msgstr "Info"
 
 msgctxt "#30638"
 msgid "Debug"
-msgstr ""
+msgstr "Depanare"
 
 msgctxt "#30639"
 msgid "Show Specials in season listings"
-msgstr ""
+msgstr "Arată episoadele speciale în listele de sezoane"
 
 msgctxt "#30640"
 msgid "Bitrate"
-msgstr ""
+msgstr "Rata de biți"
 
 msgctxt "#30641"
 msgid "Playback"
-msgstr ""
+msgstr "Redare"
 
 msgctxt "#30642"
 msgid "Force Resume options"
-msgstr ""
+msgstr "Forțează opțiunile de reluare"
 
 msgctxt "#30643"
 msgid "by Kodi"
-msgstr ""
+msgstr "de către Kodi"
 
 msgctxt "#30644"
 msgid "by Elementum - Ask"
-msgstr ""
+msgstr "de către Elementum - Întreabă"
 
 msgctxt "#30645"
 msgid "by Elementum - Force"
-msgstr ""
+msgstr "de către Elementum - Forțează"
 
 msgctxt "#30646"
 msgid "Authorize Elementum on Trakt.tv"
-msgstr ""
+msgstr "Autorizează Elementum pe Trakt.tv"
 
 msgctxt "#30647"
 msgid "Cancel Authorization for Elementum on Trakt.tv"
-msgstr ""
+msgstr "Anulează autorizarea Elementum pe Trakt.tv"
 
 msgctxt "#30648"
 msgid "Authorization"
-msgstr ""
+msgstr "Autorizare"
 
 msgctxt "#30649"
 msgid "To authorize addon for Trakt.tv you need to:[CR]1. Open [B]%s[/B][CR]2. Enter code: [B]%s[/B][CR]3. Wait for notification from Elementum."
-msgstr ""
+msgstr "Pentru a autoriza suplimentul pentru Trakt.tv trebuie să:[CR]1. Deschizi [B]%s[/B][CR]2. Introduci codul: [B]%s[/B][CR]3. Aștepți notificarea de la Elementum."
 
 msgctxt "#30650"
 msgid "Successfully authorized for Trakt.tv"
-msgstr ""
+msgstr "Autorizare pe Trakt.tv reușită"
 
 msgctxt "#30651"
 msgid "Could not authorize for Trakt.tv"
-msgstr ""
+msgstr "Autorizarea pe Trakt.tv a eșuat"
 
 msgctxt "#30652"
 msgid "Successfully deauthorized for Trakt.tv"
-msgstr ""
+msgstr "Autorizarea pe Trakt.tv a fost anulată cu succes"
 
 msgctxt "#30653"
 msgid "Which files to download"
-msgstr ""
+msgstr "Ce fișiere se descarcă"
 
 msgctxt "#30654"
 msgid "Only playback file"
-msgstr ""
+msgstr "Doar fișierul de redat"
 
 msgctxt "#30655"
 msgid "Season files"
-msgstr ""
+msgstr "Fișierele sezonului"
 
 msgctxt "#30656"
 msgid "All files"
-msgstr ""
+msgstr "Toate fișierele"
 
 msgctxt "#30657"
 msgid "Disable LSD"
-msgstr ""
+msgstr "Dezactivează LSD"
 
 msgctxt "#30658"
 msgid "Add extra trackers"
-msgstr ""
+msgstr "Adaugă trackere suplimentare"
 
 msgctxt "#30659"
 msgid "All known trackers"
-msgstr ""
+msgstr "Toate trackerele cunoscute"
 
 msgctxt "#30660"
 msgid "Best trackers"
-msgstr ""
+msgstr "Cele mai bune trackere"
 
 msgctxt "#30661"
 msgid "Minimum set"
-msgstr ""
+msgstr "Set minim"
 
 msgctxt "#30662"
 msgid "Remove original trackers from torrent"
-msgstr ""
+msgstr "Elimină trackerele originale din torrent"
 
 msgctxt "#30663"
 msgid "Show episodes on release day (w/o delay)"
-msgstr ""
+msgstr "Arată episoadele în ziua lansării (fără întârziere)"
 
 msgctxt "#30664"
 msgid "Modify trackers in torrent"
-msgstr ""
+msgstr "Modifică trackerele din torrent"
 
 msgctxt "#30665"
 msgid "At the time of adding"
-msgstr ""
+msgstr "În momentul adăugării"
 
 msgctxt "#30666"
 msgid "Every time"
-msgstr ""
+msgstr "De fiecare dată"
 
 msgctxt "#30667"
 msgid "Mark as watched in Trakt"
-msgstr ""
+msgstr "Marchează ca vizionat în Trakt"
 
 msgctxt "#30668"
 msgid "Mark as unwatched in Trakt"
-msgstr ""
+msgstr "Marchează ca nevizionat în Trakt"
 
 msgctxt "#30669"
 msgid "Delay addon startup, seconds"
-msgstr ""
+msgstr "Întârzie pornirea suplimentului, secunde"
 
 msgctxt "#30670"
 msgid "Downloading required binary file for '%s'"
-msgstr ""
+msgstr "Se descarcă fișierul binar necesar pentru '%s'"
 
 msgctxt "#30671"
 msgid "List of Opennic DNS IPs"
-msgstr ""
+msgstr "Lista adreselor IP ale DNS-urilor OpenNIC"
 
 msgctxt "#30672"
 msgid "Compact database"
-msgstr ""
+msgstr "Compactează baza de date"
 
 msgctxt "#30673"
 msgid "Compact cache database"
-msgstr ""
+msgstr "Compactează baza de date a cache-ului"
 
 msgctxt "#30674"
 msgid "Database was compacted"
-msgstr ""
+msgstr "Baza de date a fost compactată"
 
 msgctxt "#30675"
 msgid "Remote host login"
-msgstr ""
+msgstr "Utilizatorul gazdei la distanță"
 
 msgctxt "#30676"
 msgid "Remote host password"
-msgstr ""
+msgstr "Parola gazdei la distanță"
 
 msgctxt "#30677"
 msgid "Force start as a library"
-msgstr ""
+msgstr "Forțează pornirea ca bibliotecă"
 
 msgctxt "#30678"
 msgid "Remove from Kodi library, when movie is deleted from Trakt"
-msgstr ""
+msgstr "Elimină din biblioteca Kodi când filmul este șters din Trakt"
 
 msgctxt "#30679"
 msgid "Remove from Kodi library, when show is deleted from Trakt"
-msgstr ""
+msgstr "Elimină din biblioteca Kodi când serialul este șters din Trakt"
 
 msgctxt "#30680"
 msgid "Remove Elementum duplicates from library"
-msgstr ""
+msgstr "Elimină duplicatele Elementum din bibliotecă"
 
 msgctxt "#30681"
 msgid "[B]Found duplicates in Kodi library:[/B][CR]Movies: [B]%s[/B], Shows: [B]%s[/B], Episodes: [B]%s[/B][CR]Proceed?"
-msgstr ""
+msgstr "[B]S-au găsit duplicate în biblioteca Kodi:[/B][CR]Filme: [B]%s[/B], Seriale: [B]%s[/B], Episoade: [B]%s[/B][CR]Continui?"
 
 msgctxt "#30682"
 msgid "No duplicates were found in Kodi library"
-msgstr ""
+msgstr "Nu s-au găsit duplicate în biblioteca Kodi"
 
 msgctxt "#30683"
 msgid "Starting library duplicates removal"
-msgstr ""
+msgstr "Începe eliminarea duplicatelor din bibliotecă"
 
 msgctxt "#30684"
 msgid "Removed Movies: %s, Shows: %s, Episodes: %s"
-msgstr ""
+msgstr "Eliminate - Filme: %s, Seriale: %s, Episoade: %s"
 
 msgctxt "#30685"
 msgid "Remove movies from Elementum database"
-msgstr ""
+msgstr "Elimină filmele din baza de date Elementum"
 
 msgctxt "#30686"
 msgid "Remove shows from Elementum database"
-msgstr ""
+msgstr "Elimină serialele din baza de date Elementum"
 
 msgctxt "#30687"
 msgid "In Elementum library"
-msgstr ""
+msgstr "În biblioteca Elementum"
 
 msgctxt "#30688"
 msgid "Skip searching for installed Elementum repository"
-msgstr ""
+msgstr "Omite căutarea depozitului Elementum instalat"
 
 msgctxt "#30689"
 msgid "Internal DNS client"
-msgstr ""
+msgstr "Client DNS intern"
 
 msgctxt "#30691"
 msgid "Hide watched"
-msgstr ""
+msgstr "Ascunde vizionatele"
 
 msgctxt "#30692"
 msgid "TMDB images quality (affects Kodi performance)"
-msgstr ""
+msgstr "Calitatea imaginilor TMDB (afectează performanța Kodi)"
 
 msgctxt "#30693"
 msgid "Original"
-msgstr ""
+msgstr "Originală"
 
 msgctxt "#30694"
 msgid "High"
-msgstr ""
+msgstr "Înaltă"
 
 msgctxt "#30695"
 msgid "Medium"
-msgstr ""
+msgstr "Medie"
 
 msgctxt "#30696"
 msgid "Low"
-msgstr ""
+msgstr "Scăzută"
 
 msgctxt "#30697"
 msgid "Interface language"
-msgstr ""
+msgstr "Limba interfeței"
 
 msgctxt "#30698"
 msgid "Kodi language"
-msgstr ""
+msgstr "Limba Kodi"
 
 msgctxt "#30699"
 msgid "Use earliest release date for progress and calendars"
-msgstr ""
+msgstr "Folosește cea mai veche dată de lansare pentru progres și calendare"
 
 msgctxt "#30700"
 msgid "Interface fallback language"
-msgstr ""
+msgstr "Limba de rezervă a interfeței"
 
 msgctxt "#30701"
 msgid "English | en"
-msgstr ""
+msgstr "Engleză | en"
 
 msgctxt "#30702"
 msgid "Reached daily limit for subtitles downloads"
-msgstr ""
+msgstr "S-a atins limita zilnică de descărcări de subtitrări"
 
 msgctxt "#30703"
 msgid "Can be used by search providers or [CR]for debugging"
-msgstr ""
+msgstr "Poate fi folosit de furnizorii de căutare sau [CR]pentru depanare"
 
 msgctxt "#30704"
 msgid "TMDB API Key check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Verificarea cheii API TMDB a eșuat, serviciul TMDB nu poate fi folosit"
 
 msgctxt "#30705"
 msgid "TMDB API accessibility check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Verificarea accesibilității API-ului TMDB a eșuat, serviciul TMDB nu poate fi folosit"
 
 msgctxt "#30706"
 msgid "Transmission 4.05"
-msgstr ""
+msgstr "Transmission 4.05"
 
 msgctxt "#30707"
 msgid "qBittorrent 3.3.9"
-msgstr ""
+msgstr "qBittorrent 3.3.9"
 
 msgctxt "#30708"
 msgid "qBittorrent 4.6.4"
-msgstr ""
+msgstr "qBittorrent 4.6.4"
 
 msgctxt "#30709"
 msgid "Open [B]%s[/B]"
-msgstr ""
+msgstr "Deschide [B]%s[/B]"
 
 msgctxt "#30710"
 msgid "BitTorrent ports"
-msgstr ""
+msgstr "Porturi BitTorrent"
 
 msgctxt "#30711"
 msgid "Delete torrent '%s'?"
-msgstr ""
+msgstr "Ștergi torrentul '%s'?"
 
 msgctxt "#30712"
 msgid "Force to always use proxy, can break download in some cases"
-msgstr ""
+msgstr "Forțează folosirea permanentă a proxy-ului, în unele cazuri poate întrerupe descărcarea"
 
 msgctxt "#30713"
 msgid "Disable NATPMP"
@@ -2287,20 +2287,20 @@ msgstr "Dezactivează NATPMP"
 
 msgctxt "#30714"
 msgid "Re-check torrent's data"
-msgstr ""
+msgstr "Verifică din nou datele torrentului"
 
 msgctxt "#30715"
 msgid "Antizapret PAC file URL"
-msgstr ""
+msgstr "URL-ul fișierului PAC Antizapret"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "Server DNS over HTTPS"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "Server DNS over HTTPS personalizat"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "Folosește serverele DNS OpenNIC"

--- a/resources/language/Russian/strings.po
+++ b/resources/language/Russian/strings.po
@@ -278,43 +278,43 @@ msgstr "По-умолчанию рекомендуемое"
 
 msgctxt "#30076"
 msgid "libtorrent (Rasterbar) 1.1.0"
-msgstr ""
+msgstr "libtorrent (Rasterbar) 1.1.0"
 
 msgctxt "#30077"
 msgid "BitTorrent 7.5.0"
-msgstr ""
+msgstr "BitTorrent 7.5.0"
 
 msgctxt "#30078"
 msgid "BitTorrent 7.9.9"
-msgstr ""
+msgstr "BitTorrent 7.9.9"
 
 msgctxt "#30079"
 msgid "µTorrent 3.5.5"
-msgstr ""
+msgstr "µTorrent 3.5.5"
 
 msgctxt "#30080"
 msgid "µTorrent 3.6.0"
-msgstr ""
+msgstr "µTorrent 3.6.0"
 
 msgctxt "#30081"
 msgid "µTorrent 2.2.1"
-msgstr ""
+msgstr "µTorrent 2.2.1"
 
 msgctxt "#30082"
 msgid "Transmission 2.92"
-msgstr ""
+msgstr "Transmission 2.92"
 
 msgctxt "#30083"
 msgid "Deluge 1.3.6"
-msgstr ""
+msgstr "Deluge 1.3.6"
 
 msgctxt "#30084"
 msgid "Deluge 2.1.1"
-msgstr ""
+msgstr "Deluge 2.1.1"
 
 msgctxt "#30085"
 msgid "Vuze 5.7.3.0"
-msgstr ""
+msgstr "Vuze 5.7.3.0"
 
 msgctxt "#30086"
 msgid "Enable tuned storage settings"
@@ -1976,15 +1976,15 @@ msgstr "Нет"
 
 msgctxt "#30636"
 msgid "Error"
-msgstr ""
+msgstr "Ошибка"
 
 msgctxt "#30637"
 msgid "Info"
-msgstr ""
+msgstr "Информация"
 
 msgctxt "#30638"
 msgid "Debug"
-msgstr ""
+msgstr "Отладка"
 
 msgctxt "#30639"
 msgid "Show Specials in season listings"
@@ -2252,15 +2252,15 @@ msgstr "Не удалось проверить доступность API TMDB, 
 
 msgctxt "#30706"
 msgid "Transmission 4.05"
-msgstr ""
+msgstr "Transmission 4.05"
 
 msgctxt "#30707"
 msgid "qBittorrent 3.3.9"
-msgstr ""
+msgstr "qBittorrent 3.3.9"
 
 msgctxt "#30708"
 msgid "qBittorrent 4.6.4"
-msgstr ""
+msgstr "qBittorrent 4.6.4"
 
 msgctxt "#30709"
 msgid "Open [B]%s[/B]"

--- a/resources/language/Slovak/strings.po
+++ b/resources/language/Slovak/strings.po
@@ -22,7 +22,7 @@ msgstr "Všeobecné"
 
 msgctxt "#30001"
 msgid "Download path"
-msgstr ""
+msgstr "Cesta na sťahovanie"
 
 msgctxt "#30004"
 msgid "Max upload rate, kB/s"
@@ -86,7 +86,7 @@ msgstr "Údržba"
 
 msgctxt "#30021"
 msgid "Elements per page"
-msgstr ""
+msgstr "Položiek na stránku"
 
 msgctxt "#30022"
 msgid "Enable overlay status"
@@ -98,7 +98,7 @@ msgstr "Automatický výber streamu"
 
 msgctxt "#30025"
 msgid "Limit rates after initial buffering only"
-msgstr ""
+msgstr "Obmedziť rýchlosti až po úvodnom načítaní do vyrovnávacej pamäte"
 
 msgctxt "#30026"
 msgid "Library path"
@@ -110,7 +110,7 @@ msgstr "Limit pripojenia"
 
 msgctxt "#30028"
 msgid "Download after play was stopped"
-msgstr ""
+msgstr "Pokračovať v sťahovaní po zastavení prehrávania"
 
 msgctxt "#30029"
 msgid "Session saving frequency, seconds"
@@ -118,231 +118,231 @@ msgstr "Frekvencia ukladania relácie (seconds)"
 
 msgctxt "#30030"
 msgid "Overlay status vertical offset"
-msgstr ""
+msgstr "Zvislé posunutie stavového prekrytia"
 
 msgctxt "#30031"
 msgid "Disable providers that failed health check"
-msgstr ""
+msgstr "Zakázať poskytovateľov, ktorí neprešli kontrolou stavu"
 
 msgctxt "#30032"
 msgid "Allowed failures before provider is disabled"
-msgstr ""
+msgstr "Povolený počet zlyhaní pred zakázaním poskytovateľa"
 
 msgctxt "#30033"
 msgid "Appearance"
-msgstr ""
+msgstr "Vzhľad"
 
 msgctxt "#30034"
 msgid "Default view for Movies"
-msgstr ""
+msgstr "Predvolené zobrazenie pre Filmy"
 
 msgctxt "#30035"
 msgid "Default view for TV Shows"
-msgstr ""
+msgstr "Predvolené zobrazenie pre Seriály"
 
 msgctxt "#30036"
 msgid "Default view for Seasons"
-msgstr ""
+msgstr "Predvolené zobrazenie pre Sezóny"
 
 msgctxt "#30037"
 msgid "Default view for Episodes"
-msgstr ""
+msgstr "Predvolené zobrazenie pre Epizódy"
 
 msgctxt "#30039"
 msgid "TheMovieDB"
-msgstr ""
+msgstr "TheMovieDB"
 
 msgctxt "#30040"
 msgid "API key"
-msgstr ""
+msgstr "Kľúč API"
 
 msgctxt "#30041"
 msgid "Stream sorting"
-msgstr ""
+msgstr "Zoraďovanie streamov"
 
 msgctxt "#30042"
 msgid "Sorting mode for Movies"
-msgstr ""
+msgstr "Režim zoraďovania pre Filmy"
 
 msgctxt "#30043"
 msgid "Sorting mode for TV Shows"
-msgstr ""
+msgstr "Režim zoraďovania pre Seriály"
 
 msgctxt "#30044"
 msgid "By seeders"
-msgstr ""
+msgstr "Podľa seederov"
 
 msgctxt "#30045"
 msgid "By resolution"
-msgstr ""
+msgstr "Podľa rozlíšenia"
 
 msgctxt "#30046"
 msgid "Balanced"
-msgstr ""
+msgstr "Vyvážené"
 
 msgctxt "#30047"
 msgid "Resolution preference for Movies"
-msgstr ""
+msgstr "Preferované rozlíšenie pre Filmy"
 
 msgctxt "#30048"
 msgid "Resolution preference for TV Shows"
-msgstr ""
+msgstr "Preferované rozlíšenie pre Seriály"
 
 msgctxt "#30049"
 msgid "Percentage of additional seeders required before choosing next resolution"
-msgstr ""
+msgstr "Percento ďalších seederov potrebných pred zvolením vyššieho rozlíšenia"
 
 msgctxt "#30050"
 msgid "Disable DHT"
-msgstr ""
+msgstr "Zakázať DHT"
 
 msgctxt "#30051"
 msgid "Share ratio limit, percentage"
-msgstr ""
+msgstr "Limit pomeru zdieľania, percentá"
 
 msgctxt "#30052"
 msgid "Seed time ratio limit, percentage"
-msgstr ""
+msgstr "Limit pomeru času zdieľania, percentá"
 
 msgctxt "#30053"
 msgid "Seed time limit, hours"
-msgstr ""
+msgstr "Limit času zdieľania, hodiny"
 
 msgctxt "#30054"
 msgid "Update library"
-msgstr ""
+msgstr "Aktualizovať knižnicu"
 
 msgctxt "#30055"
 msgid "Add Specials to library"
-msgstr ""
+msgstr "Pridať špeciálne epizódy do knižnice"
 
 msgctxt "#30056"
 msgid "Trakt"
-msgstr ""
+msgstr "Trakt"
 
 msgctxt "#30057"
 msgid "Username"
-msgstr ""
+msgstr "Používateľské meno"
 
 msgctxt "#30059"
 msgid "Library update delay on startup, seconds"
-msgstr ""
+msgstr "Oneskorenie aktualizácie knižnice pri štarte, sekundy"
 
 msgctxt "#30060"
 msgid "Library update frequency, hours"
-msgstr ""
+msgstr "Frekvencia aktualizácie knižnice, hodiny"
 
 msgctxt "#30063"
 msgid "Disable UPNP"
-msgstr ""
+msgstr "Zakázať UPNP"
 
 msgctxt "#30064"
 msgid "Encryption policy"
-msgstr ""
+msgstr "Politika šifrovania"
 
 msgctxt "#30065"
 msgid "Disabled"
-msgstr ""
+msgstr "Zakázané"
 
 msgctxt "#30066"
 msgid "Forced"
-msgstr ""
+msgstr "Vynútené"
 
 msgctxt "#30067"
 msgid "Proxy type"
-msgstr ""
+msgstr "Typ proxy"
 
 msgctxt "#30068"
 msgid "SOCKS4"
-msgstr ""
+msgstr "SOCKS4"
 
 msgctxt "#30069"
 msgid "SOCKS5"
-msgstr ""
+msgstr "SOCKS5"
 
 msgctxt "#30071"
 msgid "HTTP"
-msgstr ""
+msgstr "HTTP"
 
 msgctxt "#30073"
 msgid "i2p"
-msgstr ""
+msgstr "i2p"
 
 msgctxt "#30074"
 msgid "Spoof user agent (highly inadvisable)"
-msgstr ""
+msgstr "Falšovať user agent (dôrazne neodporúčané)"
 
 msgctxt "#30075"
 msgid "Default advisable (acceptable)"
-msgstr ""
+msgstr "Predvolené odporúčané (prijateľné)"
 
 msgctxt "#30076"
 msgid "libtorrent (Rasterbar) 1.1.0"
-msgstr ""
+msgstr "libtorrent (Rasterbar) 1.1.0"
 
 msgctxt "#30077"
 msgid "BitTorrent 7.5.0"
-msgstr ""
+msgstr "BitTorrent 7.5.0"
 
 msgctxt "#30078"
 msgid "BitTorrent 7.9.9"
-msgstr ""
+msgstr "BitTorrent 7.9.9"
 
 msgctxt "#30079"
 msgid "µTorrent 3.5.5"
-msgstr ""
+msgstr "µTorrent 3.5.5"
 
 msgctxt "#30080"
 msgid "µTorrent 3.6.0"
-msgstr ""
+msgstr "µTorrent 3.6.0"
 
 msgctxt "#30081"
 msgid "µTorrent 2.2.1"
-msgstr ""
+msgstr "µTorrent 2.2.1"
 
 msgctxt "#30082"
 msgid "Transmission 2.92"
-msgstr ""
+msgstr "Transmission 2.92"
 
 msgctxt "#30083"
 msgid "Deluge 1.3.6"
-msgstr ""
+msgstr "Deluge 1.3.6"
 
 msgctxt "#30084"
 msgid "Deluge 2.1.1"
-msgstr ""
+msgstr "Deluge 2.1.1"
 
 msgctxt "#30085"
 msgid "Vuze 5.7.3.0"
-msgstr ""
+msgstr "Vuze 5.7.3.0"
 
 msgctxt "#30086"
 msgid "Enable tuned storage settings"
-msgstr ""
+msgstr "Povoliť optimalizované nastavenia úložiska"
 
 msgctxt "#30088"
 msgid "Initial buffering timeout, seconds"
-msgstr ""
+msgstr "Časový limit úvodného načítania do vyrovnávacej pamäte, sekundy"
 
 msgctxt "#30090"
 msgid "Listen interfaces"
-msgstr ""
+msgstr "Načúvacie rozhrania"
 
 msgctxt "#30091"
 msgid "Outgoing interfaces"
-msgstr ""
+msgstr "Odchádzajúce rozhrania"
 
 msgctxt "#30092"
 msgid "Use fallback fanart if fanart wasn't found"
-msgstr ""
+msgstr "Použiť náhradný fanart, ak sa žiadny nenašiel"
 
 msgctxt "#30093"
 msgid "Disable notification sound"
-msgstr ""
+msgstr "Zakázať zvuk upozornení"
 
 msgctxt "#30094"
 msgid "Disable background progress dialog"
-msgstr ""
+msgstr "Zakázať dialóg priebehu na pozadí"
 
 # Interface
 msgctxt "#30100"
@@ -355,7 +355,7 @@ msgstr "Tento doplnok je možné spustiť len cez Elementum"
 
 msgctxt "#30103"
 msgid "Unable to find Elementum binary[CR]Required platform:"
-msgstr ""
+msgstr "Nepodarilo sa nájsť binárny súbor Elementum[CR]Požadovaná platforma:"
 
 msgctxt "#30104"
 msgid "Insert file or URL"
@@ -383,79 +383,79 @@ msgstr "Potvrdiť"
 
 msgctxt "#30110"
 msgid "Crashed too many times, aborting..."
-msgstr ""
+msgstr "Príliš veľa pádov, prerušuje sa..."
 
 msgctxt "#30111"
 msgid "Provider failed too many times, disabling..."
-msgstr ""
+msgstr "Poskytovateľ zlyhal príliš veľakrát, zakazuje sa..."
 
 msgctxt "#30112"
 msgid "Unable to disable provider"
-msgstr ""
+msgstr "Poskytovateľa sa nepodarilo zakázať"
 
 msgctxt "#30113"
 msgid "Download path not set, check your settings"
-msgstr ""
+msgstr "Cesta na sťahovanie nie je nastavená, skontroluj nastavenia"
 
 msgctxt "#30116"
 msgid "Looks like Elementum is still starting up, give it a few seconds..."
-msgstr ""
+msgstr "Zdá sa, že Elementum sa ešte spúšťa, daj mu pár sekúnd..."
 
 msgctxt "#30117"
 msgid "Resolving torrent files..."
-msgstr ""
+msgstr "Prekladajú sa súbory torrent..."
 
 msgctxt "#30118"
 msgid "Scraping trackers..."
-msgstr ""
+msgstr "Dopytujú sa trackery..."
 
 msgctxt "#30119"
 msgid "ID of selected userlist for movies"
-msgstr ""
+msgstr "ID vybraného používateľského zoznamu pre filmy"
 
 msgctxt "#30120"
 msgid "ID of selected userlist for shows"
-msgstr ""
+msgstr "ID vybraného používateľského zoznamu pre seriály"
 
 msgctxt "#30141"
 msgid "Please support Elementum development by visiting[CR]https://elementum.surge.sh/donate/ or https://elementumorg.github.io/donate/"
-msgstr ""
+msgstr "Podpor prosím vývoj Elementum na[CR]https://elementum.surge.sh/donate/ alebo https://elementumorg.github.io/donate/"
 
 msgctxt "#30142"
 msgid "Default view for menus in Movies"
-msgstr ""
+msgstr "Predvolené zobrazenie pre ponuky vo Filmoch"
 
 msgctxt "#30143"
 msgid "Default view for menus in TV Shows"
-msgstr ""
+msgstr "Predvolené zobrazenie pre ponuky v Seriáloch"
 
 msgctxt "#30144"
 msgid "Default view for movie genres"
-msgstr ""
+msgstr "Predvolené zobrazenie pre filmové žánre"
 
 msgctxt "#30145"
 msgid "Default view for TV show genres"
-msgstr ""
+msgstr "Predvolené zobrazenie pre seriálové žánre"
 
 msgctxt "#30146"
 msgid "Keep downloading '%s'?"
-msgstr ""
+msgstr "Pokračovať v sťahovaní '%s'?"
 
 msgctxt "#30147"
 msgid "Caches are still warming up, give it a minute or two..."
-msgstr ""
+msgstr "Vyrovnávacie pamäte sa ešte pripravujú, daj im minútu či dve..."
 
 msgctxt "#30148"
 msgid "Caches warmed up"
-msgstr ""
+msgstr "Vyrovnávacie pamäte sú pripravené"
 
 msgctxt "#30149"
 msgid "Trakt username not set, check your settings"
-msgstr ""
+msgstr "Používateľské meno Trakt nie je nastavené, skontroluj nastavenia"
 
 msgctxt "#30199"
 msgid "No available JSON-RPC connection to Kodi.[CR]Enable both Application control options in Service settings / Control and restart Kodi."
-msgstr ""
+msgstr "Nie je dostupné žiadne pripojenie JSON-RPC ku Kodi.[CR]Povoľ obe možnosti ovládania aplikácie v Nastaveniach služieb / Ovládanie a reštartuj Kodi."
 
 # Elementum daemon
 msgctxt "#30200"
@@ -584,1720 +584,1720 @@ msgstr "Aktuálne Epizódy"
 
 msgctxt "#30239"
 msgid "Providers"
-msgstr ""
+msgstr "Poskytovatelia"
 
 msgctxt "#30240"
 msgid "Enable"
-msgstr ""
+msgstr "Povoliť"
 
 msgctxt "#30241"
 msgid "Disable"
-msgstr ""
+msgstr "Zakázať"
 
 msgctxt "#30242"
 msgid "Check"
-msgstr ""
+msgstr "Skontrolovať"
 
 msgctxt "#30243"
 msgid "Provider failures"
-msgstr ""
+msgstr "Zlyhania poskytovateľa"
 
 msgctxt "#30244"
 msgid "Provider settings"
-msgstr ""
+msgstr "Nastavenia poskytovateľa"
 
 msgctxt "#30246"
 msgid "Trending"
-msgstr ""
+msgstr "Trendy"
 
 msgctxt "#30247"
 msgid "Most Played"
-msgstr ""
+msgstr "Najprehrávanejšie"
 
 msgctxt "#30248"
 msgid "Most Watched"
-msgstr ""
+msgstr "Najsledovanejšie"
 
 msgctxt "#30249"
 msgid "Most Collected"
-msgstr ""
+msgstr "Najzbieranejšie"
 
 msgctxt "#30250"
 msgid "Most Anticipated"
-msgstr ""
+msgstr "Najočakávanejšie"
 
 msgctxt "#30251"
 msgid "Box Office"
-msgstr ""
+msgstr "Tržby v kinách"
 
 msgctxt "#30252"
 msgid "Add to library"
-msgstr ""
+msgstr "Pridať do knižnice"
 
 msgctxt "#30253"
 msgid "Remove from library"
-msgstr ""
+msgstr "Odstrániť z knižnice"
 
 msgctxt "#30254"
 msgid "My Watchlist"
-msgstr ""
+msgstr "Môj zoznam sledovaných"
 
 msgctxt "#30255"
 msgid "Add to watchlist"
-msgstr ""
+msgstr "Pridať do zoznamu sledovaných"
 
 msgctxt "#30256"
 msgid "Remove from watchlist"
-msgstr ""
+msgstr "Odstrániť zo zoznamu sledovaných"
 
 msgctxt "#30257"
 msgid "My Collection"
-msgstr ""
+msgstr "Moja zbierka"
 
 msgctxt "#30258"
 msgid "Add to collection"
-msgstr ""
+msgstr "Pridať do zbierky"
 
 msgctxt "#30259"
 msgid "Remove from collection"
-msgstr ""
+msgstr "Odstrániť zo zbierky"
 
 msgctxt "#30260"
 msgid "A torrent was previously chosen, use it?[CR]%s"
-msgstr ""
+msgstr "Predtým bol zvolený torrent, použiť ho?[CR]%s"
 
 msgctxt "#30263"
 msgid "My Lists"
-msgstr ""
+msgstr "Moje zoznamy"
 
 msgctxt "#30268"
 msgid "Toggle watched"
-msgstr ""
+msgstr "Prepnúť stav pozretia"
 
 msgctxt "#30269"
 msgid "Delete downloaded files '%s'?"
-msgstr ""
+msgstr "Odstrániť stiahnuté súbory '%s'?"
 
 msgctxt "#30271"
 msgid "There is now an official multi-provider for Elementum called [COLOR FFFF6B00]Burst[/COLOR], would you like to install it now?"
-msgstr ""
+msgstr "Pre Elementum teraz existuje oficiálny multi-poskytovateľ s názvom [COLOR FFFF6B00]Burst[/COLOR], chceš ho teraz nainštalovať?"
 
 msgctxt "#30272"
 msgid "Installation successful, enjoy Elementum [COLOR FFFF6B00]Burst[/COLOR]!"
-msgstr ""
+msgstr "Inštalácia úspešná, uži si Elementum [COLOR FFFF6B00]Burst[/COLOR]!"
 
 msgctxt "#30273"
 msgid "Shoot... It looks like we couldn't install [COLOR FFFF6B00]Burst[/COLOR] automatically, head over to the Elementum Repository, then under the Program add-ons section to install it."
-msgstr ""
+msgstr "Ale nie... Zdá sa, že [COLOR FFFF6B00]Burst[/COLOR] sa nepodarilo nainštalovať automaticky. Prejdi do repozitára Elementum a nainštaluj ho v sekcii Programové doplnky."
 
 msgctxt "#30274"
 msgid "Enable all"
-msgstr ""
+msgstr "Povoliť všetko"
 
 msgctxt "#30275"
 msgid "Disable all"
-msgstr ""
+msgstr "Zakázať všetko"
 
 msgctxt "#30276"
 msgid "Delete torrent and files"
-msgstr ""
+msgstr "Odstrániť torrent a súbory"
 
 msgctxt "#30277"
 msgid "%s added to library, do you want to rescan it?[CR]You can later use Kodi's 'Update library' feature instead."
-msgstr ""
+msgstr "%s bolo pridané do knižnice, chceš ju znovu prehľadať?[CR]Neskôr môžeš namiesto toho použiť funkciu Kodi 'Aktualizovať knižnicu'."
 
 msgctxt "#30278"
 msgid "%s removed from library, do you want to clean it?[CR]You can later use Kodi's 'Clean library' feature instead."
-msgstr ""
+msgstr "%s bolo odstránené z knižnice, chceš ju vyčistiť?[CR]Neskôr môžeš namiesto toho použiť funkciu Kodi 'Vyčistiť knižnicu'."
 
 msgctxt "#30279"
 msgid "Video %s was previously removed from library.[CR]Force adding?"
-msgstr ""
+msgstr "Video %s bolo predtým odstránené z knižnice.[CR]Vynútiť pridanie?"
 
 msgctxt "#30282"
 msgid "Nothing left to remove from Elementum"
-msgstr ""
+msgstr "Z Elementum už nie je čo odstrániť"
 
 msgctxt "#30283"
 msgid "Merge to library"
-msgstr ""
+msgstr "Zlúčiť do knižnice"
 
 msgctxt "#30284"
 msgid "Show unaired seasons"
-msgstr ""
+msgstr "Zobraziť neodvysielané sezóny"
 
 msgctxt "#30285"
 msgid "Show unaired episodes"
-msgstr ""
+msgstr "Zobraziť neodvysielané epizódy"
 
 msgctxt "#30286"
 msgid "%s merged to library, do you want to rescan it?[CR]You can later use Kodi's 'Update library' feature instead."
-msgstr ""
+msgstr "%s bolo zlúčené do knižnice, chceš ju znovu prehľadať?[CR]Neskôr môžeš namiesto toho použiť funkciu Kodi 'Aktualizovať knižnicu'."
 
 msgctxt "#30287"
 msgid "%s already in library"
-msgstr ""
+msgstr "%s už je v knižnici"
 
 msgctxt "#30288"
 msgid "Library updated, do you want to rescan it?[CR]You can later use Kodi's 'Update library' feature instead."
-msgstr ""
+msgstr "Knižnica bola aktualizovaná, chceš ju znovu prehľadať?[CR]Neskôr môžeš namiesto toho použiť funkciu Kodi 'Aktualizovať knižnicu'."
 
 msgctxt "#30289"
 msgid "Genres"
-msgstr ""
+msgstr "Žánre"
 
 msgctxt "#30290"
 msgid "Calendars"
-msgstr ""
+msgstr "Kalendáre"
 
 msgctxt "#30291"
 msgid "My Movies"
-msgstr ""
+msgstr "Moje filmy"
 
 msgctxt "#30292"
 msgid "My Releases"
-msgstr ""
+msgstr "Moje vydania"
 
 msgctxt "#30293"
 msgid "All Movies"
-msgstr ""
+msgstr "Všetky filmy"
 
 msgctxt "#30294"
 msgid "All Releases"
-msgstr ""
+msgstr "Všetky vydania"
 
 msgctxt "#30295"
 msgid "My Shows"
-msgstr ""
+msgstr "Moje seriály"
 
 msgctxt "#30296"
 msgid "My New Shows"
-msgstr ""
+msgstr "Moje nové seriály"
 
 msgctxt "#30297"
 msgid "My Premieres"
-msgstr ""
+msgstr "Moje premiéry"
 
 msgctxt "#30298"
 msgid "All Shows"
-msgstr ""
+msgstr "Všetky seriály"
 
 msgctxt "#30299"
 msgid "All New Shows"
-msgstr ""
+msgstr "Všetky nové seriály"
 
 msgctxt "#30300"
 msgid "All Premieres"
-msgstr ""
+msgstr "Všetky premiéry"
 
 msgctxt "#30301"
 msgid "Move finished downloads to separate folders"
-msgstr ""
+msgstr "Presunúť dokončené sťahovania do samostatných priečinkov"
 
 msgctxt "#30302"
 msgid "Files will only be moved after seeding is finished (see[CR]- BitTorrent settings), and will wait if currently playing"
-msgstr ""
+msgstr "Súbory sa presunú až po dokončení zdieľania (pozri[CR]- nastavenia BitTorrent) a počkajú, ak sa práve prehrávajú"
 
 msgctxt "#30303"
 msgid "RAR archive detected. Download will need to be completed before playback can start and will require around twice the amount of space, continue?"
-msgstr ""
+msgstr "Zistený archív RAR. Sťahovanie sa musí dokončiť, kým sa začne prehrávanie, a bude vyžadovať približne dvojnásobok miesta. Pokračovať?"
 
 msgctxt "#30304"
 msgid "Error creating output pipe for 'unrar' command"
-msgstr ""
+msgstr "Chyba pri vytváraní výstupného kanála pre príkaz 'unrar'"
 
 msgctxt "#30305"
 msgid "Error starting 'unrar' command"
-msgstr ""
+msgstr "Chyba pri spúšťaní príkazu 'unrar'"
 
 msgctxt "#30306"
 msgid "Error waiting for 'unrar' command"
-msgstr ""
+msgstr "Chyba pri čakaní na príkaz 'unrar'"
 
 msgctxt "#30307"
 msgid "Error reading from destination folder"
-msgstr ""
+msgstr "Chyba pri čítaní z cieľového priečinka"
 
 msgctxt "#30308"
 msgid "Move completed"
-msgstr ""
+msgstr "Presun dokončený"
 
 msgctxt "#30309"
 msgid "Keep"
-msgstr ""
+msgstr "Ponechať"
 
 msgctxt "#30310"
 msgid "Ask to delete"
-msgstr ""
+msgstr "Opýtať sa na odstránenie"
 
 msgctxt "#30311"
 msgid "Delete"
-msgstr ""
+msgstr "Odstrániť"
 
 msgctxt "#30312"
 msgid "Keep files for not finished video"
-msgstr ""
+msgstr "Ponechať súbory nedokončených videí"
 
 msgctxt "#30313"
 msgid "Keep files for watched/downloaded video"
-msgstr ""
+msgstr "Ponechať súbory pozretých/stiahnutých videí"
 
 msgctxt "#30314"
 msgid "Settings were not initialized.[CR]Save addon settings, then restart Kodi."
-msgstr ""
+msgstr "Nastavenia neboli inicializované.[CR]Ulož nastavenia doplnku a reštartuj Kodi."
 
 msgctxt "#30315"
 msgid "Download storage type"
-msgstr ""
+msgstr "Typ úložiska pre sťahovanie"
 
 msgctxt "#30316"
 msgid "Use files"
-msgstr ""
+msgstr "Použiť súbory"
 
 msgctxt "#30317"
 msgid "Use memory"
-msgstr ""
+msgstr "Použiť pamäť"
 
 msgctxt "#30318"
 msgid "Memory size to use for each torrent, Mb"
-msgstr ""
+msgstr "Pamäť použitá pre každý torrent, MB"
 
 msgctxt "#30319"
 msgid "Continue"
-msgstr ""
+msgstr "Pokračovať"
 
 msgctxt "#30320"
 msgid "Ask to stop"
-msgstr ""
+msgstr "Opýtať sa na zastavenie"
 
 msgctxt "#30321"
 msgid "Stop"
-msgstr ""
+msgstr "Zastaviť"
 
 msgctxt "#30323"
 msgid "New search"
-msgstr ""
+msgstr "Nové hľadanie"
 
 msgctxt "#30324"
 msgid "Force stream auto-selection from settings"
-msgstr ""
+msgstr "Vynútiť automatický výber streamu z nastavení"
 
 msgctxt "#30325"
 msgid "Download"
-msgstr ""
+msgstr "Sťahovanie"
 
 msgctxt "#30326"
 msgid "Kodi library"
-msgstr ""
+msgstr "Knižnica Kodi"
 
 msgctxt "#30327"
 msgid "Storage"
-msgstr ""
+msgstr "Úložisko"
 
 msgctxt "#30328"
 msgid "Disable TCP"
-msgstr ""
+msgstr "Zakázať TCP"
 
 msgctxt "#30329"
 msgid "Disable UTP"
-msgstr ""
+msgstr "Zakázať UTP"
 
 msgctxt "#30330"
 msgid "Update Trakt"
-msgstr ""
+msgstr "Aktualizovať Trakt"
 
 msgctxt "#30332"
 msgid "Reloading configuration..."
-msgstr ""
+msgstr "Znovu sa načítava konfigurácia..."
 
 msgctxt "#30333"
 msgid "Try to find other episodes in the torrent"
-msgstr ""
+msgstr "Skúsiť nájsť ďalšie epizódy v torrente"
 
 msgctxt "#30347"
 msgid "Could not find binary for architecture '%s'![CR]Try to uninstall this addon, re-download and re-install it from the biggest zip."
-msgstr ""
+msgstr "Nepodarilo sa nájsť binárny súbor pre architektúru '%s'![CR]Skús odinštalovať tento doplnok, znovu ho stiahnuť a nainštalovať z najväčšieho zipu."
 
 msgctxt "#30348"
 msgid "Create usual files on the file system and write to them.[CR]Needs selected file's full size to be available on the disk!"
-msgstr ""
+msgstr "Vytvára bežné súbory v súborovom systéme a zapisuje do nich.[CR]Na disku musí byť dostupná plná veľkosť vybraného súboru!"
 
 msgctxt "#30349"
 msgid "Using device's memory to download parts of the torrent.[CR]Disk is used only to download and save .torrent file,"
-msgstr ""
+msgstr "Používa pamäť zariadenia na sťahovanie častí torrentu.[CR]Disk sa používa len na stiahnutie a uloženie súboru .torrent,"
 
 msgctxt "#30350"
 msgid "so can be any storage. For 1gb memory devices[CR]100mb is enough for memory storage, 200-250mb for bigger devices."
-msgstr ""
+msgstr "takže to môže byť akékoľvek úložisko. Pre zariadenia s 1 GB pamäte[CR]stačí 100 MB, pre väčšie zariadenia 200-250 MB."
 
 msgctxt "#30351"
 msgid "Same as for usual file storage, but splits file into many small files.[CR]Should be used on FAT-32 file-systems."
-msgstr ""
+msgstr "To isté ako bežné súborové úložisko, ale rozdelí súbor na množstvo malých súborov.[CR]Používaj na súborových systémoch FAT-32."
 
 msgctxt "#30352"
 msgid "Same as for usual file storage, but using memory[CR]to lower filesystem operations. Experimental storage!"
-msgstr ""
+msgstr "To isté ako bežné súborové úložisko, ale používa pamäť[CR]na zníženie operácií súborového systému. Experimentálne úložisko!"
 
 msgctxt "#30355"
 msgid "Changelog"
-msgstr ""
+msgstr "Zoznam zmien"
 
 msgctxt "#30357"
 msgid "Use Trakt information in Trakt lists"
-msgstr ""
+msgstr "Používať informácie z Traktu v zoznamoch Trakt"
 
 msgctxt "#30358"
 msgid "Trakt update started"
-msgstr ""
+msgstr "Aktualizácia Traktu sa začala"
 
 msgctxt "#30359"
 msgid "Do not ask questions before playback"
-msgstr ""
+msgstr "Neklásť otázky pred prehrávaním"
 
 msgctxt "#30360"
 msgid "My Progress"
-msgstr ""
+msgstr "Môj priebeh"
 
 msgctxt "#30361"
 msgid "My History"
-msgstr ""
+msgstr "Moja história"
 
 msgctxt "#30362"
 msgid "Synchronization"
-msgstr ""
+msgstr "Synchronizácia"
 
 msgctxt "#30363"
 msgid "Sync items from collections into Kodi library"
-msgstr ""
+msgstr "Synchronizovať položky zo zbierok do knižnice Kodi"
 
 msgctxt "#30364"
 msgid "Sync items from watchlist into Kodi library"
-msgstr ""
+msgstr "Synchronizovať položky zo zoznamu sledovaných do knižnice Kodi"
 
 msgctxt "#30365"
 msgid "Sync items from user lists into Kodi library"
-msgstr ""
+msgstr "Synchronizovať položky z používateľských zoznamov do knižnice Kodi"
 
 msgctxt "#30366"
 msgid "Sync watched states from Trakt into Kodi library"
-msgstr ""
+msgstr "Synchronizovať stav pozretia z Traktu do knižnice Kodi"
 
 msgctxt "#30367"
 msgid "Sync back Kodi watched states into Trakt"
-msgstr ""
+msgstr "Synchronizovať stav pozretia z Kodi späť do Traktu"
 
 msgctxt "#30369"
 msgid "Disable Upload"
-msgstr ""
+msgstr "Zakázať odosielanie"
 
 msgctxt "#30370"
 msgid "Auto-assign network IP"
-msgstr ""
+msgstr "Automaticky prideliť sieťovú IP"
 
 msgctxt "#30371"
 msgid "Auto-assign network ports"
-msgstr ""
+msgstr "Automaticky prideliť sieťové porty"
 
 msgctxt "#30373"
 msgid "Languages"
-msgstr ""
+msgstr "Jazyky"
 
 msgctxt "#30374"
 msgid "Countries"
-msgstr ""
+msgstr "Krajiny"
 
 msgctxt "#30375"
 msgid "By size"
-msgstr ""
+msgstr "Podľa veľkosti"
 
 msgctxt "#30376"
 msgid "Choose memory size automatically"
-msgstr ""
+msgstr "Zvoliť veľkosť pamäte automaticky"
 
 msgctxt "#30377"
 msgid "Size is chosen automatically, based on[CR]physical amount of memory"
-msgstr ""
+msgstr "Veľkosť sa volí automaticky na základe[CR]množstva fyzickej pamäte"
 
 msgctxt "#30378"
 msgid "Allow memory usage"
-msgstr ""
+msgstr "Povoliť využitie pamäte"
 
 msgctxt "#30379"
 msgid "Minimum - 40MB, Default - 8%, Maximum - 15%"
-msgstr ""
+msgstr "Minimum - 40 MB, Predvolené - 8 %, Maximum - 15 %"
 
 msgctxt "#30380"
 msgid "Minimum"
-msgstr ""
+msgstr "Minimum"
 
 msgctxt "#30381"
 msgid "Default"
-msgstr ""
+msgstr "Predvolené"
 
 msgctxt "#30382"
 msgid "Maximum"
-msgstr ""
+msgstr "Maximum"
 
 msgctxt "#30383"
 msgid "Use Kodi language for subtitles search"
-msgstr ""
+msgstr "Použiť jazyk Kodi na hľadanie titulkov"
 
 msgctxt "#30384"
 msgid "Language code for subtitles (example: en, it, es)"
-msgstr ""
+msgstr "Kód jazyka pre titulky (napríklad: en, it, es)"
 
 msgctxt "#30386"
 msgid "Disable background progress dialog on playback"
-msgstr ""
+msgstr "Zakázať dialóg priebehu na pozadí počas prehrávania"
 
 msgctxt "#30387"
 msgid "Caching"
-msgstr ""
+msgstr "Ukladanie do vyrovnávacej pamäte"
 
 msgctxt "#30388"
 msgid "Cache stream selection"
-msgstr ""
+msgstr "Ukladať výber streamu do vyrovnávacej pamäte"
 
 msgctxt "#30389"
 msgid "Cache stream search results"
-msgstr ""
+msgstr "Ukladať výsledky hľadania streamov do vyrovnávacej pamäte"
 
 msgctxt "#30390"
 msgid "Cache search results duration, seconds"
-msgstr ""
+msgstr "Trvanie vyrovnávacej pamäte výsledkov hľadania, sekundy"
 
 msgctxt "#30393"
 msgid "Status"
-msgstr ""
+msgstr "Stav"
 
 msgctxt "#30394"
 msgid "Version"
-msgstr ""
+msgstr "Verzia"
 
 msgctxt "#30395"
 msgid "IP address"
-msgstr ""
+msgstr "IP adresa"
 
 msgctxt "#30396"
 msgid "Port"
-msgstr ""
+msgstr "Port"
 
 msgctxt "#30397"
 msgid "Web UI"
-msgstr ""
+msgstr "Webové rozhranie"
 
 msgctxt "#30398"
 msgid "Debug information (with kodi.log)"
-msgstr ""
+msgstr "Ladiace informácie (s kodi.log)"
 
 msgctxt "#30399"
 msgid "Addresses"
-msgstr ""
+msgstr "Adresy"
 
 msgctxt "#30400"
 msgid "Statistics"
-msgstr ""
+msgstr "Štatistiky"
 
 msgctxt "#30401"
 msgid "Torrent library status"
-msgstr ""
+msgstr "Stav knižnice torrentov"
 
 msgctxt "#30402"
 msgid "Size of cache.db"
-msgstr ""
+msgstr "Veľkosť cache.db"
 
 msgctxt "#30403"
 msgid "Size of app.db"
-msgstr ""
+msgstr "Veľkosť app.db"
 
 msgctxt "#30404"
 msgid "Assigned torrent files"
-msgstr ""
+msgstr "Priradené súbory torrent"
 
 msgctxt "#30405"
 msgid "Search queries"
-msgstr ""
+msgstr "Vyhľadávacie dopyty"
 
 msgctxt "#30406"
 msgid "Remove from history"
-msgstr ""
+msgstr "Odstrániť z histórie"
 
 msgctxt "#30408"
 msgid "Addon Connectivity"
-msgstr ""
+msgstr "Pripojenie doplnku"
 
 msgctxt "#30409"
 msgid "Local port"
-msgstr ""
+msgstr "Lokálny port"
 
 msgctxt "#30410"
 msgid "Remote port"
-msgstr ""
+msgstr "Vzdialený port"
 
 msgctxt "#30411"
 msgid "Remote host"
-msgstr ""
+msgstr "Vzdialený hostiteľ"
 
 msgctxt "#30412"
 msgid "Do not start binary (client mode)"
-msgstr ""
+msgstr "Nespúšťať binárny súbor (režim klienta)"
 
 msgctxt "#30413"
 msgid "Yes"
-msgstr ""
+msgstr "Áno"
 
 msgctxt "#30414"
 msgid "No"
-msgstr ""
+msgstr "Nie"
 
 msgctxt "#30415"
 msgid "Next page (%s)"
-msgstr ""
+msgstr "Ďalšia strana (%s)"
 
 msgctxt "#30416"
 msgid "Percents of playback to mark as watched"
-msgstr ""
+msgstr "Percento prehrania na označenie ako pozreté"
 
 msgctxt "#30417"
 msgid "Use name of production company as Studio for shows"
-msgstr ""
+msgstr "Použiť názov produkčnej spoločnosti ako štúdio pre seriály"
 
 msgctxt "#30418"
 msgid "Calculate number of unwatched episodes in Shows/Seasons"
-msgstr ""
+msgstr "Vypočítať počet nepozretých epizód v Seriáloch/Sezónach"
 
 msgctxt "#30421"
 msgid "Load torrents from torrents folder on startup"
-msgstr ""
+msgstr "Načítať torrenty z priečinka torrents pri štarte"
 
 msgctxt "#30422"
 msgid "Popular lists"
-msgstr ""
+msgstr "Populárne zoznamy"
 
 msgctxt "#30423"
 msgid "Recommendations"
-msgstr ""
+msgstr "Odporúčania"
 
 msgctxt "#30424"
 msgid "Progress"
-msgstr ""
+msgstr "Priebeh"
 
 msgctxt "#30425"
 msgid "Color of an air date"
-msgstr ""
+msgstr "Farba dátumu vysielania"
 
 msgctxt "#30426"
 msgid "Color of a show name"
-msgstr ""
+msgstr "Farba názvu seriálu"
 
 msgctxt "#30427"
 msgid "Color of an episode name"
-msgstr ""
+msgstr "Farba názvu epizódy"
 
 msgctxt "#30428"
 msgid "Hide unaired episodes"
-msgstr ""
+msgstr "Skryť neodvysielané epizódy"
 
 msgctxt "#30429"
 msgid "Sort shows in the list"
-msgstr ""
+msgstr "Zoradiť seriály v zozname"
 
 msgctxt "#30430"
 msgid "By latest watched"
-msgstr ""
+msgstr "Podľa naposledy pozretého"
 
 msgctxt "#30431"
 msgid "By show name"
-msgstr ""
+msgstr "Podľa názvu seriálu"
 
 msgctxt "#30432"
 msgid "By air date (newer)"
-msgstr ""
+msgstr "Podľa dátumu vysielania (novšie)"
 
 msgctxt "#30433"
 msgid "By air date (older)"
-msgstr ""
+msgstr "Podľa dátumu vysielania (staršie)"
 
 msgctxt "#30434"
 msgid "Date format"
-msgstr ""
+msgstr "Formát dátumu"
 
 msgctxt "#30436"
 msgid "Userlist"
-msgstr ""
+msgstr "Používateľský zoznam"
 
 msgctxt "#30438"
 msgid "Userlists"
-msgstr ""
+msgstr "Používateľské zoznamy"
 
 msgctxt "#30439"
 msgid "Debug information (without kodi.log)"
-msgstr ""
+msgstr "Ladiace informácie (bez kodi.log)"
 
 msgctxt "#30440"
 msgid "Color of an unaired episode name"
-msgstr ""
+msgstr "Farba názvu neodvysielanej epizódy"
 
 msgctxt "#30441"
 msgid "Select userlist for movies"
-msgstr ""
+msgstr "Vybrať používateľský zoznam pre filmy"
 
 msgctxt "#30442"
 msgid "Userlist for movies"
-msgstr ""
+msgstr "Používateľský zoznam pre filmy"
 
 msgctxt "#30443"
 msgid "Selected userlist for movies"
-msgstr ""
+msgstr "Vybraný používateľský zoznam pre filmy"
 
 msgctxt "#30444"
 msgid "Select userlist for shows"
-msgstr ""
+msgstr "Vybrať používateľský zoznam pre seriály"
 
 msgctxt "#30445"
 msgid "Userlist for shows"
-msgstr ""
+msgstr "Používateľský zoznam pre seriály"
 
 msgctxt "#30446"
 msgid "Selected userlist for shows"
-msgstr ""
+msgstr "Vybraný používateľský zoznam pre seriály"
 
 msgctxt "#30447"
 msgid "Add to Trakt, when movie is added to Kodi library"
-msgstr ""
+msgstr "Pridať do Traktu, keď sa film pridá do knižnice Kodi"
 
 msgctxt "#30448"
 msgid "Add to Trakt, when show is added to Kodi library"
-msgstr ""
+msgstr "Pridať do Traktu, keď sa seriál pridá do knižnice Kodi"
 
 msgctxt "#30449"
 msgid "Remove from Trakt, when movie is deleted from Kodi library"
-msgstr ""
+msgstr "Odstrániť z Traktu, keď sa film odstráni z knižnice Kodi"
 
 msgctxt "#30450"
 msgid "Remove from Trakt, when show is deleted from Kodi library"
-msgstr ""
+msgstr "Odstrániť z Traktu, keď sa seriál odstráni z knižnice Kodi"
 
 msgctxt "#30451"
 msgid "Torrent files path"
-msgstr ""
+msgstr "Cesta k súborom torrent"
 
 msgctxt "#30452"
 msgid "Reset all paths"
-msgstr ""
+msgstr "Obnoviť všetky cesty"
 
 msgctxt "#30453"
 msgid "Upload /debug/bundle (with kodi.log) to pastebin"
-msgstr ""
+msgstr "Nahrať /debug/bundle (s kodi.log) na pastebin"
 
 msgctxt "#30454"
 msgid "Paste url:[CR]%s"
-msgstr ""
+msgstr "URL adresa paste:[CR]%s"
 
 msgctxt "#30455"
 msgid "Logging"
-msgstr ""
+msgstr "Zaznamenávanie"
 
 msgctxt "#30456"
 msgid "Upload /debug/all (no kodi.log) to pastebin"
-msgstr ""
+msgstr "Nahrať /debug/all (bez kodi.log) na pastebin"
 
 msgctxt "#30457"
 msgid "Uploading file to pastebin"
-msgstr ""
+msgstr "Nahráva sa súbor na pastebin"
 
 msgctxt "#30458"
 msgid "Deleted movies"
-msgstr ""
+msgstr "Odstránené filmy"
 
 msgctxt "#30459"
 msgid "Deleted shows"
-msgstr ""
+msgstr "Odstránené seriály"
 
 msgctxt "#30460"
 msgid "Database"
-msgstr ""
+msgstr "Databáza"
 
 msgctxt "#30461"
 msgid "Show information"
-msgstr ""
+msgstr "Zobraziť informácie"
 
 msgctxt "#30462"
 msgid "Clear deleted movies"
-msgstr ""
+msgstr "Vyčistiť odstránené filmy"
 
 msgctxt "#30463"
 msgid "Clear deleted shows"
-msgstr ""
+msgstr "Vyčistiť odstránené seriály"
 
 msgctxt "#30464"
 msgid "Clear torrents history"
-msgstr ""
+msgstr "Vymazať históriu torrentov"
 
 msgctxt "#30465"
 msgid "Clear search history"
-msgstr ""
+msgstr "Vymazať históriu hľadania"
 
 msgctxt "#30466"
 msgid "Clear the database"
-msgstr ""
+msgstr "Vymazať databázu"
 
 msgctxt "#30467"
 msgid "Cache"
-msgstr ""
+msgstr "Vyrovnávacia pamäť"
 
 msgctxt "#30468"
 msgid "Clear TMDB cache"
-msgstr ""
+msgstr "Vymazať vyrovnávaciu pamäť TMDB"
 
 msgctxt "#30469"
 msgid "Clear Trakt cache"
-msgstr ""
+msgstr "Vymazať vyrovnávaciu pamäť Trakt"
 
 msgctxt "#30470"
 msgid "Clear the cache"
-msgstr ""
+msgstr "Vymazať vyrovnávaciu pamäť"
 
 msgctxt "#30471"
 msgid "Are you sure you want to do it?"
-msgstr ""
+msgstr "Naozaj to chceš urobiť?"
 
 msgctxt "#30472"
 msgid "Database cleared"
-msgstr ""
+msgstr "Databáza vymazaná"
 
 msgctxt "#30473"
 msgid "Select network interface"
-msgstr ""
+msgstr "Vybrať sieťové rozhranie"
 
 msgctxt "#30474"
 msgid "Network interfaces"
-msgstr ""
+msgstr "Sieťové rozhrania"
 
 msgctxt "#30475"
 msgid "Strm files language"
-msgstr ""
+msgstr "Jazyk súborov strm"
 
 msgctxt "#30476"
 msgid "Select language"
-msgstr ""
+msgstr "Vybrať jazyk"
 
 msgctxt "#30477"
 msgid "Original language"
-msgstr ""
+msgstr "Pôvodný jazyk"
 
 msgctxt "#30478"
 msgid "Searching"
-msgstr ""
+msgstr "Hľadá sa"
 
 msgctxt "#30480"
 msgid "Run Kodi library update after add/delete"
-msgstr ""
+msgstr "Spustiť aktualizáciu knižnice Kodi po pridaní/odstránení"
 
 msgctxt "#30481"
 msgid "Automatically"
-msgstr ""
+msgstr "Automaticky"
 
 msgctxt "#30482"
 msgid "Ask"
-msgstr ""
+msgstr "Opýtať sa"
 
 msgctxt "#30483"
 msgid "Create NFO files for Movie scrapers"
-msgstr ""
+msgstr "Vytvárať súbory NFO pre filmové scrapery"
 
 msgctxt "#30484"
 msgid "Create NFO files for TV Show scrapers"
-msgstr ""
+msgstr "Vytvárať súbory NFO pre seriálové scrapery"
 
 msgctxt "#30485"
 msgid "Concurrent connections limit per second"
-msgstr ""
+msgstr "Limit súbežných pripojení za sekundu"
 
 msgctxt "#30486"
 msgid "Automatic concurrent connections limit per second"
-msgstr ""
+msgstr "Automatický limit súbežných pripojení za sekundu"
 
 msgctxt "#30487"
 msgid "Enable built-in HTTP proxy"
-msgstr ""
+msgstr "Povoliť zabudovaný HTTP proxy"
 
 msgctxt "#30488"
 msgid "Internal Proxy Port"
-msgstr ""
+msgstr "Port interného proxy"
 
 msgctxt "#30489"
 msgid "Log Internal proxy requests"
-msgstr ""
+msgstr "Zaznamenávať požiadavky interného proxy"
 
 msgctxt "#30490"
 msgid "Internal HTTP proxy"
-msgstr ""
+msgstr "Interný HTTP proxy"
 
 msgctxt "#30491"
 msgid "Use Fanart.tv for posters/images"
-msgstr ""
+msgstr "Používať Fanart.tv pre plagáty/obrázky"
 
 msgctxt "#30492"
 msgid "Use Proxy for downloading .torrent files"
-msgstr ""
+msgstr "Používať proxy na sťahovanie súborov .torrent"
 
 msgctxt "#30493"
 msgid "Use Proxy for trackers"
-msgstr ""
+msgstr "Používať proxy pre trackery"
 
 msgctxt "#30494"
 msgid "Use Proxy for torrent downloading"
-msgstr ""
+msgstr "Používať proxy na sťahovanie torrentov"
 
 msgctxt "#30495"
 msgid "Use built-in DNS resolver"
-msgstr ""
+msgstr "Používať zabudovaný DNS resolver"
 
 msgctxt "#30496"
 msgid "Turn off if you use Tor addresses, or you want [CR]to use DNS settings from OS"
-msgstr ""
+msgstr "Vypni, ak používaš adresy Tor, alebo ak chceš [CR]používať nastavenia DNS z operačného systému"
 
 msgctxt "#30497"
 msgid "Use Antizapret proxy (only for Russia)"
-msgstr ""
+msgstr "Používať proxy Antizapret (len pre Rusko)"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"
-msgstr ""
+msgstr "Obnoviť túto cestu na '/'"
 
 msgctxt "#30499"
 msgid "Automatically adjust memory size[CR]for heavy torrents, if possible"
-msgstr ""
+msgstr "Automaticky prispôsobiť veľkosť pamäte[CR]pre veľké torrenty, ak je to možné"
 
 msgctxt "#30500"
 msgid "Automatically adjust buffer size[CR]for heavy torrents"
-msgstr ""
+msgstr "Automaticky prispôsobiť veľkosť vyrovnávacej pamäte[CR]pre veľké torrenty"
 
 msgctxt "#30502"
 msgid "Adjust buffer according to Kodi advancedsettings.xml, if set"
-msgstr ""
+msgstr "Prispôsobiť vyrovnávaciu pamäť podľa advancedsettings.xml v Kodi, ak je nastavený"
 
 msgctxt "#30503"
 msgid "Use libtorrent.config to override torrent engine settings"
-msgstr ""
+msgstr "Použiť libtorrent.config na prepísanie nastavení torrentového jadra"
 
 msgctxt "#30504"
 msgid "Located at USERDATA/plugin.video.elementum/libtorrent.config file[CR]Settings apply automatically. Visit https://libtorrent.org for info."
-msgstr ""
+msgstr "Nachádza sa v súbore USERDATA/plugin.video.elementum/libtorrent.config[CR]Nastavenia sa použijú automaticky. Informácie nájdeš na https://libtorrent.org ."
 
 msgctxt "#30505"
 msgid "Add episode number to the title"
-msgstr ""
+msgstr "Pridať číslo epizódy do názvu"
 
 msgctxt "#30506"
 msgid "Enable libtorrent logging"
-msgstr ""
+msgstr "Povoliť zaznamenávanie libtorrent"
 
 msgctxt "#30511"
 msgid "Libtorrent settings profile"
-msgstr ""
+msgstr "Profil nastavení libtorrent"
 
 msgctxt "#30512"
 msgid "Default"
-msgstr ""
+msgstr "Predvolené"
 
 msgctxt "#30513"
 msgid "Minimal memory"
-msgstr ""
+msgstr "Minimálna pamäť"
 
 msgctxt "#30514"
 msgid "High speed"
-msgstr ""
+msgstr "Vysoká rýchlosť"
 
 msgctxt "#30515"
 msgid "Load torrents from torrents folder paused"
-msgstr ""
+msgstr "Načítať torrenty z priečinka torrents pozastavené"
 
 msgctxt "#30516"
 msgid "... resume N seconds earlier"
-msgstr ""
+msgstr "... pokračovať o N sekúnd skôr"
 
 msgctxt "#30517"
 msgid "In Kodi library"
-msgstr ""
+msgstr "V knižnici Kodi"
 
 msgctxt "#30518"
 msgid "Use libtorrent deadlines"
-msgstr ""
+msgstr "Používať termíny libtorrent"
 
 msgctxt "#30519"
 msgid "Use libtorrent pause/resume trick for added torrents"
-msgstr ""
+msgstr "Používať trik pozastavenia/pokračovania libtorrent pre pridané torrenty"
 
 msgctxt "#30520"
 msgid "Add item to start menu"
-msgstr ""
+msgstr "Pridať položku do štartovacieho menu"
 
 msgctxt "#30521"
 msgid "Delete item from start menu"
-msgstr ""
+msgstr "Odstrániť položku zo štartovacieho menu"
 
 msgctxt "#30522"
 msgid "Minimum file size"
-msgstr ""
+msgstr "Minimálna veľkosť súboru"
 
 msgctxt "#30523"
 msgid "Minimum file size for Movies, MB"
-msgstr ""
+msgstr "Minimálna veľkosť súboru pre filmy, MB"
 
 msgctxt "#30524"
 msgid "Minimum file size for Shows, MB per minute"
-msgstr ""
+msgstr "Minimálna veľkosť súboru pre seriály, MB za minútu"
 
 msgctxt "#30525"
 msgid "Automatically start downloading next episode"
-msgstr ""
+msgstr "Automaticky začať sťahovať ďalšiu epizódu"
 
 msgctxt "#30527"
 msgid "Donate"
-msgstr ""
+msgstr "Prispieť"
 
 msgctxt "#30528"
 msgid "Automatically load first found subtitles"
-msgstr ""
+msgstr "Automaticky načítať prvé nájdené titulky"
 
 msgctxt "#30529"
 msgid "Number of subtitles to load automatically"
-msgstr ""
+msgstr "Počet automaticky načítaných titulkov"
 
 msgctxt "#30530"
 msgid "Delete autoloaded subtitles on player stop"
-msgstr ""
+msgstr "Odstrániť automaticky načítané titulky pri zastavení prehrávača"
 
 msgctxt "#30531"
 msgid "Download all files from torrent"
-msgstr ""
+msgstr "Stiahnuť všetky súbory z torrentu"
 
 msgctxt "#30532"
 msgid "Stop Downloading all files"
-msgstr ""
+msgstr "Zastaviť sťahovanie všetkých súborov"
 
 msgctxt "#30535"
 msgid "Continue playback from [B]%s[/B]?"
-msgstr ""
+msgstr "Pokračovať v prehrávaní od [B]%s[/B]?"
 
 msgctxt "#30536"
 msgid "Skip IPv6 addresses resolving"
-msgstr ""
+msgstr "Preskočiť prekladanie adries IPv6"
 
 msgctxt "#30537"
 msgid "Torrents history"
-msgstr ""
+msgstr "História torrentov"
 
 msgctxt "#30538"
 msgid "Use torrents history?"
-msgstr ""
+msgstr "Používať históriu torrentov?"
 
 msgctxt "#30539"
 msgid "Store N torrents in history"
-msgstr ""
+msgstr "Uchovávať N torrentov v histórii"
 
 msgctxt "#30540"
 msgid "Subtitles"
-msgstr ""
+msgstr "Titulky"
 
 msgctxt "#30541"
 msgid "Automatic Subtitles Search"
-msgstr ""
+msgstr "Automatické hľadanie titulkov"
 
 msgctxt "#30542"
 msgid "Disable if subtitles are available in player"
-msgstr ""
+msgstr "Zakáž, ak sú titulky dostupné v prehrávači"
 
 msgctxt "#30543"
 msgid "Subtitles included in torrent"
-msgstr ""
+msgstr "Titulky obsiahnuté v torrente"
 
 msgctxt "#30544"
 msgid "Automatic Scrape"
-msgstr ""
+msgstr "Automatické zbieranie"
 
 msgctxt "#30545"
 msgid "Automatic scraping allows to scrape connected providers[CR]to find new movies, if there are results,"
-msgstr ""
+msgstr "Automatické zbieranie umožňuje hľadať u pripojených poskytovateľov[CR]nové filmy. Ak sú výsledky"
 
 msgctxt "#30546"
 msgid "Strategy"
-msgstr ""
+msgstr "Stratégia"
 
 msgctxt "#30547"
 msgid "Find in each provider"
-msgstr ""
+msgstr "Hľadať u každého poskytovateľa"
 
 msgctxt "#30548"
 msgid "Find in overall"
-msgstr ""
+msgstr "Hľadať celkovo"
 
 msgctxt "#30549"
 msgid "Search is successful when found N results"
-msgstr ""
+msgstr "Hľadanie je úspešné, keď sa nájde N výsledkov"
 
 msgctxt "#30550"
 msgid "What to search"
-msgstr ""
+msgstr "Čo sa hľadá"
 
 msgctxt "#30551"
 msgid "How to search"
-msgstr ""
+msgstr "Ako sa hľadá"
 
 msgctxt "#30552"
 msgid "Search each N hours"
-msgstr ""
+msgstr "Hľadať každých N hodín"
 
 msgctxt "#30553"
 msgid "Find 4K resolution"
-msgstr ""
+msgstr "Nájsť rozlíšenie 4K"
 
 msgctxt "#30554"
 msgid "Find 1080p resolution"
-msgstr ""
+msgstr "Nájsť rozlíšenie 1080p"
 
 msgctxt "#30555"
 msgid "and movie passes checks for number of results[CR]movie can be added to the library."
-msgstr ""
+msgstr "a film prejde kontrolou počtu výsledkov,[CR]môže byť pridaný do knižnice."
 
 msgctxt "#30556"
 msgid "Add to the library"
-msgstr ""
+msgstr "Pridať do knižnice"
 
 msgctxt "#30557"
 msgid "Number of popular movies to search"
-msgstr ""
+msgstr "Počet populárnych filmov na prehľadanie"
 
 msgctxt "#30558"
 msgid "Latest available movies"
-msgstr ""
+msgstr "Najnovšie dostupné filmy"
 
 msgctxt "#30559"
 msgid "Skip searching for installed providers"
-msgstr ""
+msgstr "Preskočiť hľadanie nainštalovaných poskytovateľov"
 
 msgctxt "#30560"
 msgid "Files: %s"
-msgstr ""
+msgstr "Súbory: %s"
 
 msgctxt "#30561"
 msgid "Interval between requests, seconds"
-msgstr ""
+msgstr "Interval medzi požiadavkami, sekundy"
 
 msgctxt "#30562"
 msgid "Open directory with Kodi file browser"
-msgstr ""
+msgstr "Otvoriť priečinok v prehliadači súborov Kodi"
 
 msgctxt "#30563"
 msgid "Synchronize frequency of Trakt, minutes"
-msgstr ""
+msgstr "Frekvencia synchronizácie s Traktom, minúty"
 
 msgctxt "#30564"
 msgid "Sync hidden items"
-msgstr ""
+msgstr "Synchronizovať skryté položky"
 
 msgctxt "#30565"
 msgid "Sync playback progress into Kodi library"
-msgstr ""
+msgstr "Synchronizovať priebeh prehrávania do knižnice Kodi"
 
 msgctxt "#30566"
 msgid "Lists"
-msgstr ""
+msgstr "Zoznamy"
 
 msgctxt "#30567"
 msgid "Show \"All seasons\" in shows"
-msgstr ""
+msgstr "Zobraziť \"Všetky sezóny\" v seriáloch"
 
 msgctxt "#30568"
 msgid "Seasons order"
-msgstr ""
+msgstr "Poradie sezón"
 
 msgctxt "#30569"
 msgid "Ascending"
-msgstr ""
+msgstr "Vzostupne"
 
 msgctxt "#30570"
 msgid "Descending"
-msgstr ""
+msgstr "Zostupne"
 
 msgctxt "#30571"
 msgid "* All seasons"
-msgstr ""
+msgstr "* Všetky sezóny"
 
 msgctxt "#30572"
 msgid "Log server's response body"
-msgstr ""
+msgstr "Zaznamenávať telo odpovede servera"
 
 msgctxt "#30573"
 msgid "Select file to play"
-msgstr ""
+msgstr "Vyber súbor na prehratie"
 
 msgctxt "#30574"
 msgid "Automatically answer Yes after timeout"
-msgstr ""
+msgstr "Automaticky odpovedať Áno po vypršaní času"
 
 msgctxt "#30575"
 msgid "Timeout, seconds"
-msgstr ""
+msgstr "Časový limit, sekundy"
 
 msgctxt "#30576"
 msgid "Trakt authentication needs to be updated!"
-msgstr ""
+msgstr "Overenie Trakt je potrebné aktualizovať!"
 
 msgctxt "#30577"
 msgid "End of file Buffer size, MB"
-msgstr ""
+msgstr "Veľkosť vyrovnávacej pamäte na konci súboru, MB"
 
 msgctxt "#30578"
 msgid "Beginning of file Buffer size, MB"
-msgstr ""
+msgstr "Veľkosť vyrovnávacej pamäte na začiatku súboru, MB"
 
 msgctxt "#30579"
 msgid "Settings"
-msgstr ""
+msgstr "Nastavenia"
 
 msgctxt "#30580"
 msgid "Custom Trakt API Client ID"
-msgstr ""
+msgstr "Vlastné Client ID pre API Trakt"
 
 msgctxt "#30581"
 msgid "Custom Trakt API Client Secret"
-msgstr ""
+msgstr "Vlastné Client Secret pre API Trakt"
 
 msgctxt "#30582"
 msgid "Settings for %s provider"
-msgstr ""
+msgstr "Nastavenia poskytovateľa %s"
 
 msgctxt "#30583"
 msgid "Resolving magnet link"
-msgstr ""
+msgstr "Prekladá sa odkaz magnet"
 
 msgctxt "#30585"
 msgid "Enable library integration with Kodi"
-msgstr ""
+msgstr "Povoliť integráciu s knižnicou Kodi"
 
 msgctxt "#30586"
 msgid "If disabled - Elementum will not get/insert items to Kodi library [CR]and skip watched management with Kodi."
-msgstr ""
+msgstr "Ak je zakázané, Elementum nebude načítavať ani vkladať položky do knižnice Kodi [CR]a preskočí správu stavu pozretia s Kodi."
 
 msgctxt "#30587"
 msgid "Show welcome message on start"
-msgstr ""
+msgstr "Zobraziť uvítaciu správu pri štarte"
 
 msgctxt "#30588"
 msgid "Pre-Play Buffering"
-msgstr ""
+msgstr "Načítanie do vyrovnávacej pamäte pred prehrávaním"
 
 msgctxt "#30589"
 msgid "Speed limiting"
-msgstr ""
+msgstr "Obmedzenie rýchlosti"
 
 msgctxt "#30590"
 msgid "Torrents autoload on addon startup"
-msgstr ""
+msgstr "Automatické načítanie torrentov pri štarte doplnku"
 
 msgctxt "#30591"
 msgid "Limits for connections"
-msgstr ""
+msgstr "Limity pre pripojenia"
 
 msgctxt "#30592"
 msgid "Seeding"
-msgstr ""
+msgstr "Zdieľanie"
 
 msgctxt "#30593"
 msgid "Seed forever"
-msgstr ""
+msgstr "Zdieľať navždy"
 
 msgctxt "#30594"
 msgid "Network"
-msgstr ""
+msgstr "Sieť"
 
 msgctxt "#30595"
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Rôzne"
 
 msgctxt "#30597"
 msgid "Cache size, MB"
-msgstr ""
+msgstr "Veľkosť vyrovnávacej pamäte, MB"
 
 msgctxt "#30598"
 msgid "Enable caching if using File storage and have speed problems.[CR]Will use more memory, but can improve the speed."
-msgstr ""
+msgstr "Povoľ vyrovnávaciu pamäť, ak používaš súborové úložisko a máš problémy s rýchlosťou.[CR]Použije viac pamäte, ale môže zlepšiť rýchlosť."
 
 msgctxt "#30599"
 msgid "Enable Kodi library synchronization"
-msgstr ""
+msgstr "Povoliť synchronizáciu knižnice Kodi"
 
 msgctxt "#30600"
 msgid "Enable Trakt synchronization"
-msgstr ""
+msgstr "Povoliť synchronizáciu s Traktom"
 
 msgctxt "#30601"
 msgid "Enable synchronization while playback"
-msgstr ""
+msgstr "Povoliť synchronizáciu počas prehrávania"
 
 msgctxt "#30602"
 msgid "Retry requests to addon after timeout, seconds"
-msgstr ""
+msgstr "Zopakovať požiadavky na doplnok po vypršaní času, sekundy"
 
 msgctxt "#30603"
 msgid "Addon Startup"
-msgstr ""
+msgstr "Štart doplnku"
 
 msgctxt "#30604"
 msgid "Clean all history"
-msgstr ""
+msgstr "Vyčistiť celú históriu"
 
 msgctxt "#30605"
 msgid "Cache downloaded torrent files after search"
-msgstr ""
+msgstr "Ukladať stiahnuté súbory torrent do vyrovnávacej pamäte po hľadaní"
 
 msgctxt "#30606"
 msgid "Show watched state for torrent's files"
-msgstr ""
+msgstr "Zobraziť stav pozretia pre súbory torrentu"
 
 msgctxt "#30607"
 msgid "Use earliest release date as basic for searching"
-msgstr ""
+msgstr "Použiť najskorší dátum vydania ako základ pre hľadanie"
 
 msgctxt "#30608"
 msgid "Match found in your active torrents, play it?[CR]%s"
-msgstr ""
+msgstr "Našla sa zhoda v tvojich aktívnych torrentoch, prehrať ju?[CR]%s"
 
 msgctxt "#30609"
 msgid "Automatically start next episode if available"
-msgstr ""
+msgstr "Automaticky spustiť ďalšiu epizódu, ak je dostupná"
 
 msgctxt "#30610"
 msgid "Magnet resolve timeout, seconds"
-msgstr ""
+msgstr "Časový limit prekladu magnet, sekundy"
 
 msgctxt "#30611"
 msgid "Application platform type"
-msgstr ""
+msgstr "Typ platformy aplikácie"
 
 msgctxt "#30612"
 msgid "Select file to download"
-msgstr ""
+msgstr "Vyber súbor na stiahnutie"
 
 msgctxt "#30613"
 msgid "... for movie"
-msgstr ""
+msgstr "... pre film"
 
 msgctxt "#30614"
 msgid "... for tv show"
-msgstr ""
+msgstr "... pre seriál"
 
 msgctxt "#30615"
 msgid "... for search"
-msgstr ""
+msgstr "... pre hľadanie"
 
 msgctxt "#30616"
 msgid "Elementum | Trakt Account"
-msgstr ""
+msgstr "Elementum | Účet Trakt"
 
 msgctxt "#30617"
 msgid "Your account is locked for API on Trakt.tv[CR]Please, contact Trakt Support at https://support.trakt.tv ."
-msgstr ""
+msgstr "Tvoj účet je zablokovaný pre API na Trakt.tv[CR]Kontaktuj podporu Trakt na https://support.trakt.tv ."
 
 msgctxt "#30618"
 msgid "%s is downloaded"
-msgstr ""
+msgstr "%s je stiahnuté"
 
 msgctxt "#30619"
 msgid "Return to [B]%s[/B]"
-msgstr ""
+msgstr "Späť na [B]%s[/B]"
 
 msgctxt "#30620"
 msgid "Restart Elementum addon"
-msgstr ""
+msgstr "Reštartovať doplnok Elementum"
 
 msgctxt "#30621"
 msgid "Queued"
-msgstr ""
+msgstr "V poradí"
 
 msgctxt "#30622"
 msgid "Checking"
-msgstr ""
+msgstr "Kontroluje sa"
 
 msgctxt "#30623"
 msgid "Finding"
-msgstr ""
+msgstr "Hľadá sa"
 
 msgctxt "#30624"
 msgid "Downloading"
-msgstr ""
+msgstr "Sťahuje sa"
 
 msgctxt "#30625"
 msgid "Finished"
-msgstr ""
+msgstr "Dokončené"
 
 msgctxt "#30626"
 msgid "Seeding"
-msgstr ""
+msgstr "Zdieľa sa"
 
 msgctxt "#30627"
 msgid "Allocating"
-msgstr ""
+msgstr "Alokuje sa"
 
 msgctxt "#30628"
 msgid "Stalled"
-msgstr ""
+msgstr "Zastavené"
 
 msgctxt "#30629"
 msgid "Paused"
-msgstr ""
+msgstr "Pozastavené"
 
 msgctxt "#30630"
 msgid "Buffering"
-msgstr ""
+msgstr "Načítava sa do vyrovnávacej pamäte"
 
 msgctxt "#30631"
 msgid "Playing"
-msgstr ""
+msgstr "Prehráva sa"
 
 msgctxt "#30632"
 msgid "Yes (%s seconds)"
-msgstr ""
+msgstr "Áno (%s sekúnd)"
 
 msgctxt "#30633"
 msgid "No (%s seconds)"
-msgstr ""
+msgstr "Nie (%s sekúnd)"
 
 msgctxt "#30634"
 msgid "Log level"
-msgstr ""
+msgstr "Úroveň zaznamenávania"
 
 msgctxt "#30635"
 msgid "None"
-msgstr ""
+msgstr "Žiadna"
 
 msgctxt "#30636"
 msgid "Error"
-msgstr ""
+msgstr "Chyba"
 
 msgctxt "#30637"
 msgid "Info"
-msgstr ""
+msgstr "Info"
 
 msgctxt "#30638"
 msgid "Debug"
-msgstr ""
+msgstr "Ladenie"
 
 msgctxt "#30639"
 msgid "Show Specials in season listings"
-msgstr ""
+msgstr "Zobraziť špeciálne epizódy v zoznamoch sezón"
 
 msgctxt "#30640"
 msgid "Bitrate"
-msgstr ""
+msgstr "Dátový tok"
 
 msgctxt "#30641"
 msgid "Playback"
-msgstr ""
+msgstr "Prehrávanie"
 
 msgctxt "#30642"
 msgid "Force Resume options"
-msgstr ""
+msgstr "Vynútiť možnosti pokračovania"
 
 msgctxt "#30643"
 msgid "by Kodi"
-msgstr ""
+msgstr "cez Kodi"
 
 msgctxt "#30644"
 msgid "by Elementum - Ask"
-msgstr ""
+msgstr "cez Elementum - Opýtať sa"
 
 msgctxt "#30645"
 msgid "by Elementum - Force"
-msgstr ""
+msgstr "cez Elementum - Vynútiť"
 
 msgctxt "#30646"
 msgid "Authorize Elementum on Trakt.tv"
-msgstr ""
+msgstr "Autorizovať Elementum na Trakt.tv"
 
 msgctxt "#30647"
 msgid "Cancel Authorization for Elementum on Trakt.tv"
-msgstr ""
+msgstr "Zrušiť autorizáciu Elementum na Trakt.tv"
 
 msgctxt "#30648"
 msgid "Authorization"
-msgstr ""
+msgstr "Autorizácia"
 
 msgctxt "#30649"
 msgid "To authorize addon for Trakt.tv you need to:[CR]1. Open [B]%s[/B][CR]2. Enter code: [B]%s[/B][CR]3. Wait for notification from Elementum."
-msgstr ""
+msgstr "Na autorizáciu doplnku pre Trakt.tv musíš:[CR]1. Otvoriť [B]%s[/B][CR]2. Zadať kód: [B]%s[/B][CR]3. Počkať na upozornenie od Elementum."
 
 msgctxt "#30650"
 msgid "Successfully authorized for Trakt.tv"
-msgstr ""
+msgstr "Autorizácia na Trakt.tv bola úspešná"
 
 msgctxt "#30651"
 msgid "Could not authorize for Trakt.tv"
-msgstr ""
+msgstr "Nepodarilo sa autorizovať na Trakt.tv"
 
 msgctxt "#30652"
 msgid "Successfully deauthorized for Trakt.tv"
-msgstr ""
+msgstr "Autorizácia na Trakt.tv bola úspešne zrušená"
 
 msgctxt "#30653"
 msgid "Which files to download"
-msgstr ""
+msgstr "Ktoré súbory sťahovať"
 
 msgctxt "#30654"
 msgid "Only playback file"
-msgstr ""
+msgstr "Len prehrávaný súbor"
 
 msgctxt "#30655"
 msgid "Season files"
-msgstr ""
+msgstr "Súbory sezóny"
 
 msgctxt "#30656"
 msgid "All files"
-msgstr ""
+msgstr "Všetky súbory"
 
 msgctxt "#30657"
 msgid "Disable LSD"
-msgstr ""
+msgstr "Zakázať LSD"
 
 msgctxt "#30658"
 msgid "Add extra trackers"
-msgstr ""
+msgstr "Pridať ďalšie trackery"
 
 msgctxt "#30659"
 msgid "All known trackers"
-msgstr ""
+msgstr "Všetky známe trackery"
 
 msgctxt "#30660"
 msgid "Best trackers"
-msgstr ""
+msgstr "Najlepšie trackery"
 
 msgctxt "#30661"
 msgid "Minimum set"
-msgstr ""
+msgstr "Minimálna sada"
 
 msgctxt "#30662"
 msgid "Remove original trackers from torrent"
-msgstr ""
+msgstr "Odstrániť pôvodné trackery z torrentu"
 
 msgctxt "#30663"
 msgid "Show episodes on release day (w/o delay)"
-msgstr ""
+msgstr "Zobraziť epizódy v deň vydania (bez oneskorenia)"
 
 msgctxt "#30664"
 msgid "Modify trackers in torrent"
-msgstr ""
+msgstr "Upraviť trackery v torrente"
 
 msgctxt "#30665"
 msgid "At the time of adding"
-msgstr ""
+msgstr "V čase pridania"
 
 msgctxt "#30666"
 msgid "Every time"
-msgstr ""
+msgstr "Zakaždým"
 
 msgctxt "#30667"
 msgid "Mark as watched in Trakt"
-msgstr ""
+msgstr "Označiť ako pozreté v Trakte"
 
 msgctxt "#30668"
 msgid "Mark as unwatched in Trakt"
-msgstr ""
+msgstr "Označiť ako nepozreté v Trakte"
 
 msgctxt "#30669"
 msgid "Delay addon startup, seconds"
-msgstr ""
+msgstr "Oneskoriť štart doplnku, sekundy"
 
 msgctxt "#30670"
 msgid "Downloading required binary file for '%s'"
-msgstr ""
+msgstr "Sťahuje sa potrebný binárny súbor pre '%s'"
 
 msgctxt "#30671"
 msgid "List of Opennic DNS IPs"
-msgstr ""
+msgstr "Zoznam IP adries DNS serverov OpenNIC"
 
 msgctxt "#30672"
 msgid "Compact database"
-msgstr ""
+msgstr "Komprimovať databázu"
 
 msgctxt "#30673"
 msgid "Compact cache database"
-msgstr ""
+msgstr "Komprimovať databázu vyrovnávacej pamäte"
 
 msgctxt "#30674"
 msgid "Database was compacted"
-msgstr ""
+msgstr "Databáza bola komprimovaná"
 
 msgctxt "#30675"
 msgid "Remote host login"
-msgstr ""
+msgstr "Používateľské meno vzdialeného hostiteľa"
 
 msgctxt "#30676"
 msgid "Remote host password"
-msgstr ""
+msgstr "Heslo vzdialeného hostiteľa"
 
 msgctxt "#30677"
 msgid "Force start as a library"
-msgstr ""
+msgstr "Vynútiť štart ako knižnica"
 
 msgctxt "#30678"
 msgid "Remove from Kodi library, when movie is deleted from Trakt"
-msgstr ""
+msgstr "Odstrániť z knižnice Kodi, keď sa film odstráni z Traktu"
 
 msgctxt "#30679"
 msgid "Remove from Kodi library, when show is deleted from Trakt"
-msgstr ""
+msgstr "Odstrániť z knižnice Kodi, keď sa seriál odstráni z Traktu"
 
 msgctxt "#30680"
 msgid "Remove Elementum duplicates from library"
-msgstr ""
+msgstr "Odstrániť duplikáty Elementum z knižnice"
 
 msgctxt "#30681"
 msgid "[B]Found duplicates in Kodi library:[/B][CR]Movies: [B]%s[/B], Shows: [B]%s[/B], Episodes: [B]%s[/B][CR]Proceed?"
-msgstr ""
+msgstr "[B]V knižnici Kodi sa našli duplikáty:[/B][CR]Filmy: [B]%s[/B], Seriály: [B]%s[/B], Epizódy: [B]%s[/B][CR]Pokračovať?"
 
 msgctxt "#30682"
 msgid "No duplicates were found in Kodi library"
-msgstr ""
+msgstr "V knižnici Kodi sa nenašli žiadne duplikáty"
 
 msgctxt "#30683"
 msgid "Starting library duplicates removal"
-msgstr ""
+msgstr "Začína sa odstraňovanie duplikátov z knižnice"
 
 msgctxt "#30684"
 msgid "Removed Movies: %s, Shows: %s, Episodes: %s"
-msgstr ""
+msgstr "Odstránené - Filmy: %s, Seriály: %s, Epizódy: %s"
 
 msgctxt "#30685"
 msgid "Remove movies from Elementum database"
-msgstr ""
+msgstr "Odstrániť filmy z databázy Elementum"
 
 msgctxt "#30686"
 msgid "Remove shows from Elementum database"
-msgstr ""
+msgstr "Odstrániť seriály z databázy Elementum"
 
 msgctxt "#30687"
 msgid "In Elementum library"
-msgstr ""
+msgstr "V knižnici Elementum"
 
 msgctxt "#30688"
 msgid "Skip searching for installed Elementum repository"
-msgstr ""
+msgstr "Preskočiť hľadanie nainštalovaného repozitára Elementum"
 
 msgctxt "#30689"
 msgid "Internal DNS client"
-msgstr ""
+msgstr "Interný DNS klient"
 
 msgctxt "#30691"
 msgid "Hide watched"
-msgstr ""
+msgstr "Skryť pozreté"
 
 msgctxt "#30692"
 msgid "TMDB images quality (affects Kodi performance)"
-msgstr ""
+msgstr "Kvalita obrázkov TMDB (ovplyvňuje výkon Kodi)"
 
 msgctxt "#30693"
 msgid "Original"
-msgstr ""
+msgstr "Pôvodná"
 
 msgctxt "#30694"
 msgid "High"
-msgstr ""
+msgstr "Vysoká"
 
 msgctxt "#30695"
 msgid "Medium"
-msgstr ""
+msgstr "Stredná"
 
 msgctxt "#30696"
 msgid "Low"
-msgstr ""
+msgstr "Nízka"
 
 msgctxt "#30697"
 msgid "Interface language"
-msgstr ""
+msgstr "Jazyk rozhrania"
 
 msgctxt "#30698"
 msgid "Kodi language"
-msgstr ""
+msgstr "Jazyk Kodi"
 
 msgctxt "#30699"
 msgid "Use earliest release date for progress and calendars"
-msgstr ""
+msgstr "Použiť najskorší dátum vydania pre priebeh a kalendáre"
 
 msgctxt "#30700"
 msgid "Interface fallback language"
-msgstr ""
+msgstr "Záložný jazyk rozhrania"
 
 msgctxt "#30701"
 msgid "English | en"
-msgstr ""
+msgstr "Angličtina | en"
 
 msgctxt "#30702"
 msgid "Reached daily limit for subtitles downloads"
-msgstr ""
+msgstr "Dosiahnutý denný limit sťahovania titulkov"
 
 msgctxt "#30703"
 msgid "Can be used by search providers or [CR]for debugging"
-msgstr ""
+msgstr "Môžu ho používať poskytovatelia hľadania alebo [CR]na ladenie"
 
 msgctxt "#30704"
 msgid "TMDB API Key check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Kontrola kľúča API TMDB zlyhala, službu TMDB nemožno použiť"
 
 msgctxt "#30705"
 msgid "TMDB API accessibility check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Kontrola dostupnosti API TMDB zlyhala, službu TMDB nemožno použiť"
 
 msgctxt "#30706"
 msgid "Transmission 4.05"
-msgstr ""
+msgstr "Transmission 4.05"
 
 msgctxt "#30707"
 msgid "qBittorrent 3.3.9"
-msgstr ""
+msgstr "qBittorrent 3.3.9"
 
 msgctxt "#30708"
 msgid "qBittorrent 4.6.4"
-msgstr ""
+msgstr "qBittorrent 4.6.4"
 
 msgctxt "#30709"
 msgid "Open [B]%s[/B]"
-msgstr ""
+msgstr "Otvoriť [B]%s[/B]"
 
 msgctxt "#30710"
 msgid "BitTorrent ports"
-msgstr ""
+msgstr "Porty BitTorrent"
 
 msgctxt "#30711"
 msgid "Delete torrent '%s'?"
-msgstr ""
+msgstr "Odstrániť torrent '%s'?"
 
 msgctxt "#30712"
 msgid "Force to always use proxy, can break download in some cases"
-msgstr ""
+msgstr "Vynútiť trvalé použitie proxy, v niektorých prípadoch môže narušiť sťahovanie"
 
 msgctxt "#30713"
 msgid "Disable NATPMP"
-msgstr ""
+msgstr "Zakázať NATPMP"
 
 msgctxt "#30714"
 msgid "Re-check torrent's data"
-msgstr ""
+msgstr "Znovu skontrolovať údaje torrentu"
 
 msgctxt "#30715"
 msgid "Antizapret PAC file URL"
-msgstr ""
+msgstr "URL adresa súboru PAC Antizapret"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "Server DNS over HTTPS"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "Vlastný server DNS over HTTPS"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "Používať servery DNS OpenNIC"

--- a/resources/language/Spanish (Mexico)/strings.po
+++ b/resources/language/Spanish (Mexico)/strings.po
@@ -21,7 +21,7 @@ msgstr "General"
 
 msgctxt "#30001"
 msgid "Download path"
-msgstr ""
+msgstr "Ruta para descargas"
 
 msgctxt "#30004"
 msgid "Max upload rate, kB/s"
@@ -85,7 +85,7 @@ msgstr "Mantenimiento"
 
 msgctxt "#30021"
 msgid "Elements per page"
-msgstr ""
+msgstr "Resultados por página"
 
 msgctxt "#30022"
 msgid "Enable overlay status"
@@ -97,7 +97,7 @@ msgstr "Seleccionar fuente automáticamente"
 
 msgctxt "#30025"
 msgid "Limit rates after initial buffering only"
-msgstr ""
+msgstr "Limitar ratios después de buffering inicial"
 
 msgctxt "#30026"
 msgid "Library path"
@@ -109,7 +109,7 @@ msgstr "Límite de conexiones"
 
 msgctxt "#30028"
 msgid "Download after play was stopped"
-msgstr ""
+msgstr "Continuar descarga tras detener reproducción"
 
 msgctxt "#30029"
 msgid "Session saving frequency, seconds"
@@ -117,231 +117,231 @@ msgstr "Frecuencia para grabar sesiones (segundos)"
 
 msgctxt "#30030"
 msgid "Overlay status vertical offset"
-msgstr ""
+msgstr "Desplazamiento vertical para barra de estado"
 
 msgctxt "#30031"
 msgid "Disable providers that failed health check"
-msgstr ""
+msgstr "Desactivar control de salud"
 
 msgctxt "#30032"
 msgid "Allowed failures before provider is disabled"
-msgstr ""
+msgstr "Fallos permitidos antes de desactivar un proveedor"
 
 msgctxt "#30033"
 msgid "Appearance"
-msgstr ""
+msgstr "Apariencia"
 
 msgctxt "#30034"
 msgid "Default view for Movies"
-msgstr ""
+msgstr "Vista por defecto para Películas"
 
 msgctxt "#30035"
 msgid "Default view for TV Shows"
-msgstr ""
+msgstr "Vista por defecto para Series TV"
 
 msgctxt "#30036"
 msgid "Default view for Seasons"
-msgstr ""
+msgstr "Vista por defecto para Temporadas"
 
 msgctxt "#30037"
 msgid "Default view for Episodes"
-msgstr ""
+msgstr "Vista por defecto para Episodios"
 
 msgctxt "#30039"
 msgid "TheMovieDB"
-msgstr ""
+msgstr "TheMovieDB"
 
 msgctxt "#30040"
 msgid "API key"
-msgstr ""
+msgstr "API key"
 
 msgctxt "#30041"
 msgid "Stream sorting"
-msgstr ""
+msgstr "Ordenación de Stream"
 
 msgctxt "#30042"
 msgid "Sorting mode for Movies"
-msgstr ""
+msgstr "Modo para Películas"
 
 msgctxt "#30043"
 msgid "Sorting mode for TV Shows"
-msgstr ""
+msgstr "Modo para Series TV"
 
 msgctxt "#30044"
 msgid "By seeders"
-msgstr ""
+msgstr "Por semillas"
 
 msgctxt "#30045"
 msgid "By resolution"
-msgstr ""
+msgstr "Por resolución"
 
 msgctxt "#30046"
 msgid "Balanced"
-msgstr ""
+msgstr "Equilibrado"
 
 msgctxt "#30047"
 msgid "Resolution preference for Movies"
-msgstr ""
+msgstr "Preferencias de resolución para Películas"
 
 msgctxt "#30048"
 msgid "Resolution preference for TV Shows"
-msgstr ""
+msgstr "Preferencias de resolución para Series TV"
 
 msgctxt "#30049"
 msgid "Percentage of additional seeders required before choosing next resolution"
-msgstr ""
+msgstr "Porcentaje adicional de semillas antes de escoger próxima resolución"
 
 msgctxt "#30050"
 msgid "Disable DHT"
-msgstr ""
+msgstr "Desactivar DHT (distributed hash table)"
 
 msgctxt "#30051"
 msgid "Share ratio limit, percentage"
-msgstr ""
+msgstr "Ratio de compartición (porcentaje)"
 
 msgctxt "#30052"
 msgid "Seed time ratio limit, percentage"
-msgstr ""
+msgstr "Ratio de tiempo como semilla (porcentaje)"
 
 msgctxt "#30053"
 msgid "Seed time limit, hours"
-msgstr ""
+msgstr "Tiempo como semilla (horas)"
 
 msgctxt "#30054"
 msgid "Update library"
-msgstr ""
+msgstr "Actualizar biblioteca"
 
 msgctxt "#30055"
 msgid "Add Specials to library"
-msgstr ""
+msgstr "Añadir Especiales a biblioteca"
 
 msgctxt "#30056"
 msgid "Trakt"
-msgstr ""
+msgstr "Trakt"
 
 msgctxt "#30057"
 msgid "Username"
-msgstr ""
+msgstr "Usuario"
 
 msgctxt "#30059"
 msgid "Library update delay on startup, seconds"
-msgstr ""
+msgstr "Retraso durante el inicio (segundos)"
 
 msgctxt "#30060"
 msgid "Library update frequency, hours"
-msgstr ""
+msgstr "Actualización de la biblioteca (horas)"
 
 msgctxt "#30063"
 msgid "Disable UPNP"
-msgstr ""
+msgstr "Desactivar UPNP"
 
 msgctxt "#30064"
 msgid "Encryption policy"
-msgstr ""
+msgstr "Política de cifrado"
 
 msgctxt "#30065"
 msgid "Disabled"
-msgstr ""
+msgstr "Desactivado"
 
 msgctxt "#30066"
 msgid "Forced"
-msgstr ""
+msgstr "Forzado"
 
 msgctxt "#30067"
 msgid "Proxy type"
-msgstr ""
+msgstr "Tipo de proxy"
 
 msgctxt "#30068"
 msgid "SOCKS4"
-msgstr ""
+msgstr "SOCKS4"
 
 msgctxt "#30069"
 msgid "SOCKS5"
-msgstr ""
+msgstr "SOCKS5"
 
 msgctxt "#30071"
 msgid "HTTP"
-msgstr ""
+msgstr "HTTP"
 
 msgctxt "#30073"
 msgid "i2p"
-msgstr ""
+msgstr "i2p"
 
 msgctxt "#30074"
 msgid "Spoof user agent (highly inadvisable)"
-msgstr ""
+msgstr "User-agent engañoso (altamente desaconsejable)"
 
 msgctxt "#30075"
 msgid "Default advisable (acceptable)"
-msgstr ""
+msgstr "Por defecto (aceptable)"
 
 msgctxt "#30076"
 msgid "libtorrent (Rasterbar) 1.1.0"
-msgstr ""
+msgstr "libtorrent (Rasterbar) 1.1.0"
 
 msgctxt "#30077"
 msgid "BitTorrent 7.5.0"
-msgstr ""
+msgstr "BitTorrent 7.5.0"
 
 msgctxt "#30078"
 msgid "BitTorrent 7.9.9"
-msgstr ""
+msgstr "BitTorrent 7.9.9"
 
 msgctxt "#30079"
 msgid "µTorrent 3.5.5"
-msgstr ""
+msgstr "µTorrent 3.5.5"
 
 msgctxt "#30080"
 msgid "µTorrent 3.6.0"
-msgstr ""
+msgstr "µTorrent 3.6.0"
 
 msgctxt "#30081"
 msgid "µTorrent 2.2.1"
-msgstr ""
+msgstr "µTorrent 2.2.1"
 
 msgctxt "#30082"
 msgid "Transmission 2.92"
-msgstr ""
+msgstr "Transmission 2.92"
 
 msgctxt "#30083"
 msgid "Deluge 1.3.6"
-msgstr ""
+msgstr "Deluge 1.3.6"
 
 msgctxt "#30084"
 msgid "Deluge 2.1.1"
-msgstr ""
+msgstr "Deluge 2.1.1"
 
 msgctxt "#30085"
 msgid "Vuze 5.7.3.0"
-msgstr ""
+msgstr "Vuze 5.7.3.0"
 
 msgctxt "#30086"
 msgid "Enable tuned storage settings"
-msgstr ""
+msgstr "Activar ajustes para almacenamiento optimizado"
 
 msgctxt "#30088"
 msgid "Initial buffering timeout, seconds"
-msgstr ""
+msgstr "Timeout buffering inicial (segundos)"
 
 msgctxt "#30090"
 msgid "Listen interfaces"
-msgstr ""
+msgstr "Interfaces en escucha"
 
 msgctxt "#30091"
 msgid "Outgoing interfaces"
-msgstr ""
+msgstr "Interfaces de salida"
 
 msgctxt "#30092"
 msgid "Use fallback fanart if fanart wasn't found"
-msgstr ""
+msgstr "Usar fanart por defecto"
 
 msgctxt "#30093"
 msgid "Disable notification sound"
-msgstr ""
+msgstr "Desactivar sonido de notificación"
 
 msgctxt "#30094"
 msgid "Disable background progress dialog"
-msgstr ""
+msgstr "Desactivar diálogo de progreso en segundo plano"
 
 # Interface
 msgctxt "#30100"
@@ -354,7 +354,7 @@ msgstr "Este complemento solo puede ser utilizado desde Elementum"
 
 msgctxt "#30103"
 msgid "Unable to find Elementum binary[CR]Required platform:"
-msgstr ""
+msgstr "No se pudo encontrar binario Elementum[CR]Plataforma requerida:"
 
 msgctxt "#30104"
 msgid "Insert file or URL"
@@ -382,79 +382,79 @@ msgstr "OK"
 
 msgctxt "#30110"
 msgid "Crashed too many times, aborting..."
-msgstr ""
+msgstr "Falló demasiadas veces, abortando..."
 
 msgctxt "#30111"
 msgid "Provider failed too many times, disabling..."
-msgstr ""
+msgstr "El proveedor falló demasiadas veces, deshabilitando..."
 
 msgctxt "#30112"
 msgid "Unable to disable provider"
-msgstr ""
+msgstr "Incapaz de deshabilitar proveedor"
 
 msgctxt "#30113"
 msgid "Download path not set, check your settings"
-msgstr ""
+msgstr "Ruta de descarga no configurada, revisa tu configuración"
 
 msgctxt "#30116"
 msgid "Looks like Elementum is still starting up, give it a few seconds..."
-msgstr ""
+msgstr "Parece que Elementum todavía está arrancando, dale unos segundos..."
 
 msgctxt "#30117"
 msgid "Resolving torrent files..."
-msgstr ""
+msgstr "Resolviendo archivos torrent..."
 
 msgctxt "#30118"
 msgid "Scraping trackers..."
-msgstr ""
+msgstr "Obteniendo información de trackers..."
 
 msgctxt "#30119"
 msgid "ID of selected userlist for movies"
-msgstr ""
+msgstr "ID de la lista de usuario seleccionada para películas"
 
 msgctxt "#30120"
 msgid "ID of selected userlist for shows"
-msgstr ""
+msgstr "ID de la lista de usuario seleccionada para series"
 
 msgctxt "#30141"
 msgid "Please support Elementum development by visiting[CR]https://elementum.surge.sh/donate/ or https://elementumorg.github.io/donate/"
-msgstr ""
+msgstr "Por favor, apoya el desarrollo de Elementum visitando[CR]https://elementum.surge.sh/donate/ o https://elementumorg.github.io/donate/"
 
 msgctxt "#30142"
 msgid "Default view for menus in Movies"
-msgstr ""
+msgstr "Vista por defecto para menús en Películas"
 
 msgctxt "#30143"
 msgid "Default view for menus in TV Shows"
-msgstr ""
+msgstr "Vista por defecto para menús en Series TV"
 
 msgctxt "#30144"
 msgid "Default view for movie genres"
-msgstr ""
+msgstr "Vista por defecto para géneros de Películas"
 
 msgctxt "#30145"
 msgid "Default view for TV show genres"
-msgstr ""
+msgstr "Vista por defecto para géneros de Series TV"
 
 msgctxt "#30146"
 msgid "Keep downloading '%s'?"
-msgstr ""
+msgstr "¿Continuo con la descarga del archivo '%s'?"
 
 msgctxt "#30147"
 msgid "Caches are still warming up, give it a minute or two..."
-msgstr ""
+msgstr "La caché todavía se está preparando, dale un minuto o dos..."
 
 msgctxt "#30148"
 msgid "Caches warmed up"
-msgstr ""
+msgstr "Caché horneada"
 
 msgctxt "#30149"
 msgid "Trakt username not set, check your settings"
-msgstr ""
+msgstr "Usuario para Trakt no definido, revisa tu configuración"
 
 msgctxt "#30199"
 msgid "No available JSON-RPC connection to Kodi.[CR]Enable both Application control options in Service settings / Control and restart Kodi."
-msgstr ""
+msgstr "No hay conexión JSON-RPC disponible para Kodi.[CR]Habilita opciones en Control de aplicación en Ajustes > Ajustes de servicio > Control y reinicia Kodi."
 
 # Elementum daemon
 msgctxt "#30200"
@@ -583,1720 +583,1720 @@ msgstr "Episodios Recientes"
 
 msgctxt "#30239"
 msgid "Providers"
-msgstr ""
+msgstr "Proveedores"
 
 msgctxt "#30240"
 msgid "Enable"
-msgstr ""
+msgstr "Activado"
 
 msgctxt "#30241"
 msgid "Disable"
-msgstr ""
+msgstr "Desactivado"
 
 msgctxt "#30242"
 msgid "Check"
-msgstr ""
+msgstr "Comprobar"
 
 msgctxt "#30243"
 msgid "Provider failures"
-msgstr ""
+msgstr "Errores proveedor"
 
 msgctxt "#30244"
 msgid "Provider settings"
-msgstr ""
+msgstr "Configuración Proveedor"
 
 msgctxt "#30246"
 msgid "Trending"
-msgstr ""
+msgstr "Tendencia"
 
 msgctxt "#30247"
 msgid "Most Played"
-msgstr ""
+msgstr "Más reproducidas"
 
 msgctxt "#30248"
 msgid "Most Watched"
-msgstr ""
+msgstr "Más visto"
 
 msgctxt "#30249"
 msgid "Most Collected"
-msgstr ""
+msgstr "Más coleccionadas"
 
 msgctxt "#30250"
 msgid "Most Anticipated"
-msgstr ""
+msgstr "Más esperado"
 
 msgctxt "#30251"
 msgid "Box Office"
-msgstr ""
+msgstr "Taquilla"
 
 msgctxt "#30252"
 msgid "Add to library"
-msgstr ""
+msgstr "Añadir a biblioteca"
 
 msgctxt "#30253"
 msgid "Remove from library"
-msgstr ""
+msgstr "Eliminar de biblioteca"
 
 msgctxt "#30254"
 msgid "My Watchlist"
-msgstr ""
+msgstr "Mi lista de seguimiento"
 
 msgctxt "#30255"
 msgid "Add to watchlist"
-msgstr ""
+msgstr "Añadir a lista de seguimiento"
 
 msgctxt "#30256"
 msgid "Remove from watchlist"
-msgstr ""
+msgstr "Eliminar de lista de seguimiento"
 
 msgctxt "#30257"
 msgid "My Collection"
-msgstr ""
+msgstr "Mi colección"
 
 msgctxt "#30258"
 msgid "Add to collection"
-msgstr ""
+msgstr "Añadir a colección"
 
 msgctxt "#30259"
 msgid "Remove from collection"
-msgstr ""
+msgstr "Eliminar de colección"
 
 msgctxt "#30260"
 msgid "A torrent was previously chosen, use it?[CR]%s"
-msgstr ""
+msgstr "Anteriormente se seleccionó un torrent, ¿deseas usarlo?[CR]%s"
 
 msgctxt "#30263"
 msgid "My Lists"
-msgstr ""
+msgstr "Mis listas"
 
 msgctxt "#30268"
 msgid "Toggle watched"
-msgstr ""
+msgstr "Marcar como ya visto"
 
 msgctxt "#30269"
 msgid "Delete downloaded files '%s'?"
-msgstr ""
+msgstr "¿Deseas eliminar los archivos descargados '%s'?"
 
 msgctxt "#30271"
 msgid "There is now an official multi-provider for Elementum called [COLOR FFFF6B00]Burst[/COLOR], would you like to install it now?"
-msgstr ""
+msgstr "Ahora hay un multiproveedor oficial para Elementum llamado [COLOR FFFF6B00]Burst[/COLOR], ¿Te gustaría instalarlo ahora?"
 
 msgctxt "#30272"
 msgid "Installation successful, enjoy Elementum [COLOR FFFF6B00]Burst[/COLOR]!"
-msgstr ""
+msgstr "¡Instalación completada correctamente, disfruta de Elementum [COLOR FFFF6B00]Burst[/COLOR]!"
 
 msgctxt "#30273"
 msgid "Shoot... It looks like we couldn't install [COLOR FFFF6B00]Burst[/COLOR] automatically, head over to the Elementum Repository, then under the Program add-ons section to install it."
-msgstr ""
+msgstr "¡Ups, vaya! Parece que no pudimos instalar [COLOR FFFF6B00]Burst[/COLOR] automáticamente, ve al Repositorio Elementum, a la sección Programas para instalarlo manualmente."
 
 msgctxt "#30274"
 msgid "Enable all"
-msgstr ""
+msgstr "Habilitar todo"
 
 msgctxt "#30275"
 msgid "Disable all"
-msgstr ""
+msgstr "Deshabilitar todo"
 
 msgctxt "#30276"
 msgid "Delete torrent and files"
-msgstr ""
+msgstr "Eliminar torrents y archivos"
 
 msgctxt "#30277"
 msgid "%s added to library, do you want to rescan it?[CR]You can later use Kodi's 'Update library' feature instead."
-msgstr ""
+msgstr "%s se agregó a la biblioteca, ¿quieres volver a escanearla?[CR]Más adelante puedes usar la función 'Actualizar biblioteca' de Kodi."
 
 msgctxt "#30278"
 msgid "%s removed from library, do you want to clean it?[CR]You can later use Kodi's 'Clean library' feature instead."
-msgstr ""
+msgstr "%s se eliminó de la biblioteca, ¿quieres limpiarla ahora?[CR]Más adelante puedes usar la función 'Limpiar biblioteca' de Kodi."
 
 msgctxt "#30279"
 msgid "Video %s was previously removed from library.[CR]Force adding?"
-msgstr ""
+msgstr "El video %s se eliminó previamente de la biblioteca.[CR]¿Forzar la adición?"
 
 msgctxt "#30282"
 msgid "Nothing left to remove from Elementum"
-msgstr ""
+msgstr "No queda nada por eliminar de Elementum"
 
 msgctxt "#30283"
 msgid "Merge to library"
-msgstr ""
+msgstr "Fusionar con biblioteca"
 
 msgctxt "#30284"
 msgid "Show unaired seasons"
-msgstr ""
+msgstr "Mostrar temporadas no emitidas"
 
 msgctxt "#30285"
 msgid "Show unaired episodes"
-msgstr ""
+msgstr "Mostrar episodios no emitidos"
 
 msgctxt "#30286"
 msgid "%s merged to library, do you want to rescan it?[CR]You can later use Kodi's 'Update library' feature instead."
-msgstr ""
+msgstr "%s se agregó a la biblioteca, ¿quieres volver a escanearla?[CR]Más adelante puedes usar la función 'Actualizar biblioteca' de Kodi."
 
 msgctxt "#30287"
 msgid "%s already in library"
-msgstr ""
+msgstr "%s ya existe en la biblioteca"
 
 msgctxt "#30288"
 msgid "Library updated, do you want to rescan it?[CR]You can later use Kodi's 'Update library' feature instead."
-msgstr ""
+msgstr "Biblioteca actualizada, ¿quieres volver a escanearla?[CR]Más adelante puedes usar la función 'Actualizar biblioteca' de Kodi."
 
 msgctxt "#30289"
 msgid "Genres"
-msgstr ""
+msgstr "Géneros"
 
 msgctxt "#30290"
 msgid "Calendars"
-msgstr ""
+msgstr "Calendarios"
 
 msgctxt "#30291"
 msgid "My Movies"
-msgstr ""
+msgstr "Mis películas"
 
 msgctxt "#30292"
 msgid "My Releases"
-msgstr ""
+msgstr "Mis ediciones"
 
 msgctxt "#30293"
 msgid "All Movies"
-msgstr ""
+msgstr "Todas las películas"
 
 msgctxt "#30294"
 msgid "All Releases"
-msgstr ""
+msgstr "Todas las ediciones"
 
 msgctxt "#30295"
 msgid "My Shows"
-msgstr ""
+msgstr "Mis series"
 
 msgctxt "#30296"
 msgid "My New Shows"
-msgstr ""
+msgstr "Mis nuevas series"
 
 msgctxt "#30297"
 msgid "My Premieres"
-msgstr ""
+msgstr "Mis estrenos"
 
 msgctxt "#30298"
 msgid "All Shows"
-msgstr ""
+msgstr "Todas las series"
 
 msgctxt "#30299"
 msgid "All New Shows"
-msgstr ""
+msgstr "Todas las series nuevas"
 
 msgctxt "#30300"
 msgid "All Premieres"
-msgstr ""
+msgstr "Todos los estrenos"
 
 msgctxt "#30301"
 msgid "Move finished downloads to separate folders"
-msgstr ""
+msgstr "Mover descargas finalizadas a carpetas separadas"
 
 msgctxt "#30302"
 msgid "Files will only be moved after seeding is finished (see[CR]- BitTorrent settings), and will wait if currently playing"
-msgstr ""
+msgstr "Los archivos sólo se moverán una vez finalizada la siembra[CR](ver Ajustes > BitTorrent), y esperará si se está reproduciendo."
 
 msgctxt "#30303"
 msgid "RAR archive detected. Download will need to be completed before playback can start and will require around twice the amount of space, continue?"
-msgstr ""
+msgstr "Se detectó un archivo RAR. La descarga deberá completarse antes de que pueda comenzar la reproducción y requerirá aproximadamente el doble de espacio, ¿deseas continuar?"
 
 msgctxt "#30304"
 msgid "Error creating output pipe for 'unrar' command"
-msgstr ""
+msgstr "Error creando salida para el comando 'unrar'."
 
 msgctxt "#30305"
 msgid "Error starting 'unrar' command"
-msgstr ""
+msgstr "Error iniciando el comando 'unrar'."
 
 msgctxt "#30306"
 msgid "Error waiting for 'unrar' command"
-msgstr ""
+msgstr "Error esperando el comando 'unrar'."
 
 msgctxt "#30307"
 msgid "Error reading from destination folder"
-msgstr ""
+msgstr "Error de lectura de carpeta de destino"
 
 msgctxt "#30308"
 msgid "Move completed"
-msgstr ""
+msgstr "Mover completado"
 
 msgctxt "#30309"
 msgid "Keep"
-msgstr ""
+msgstr "Mantener"
 
 msgctxt "#30310"
 msgid "Ask to delete"
-msgstr ""
+msgstr "Preguntar"
 
 msgctxt "#30311"
 msgid "Delete"
-msgstr ""
+msgstr "Eliminar"
 
 msgctxt "#30312"
 msgid "Keep files for not finished video"
-msgstr ""
+msgstr "Conservar archivos de video no completados"
 
 msgctxt "#30313"
 msgid "Keep files for watched/downloaded video"
-msgstr ""
+msgstr "Conservar archivos de video vistos/descargados"
 
 msgctxt "#30314"
 msgid "Settings were not initialized.[CR]Save addon settings, then restart Kodi."
-msgstr ""
+msgstr "Los ajustes no se inicializaron.[CR]Guarda la configuración del addon, luego reinicia Kodi."
 
 msgctxt "#30315"
 msgid "Download storage type"
-msgstr ""
+msgstr "Tipo de almacenamiento para descargas"
 
 msgctxt "#30316"
 msgid "Use files"
-msgstr ""
+msgstr "Usar archivos"
 
 msgctxt "#30317"
 msgid "Use memory"
-msgstr ""
+msgstr "Usar memoria"
 
 msgctxt "#30318"
 msgid "Memory size to use for each torrent, Mb"
-msgstr ""
+msgstr "Memoria usada para cada torrent (Mb)"
 
 msgctxt "#30319"
 msgid "Continue"
-msgstr ""
+msgstr "Continuar"
 
 msgctxt "#30320"
 msgid "Ask to stop"
-msgstr ""
+msgstr "Preguntar"
 
 msgctxt "#30321"
 msgid "Stop"
-msgstr ""
+msgstr "Detener"
 
 msgctxt "#30323"
 msgid "New search"
-msgstr ""
+msgstr "Nueva búsqueda"
 
 msgctxt "#30324"
 msgid "Force stream auto-selection from settings"
-msgstr ""
+msgstr "Forzar selección automática de stream desde ajustes"
 
 msgctxt "#30325"
 msgid "Download"
-msgstr ""
+msgstr "Descargas"
 
 msgctxt "#30326"
 msgid "Kodi library"
-msgstr ""
+msgstr "Biblioteca"
 
 msgctxt "#30327"
 msgid "Storage"
-msgstr ""
+msgstr "Almacenamiento"
 
 msgctxt "#30328"
 msgid "Disable TCP"
-msgstr ""
+msgstr "Desactivar TCP"
 
 msgctxt "#30329"
 msgid "Disable UTP"
-msgstr ""
+msgstr "Desactivar UDP"
 
 msgctxt "#30330"
 msgid "Update Trakt"
-msgstr ""
+msgstr "Actualizar Trakt"
 
 msgctxt "#30332"
 msgid "Reloading configuration..."
-msgstr ""
+msgstr "Volviendo a cargar configuración..."
 
 msgctxt "#30333"
 msgid "Try to find other episodes in the torrent"
-msgstr ""
+msgstr "Tratar de encontrar otros episodios en el torrent"
 
 msgctxt "#30347"
 msgid "Could not find binary for architecture '%s'![CR]Try to uninstall this addon, re-download and re-install it from the biggest zip."
-msgstr ""
+msgstr "¡No se pudo encontrar el binario para la arquitectura '%s'![CR]Trata de desinstalar el complemento, volver a descargarlo e instalarlo desde el zip más grande."
 
 msgctxt "#30348"
 msgid "Create usual files on the file system and write to them.[CR]Needs selected file's full size to be available on the disk!"
-msgstr ""
+msgstr "Crea los archivos habituales en el sistema de archivos y escribe en ellos.[CR]¡Necesita tener disponible en disco el tamaño total del archivo!"
 
 msgctxt "#30349"
 msgid "Using device's memory to download parts of the torrent.[CR]Disk is used only to download and save .torrent file,"
-msgstr ""
+msgstr "Usa la memoria del dispositivo para descargar partes del torrent.[CR]El disco solo se usa para descargar y guardar el archivo .torrent,"
 
 msgctxt "#30350"
 msgid "so can be any storage. For 1gb memory devices[CR]100mb is enough for memory storage, 200-250mb for bigger devices."
-msgstr ""
+msgstr "puede ser cualquier tipo de almacenamiento.[CR]Para dispositivos de 1gb 100mb son suficientes para el almacenamiento en memoria, para dispositivos más grandes 200-250mb."
 
 msgctxt "#30351"
 msgid "Same as for usual file storage, but splits file into many small files.[CR]Should be used on FAT-32 file-systems."
-msgstr ""
+msgstr "Igual que el almacenamiento de archivos habitual, pero divide el archivo[CR]en muchos archivos pequeños. Debe utilizarse para sistemas de archivos FAT32."
 
 msgctxt "#30352"
 msgid "Same as for usual file storage, but using memory[CR]to lower filesystem operations. Experimental storage!"
-msgstr ""
+msgstr "Igual que el almacenamiento de archivos habitual, pero utilizando[CR]la memoria para reducir las operaciones del sistema de archivos. ¡Almacenamiento experimental!"
 
 msgctxt "#30355"
 msgid "Changelog"
-msgstr ""
+msgstr "Registro de cambios"
 
 msgctxt "#30357"
 msgid "Use Trakt information in Trakt lists"
-msgstr ""
+msgstr "Utilizar información de Trakt para listas"
 
 msgctxt "#30358"
 msgid "Trakt update started"
-msgstr ""
+msgstr "Actualización de Trakt iniciada"
 
 msgctxt "#30359"
 msgid "Do not ask questions before playback"
-msgstr ""
+msgstr "No realizar solicitudes antes de reproducción"
 
 msgctxt "#30360"
 msgid "My Progress"
-msgstr ""
+msgstr "Mis progresos"
 
 msgctxt "#30361"
 msgid "My History"
-msgstr ""
+msgstr "Mi historial"
 
 msgctxt "#30362"
 msgid "Synchronization"
-msgstr ""
+msgstr "Sincronización"
 
 msgctxt "#30363"
 msgid "Sync items from collections into Kodi library"
-msgstr ""
+msgstr "Sincronizar colecciones con biblioteca Kodi"
 
 msgctxt "#30364"
 msgid "Sync items from watchlist into Kodi library"
-msgstr ""
+msgstr "Sincronizar listas de seguimiento con biblioteca Kodi"
 
 msgctxt "#30365"
 msgid "Sync items from user lists into Kodi library"
-msgstr ""
+msgstr "Sincronizar listas de usuario con biblioteca Kodi"
 
 msgctxt "#30366"
 msgid "Sync watched states from Trakt into Kodi library"
-msgstr ""
+msgstr "Sincronizar vistos de Trakt con biblioteca Kodi"
 
 msgctxt "#30367"
 msgid "Sync back Kodi watched states into Trakt"
-msgstr ""
+msgstr "Sincronizar vistos de Kodi con Trakt"
 
 msgctxt "#30369"
 msgid "Disable Upload"
-msgstr ""
+msgstr "Desactivar subida"
 
 msgctxt "#30370"
 msgid "Auto-assign network IP"
-msgstr ""
+msgstr "Asignar automáticamente dirección IP"
 
 msgctxt "#30371"
 msgid "Auto-assign network ports"
-msgstr ""
+msgstr "Asignar automáticamente los puertos de red"
 
 msgctxt "#30373"
 msgid "Languages"
-msgstr ""
+msgstr "Idiomas"
 
 msgctxt "#30374"
 msgid "Countries"
-msgstr ""
+msgstr "Países"
 
 msgctxt "#30375"
 msgid "By size"
-msgstr ""
+msgstr "Por tamaño"
 
 msgctxt "#30376"
 msgid "Choose memory size automatically"
-msgstr ""
+msgstr "Seleccionar automáticamente tamaño de memoria"
 
 msgctxt "#30377"
 msgid "Size is chosen automatically, based on[CR]physical amount of memory"
-msgstr ""
+msgstr "El tamaño se selecciona automáticamente, según[CR]la cantidad de memoria física disponible"
 
 msgctxt "#30378"
 msgid "Allow memory usage"
-msgstr ""
+msgstr "Uso de memoria permitido"
 
 msgctxt "#30379"
 msgid "Minimum - 40MB, Default - 8%, Maximum - 15%"
-msgstr ""
+msgstr "Mínimo - 40MB | Por defecto - 8% | Máximo - 15%"
 
 msgctxt "#30380"
 msgid "Minimum"
-msgstr ""
+msgstr "Mínimo"
 
 msgctxt "#30381"
 msgid "Default"
-msgstr ""
+msgstr "Por defecto"
 
 msgctxt "#30382"
 msgid "Maximum"
-msgstr ""
+msgstr "Máximo"
 
 msgctxt "#30383"
 msgid "Use Kodi language for subtitles search"
-msgstr ""
+msgstr "Usar idioma de Kodi para la búsqueda de subtítulos"
 
 msgctxt "#30384"
 msgid "Language code for subtitles (example: en, it, es)"
-msgstr ""
+msgstr "Código de idioma para subtítulos (por ejemplo: en, it, es)"
 
 msgctxt "#30386"
 msgid "Disable background progress dialog on playback"
-msgstr ""
+msgstr "Desactivar progreso de descarga durante reproducción"
 
 msgctxt "#30387"
 msgid "Caching"
-msgstr ""
+msgstr "Almacenamiento en caché"
 
 msgctxt "#30388"
 msgid "Cache stream selection"
-msgstr ""
+msgstr "Guardar en caché streams seleccionados"
 
 msgctxt "#30389"
 msgid "Cache stream search results"
-msgstr ""
+msgstr "Guardar en caché resultados de búsqueda"
 
 msgctxt "#30390"
 msgid "Cache search results duration, seconds"
-msgstr ""
+msgstr "Tiempo para mantener búsquedas en caché (segundos)"
 
 msgctxt "#30393"
 msgid "Status"
-msgstr ""
+msgstr "Estado"
 
 msgctxt "#30394"
 msgid "Version"
-msgstr ""
+msgstr "Versión"
 
 msgctxt "#30395"
 msgid "IP address"
-msgstr ""
+msgstr "Dirección IP"
 
 msgctxt "#30396"
 msgid "Port"
-msgstr ""
+msgstr "Puerto"
 
 msgctxt "#30397"
 msgid "Web UI"
-msgstr ""
+msgstr "Interfaz Web"
 
 msgctxt "#30398"
 msgid "Debug information (with kodi.log)"
-msgstr ""
+msgstr "Info de depuración (con kodi.log)"
 
 msgctxt "#30399"
 msgid "Addresses"
-msgstr ""
+msgstr "Direcciones"
 
 msgctxt "#30400"
 msgid "Statistics"
-msgstr ""
+msgstr "Estadísticas"
 
 msgctxt "#30401"
 msgid "Torrent library status"
-msgstr ""
+msgstr "Estado de biblioteca torrent"
 
 msgctxt "#30402"
 msgid "Size of cache.db"
-msgstr ""
+msgstr "Tamaño de cache.db"
 
 msgctxt "#30403"
 msgid "Size of app.db"
-msgstr ""
+msgstr "Tamaño de app.db"
 
 msgctxt "#30404"
 msgid "Assigned torrent files"
-msgstr ""
+msgstr "Archivos torrent asignados"
 
 msgctxt "#30405"
 msgid "Search queries"
-msgstr ""
+msgstr "Consultas de búsqueda"
 
 msgctxt "#30406"
 msgid "Remove from history"
-msgstr ""
+msgstr "Eliminar del historial"
 
 msgctxt "#30408"
 msgid "Addon Connectivity"
-msgstr ""
+msgstr "Conectividad de plugin"
 
 msgctxt "#30409"
 msgid "Local port"
-msgstr ""
+msgstr "Puerto local"
 
 msgctxt "#30410"
 msgid "Remote port"
-msgstr ""
+msgstr "Puerto remoto"
 
 msgctxt "#30411"
 msgid "Remote host"
-msgstr ""
+msgstr "Host remoto"
 
 msgctxt "#30412"
 msgid "Do not start binary (client mode)"
-msgstr ""
+msgstr "No iniciar binario"
 
 msgctxt "#30413"
 msgid "Yes"
-msgstr ""
+msgstr "Sí"
 
 msgctxt "#30414"
 msgid "No"
-msgstr ""
+msgstr "No"
 
 msgctxt "#30415"
 msgid "Next page (%s)"
-msgstr ""
+msgstr "Siguiente página (%s)"
 
 msgctxt "#30416"
 msgid "Percents of playback to mark as watched"
-msgstr ""
+msgstr "Porcentaje de reproducción para marcar como visto"
 
 msgctxt "#30417"
 msgid "Use name of production company as Studio for shows"
-msgstr ""
+msgstr "Usar nombre de la productora como estudio para series"
 
 msgctxt "#30418"
 msgid "Calculate number of unwatched episodes in Shows/Seasons"
-msgstr ""
+msgstr "Mostrar número de episodios no vistos en Series/Temporadas"
 
 msgctxt "#30421"
 msgid "Load torrents from torrents folder on startup"
-msgstr ""
+msgstr "Cargar torrents de la carpeta torrents durante el inicio"
 
 msgctxt "#30422"
 msgid "Popular lists"
-msgstr ""
+msgstr "Listas populares"
 
 msgctxt "#30423"
 msgid "Recommendations"
-msgstr ""
+msgstr "Recomendaciones"
 
 msgctxt "#30424"
 msgid "Progress"
-msgstr ""
+msgstr "Progreso"
 
 msgctxt "#30425"
 msgid "Color of an air date"
-msgstr ""
+msgstr "Color para fecha de emisión"
 
 msgctxt "#30426"
 msgid "Color of a show name"
-msgstr ""
+msgstr "Color para nombre de serie"
 
 msgctxt "#30427"
 msgid "Color of an episode name"
-msgstr ""
+msgstr "Color para nombre de episodio"
 
 msgctxt "#30428"
 msgid "Hide unaired episodes"
-msgstr ""
+msgstr "Ocultar episodios no emitidos"
 
 msgctxt "#30429"
 msgid "Sort shows in the list"
-msgstr ""
+msgstr "Ordenación de series"
 
 msgctxt "#30430"
 msgid "By latest watched"
-msgstr ""
+msgstr "Por el último visto"
 
 msgctxt "#30431"
 msgid "By show name"
-msgstr ""
+msgstr "Por nombre de la serie"
 
 msgctxt "#30432"
 msgid "By air date (newer)"
-msgstr ""
+msgstr "Por fecha de emisión (más reciente)"
 
 msgctxt "#30433"
 msgid "By air date (older)"
-msgstr ""
+msgstr "Por fecha de emisión (más antiguo)"
 
 msgctxt "#30434"
 msgid "Date format"
-msgstr ""
+msgstr "Formato para fecha"
 
 msgctxt "#30436"
 msgid "Userlist"
-msgstr ""
+msgstr "Lista de usuario"
 
 msgctxt "#30438"
 msgid "Userlists"
-msgstr ""
+msgstr "Listas de usuario"
 
 msgctxt "#30439"
 msgid "Debug information (without kodi.log)"
-msgstr ""
+msgstr "Info de depuración (sin kodi.log)"
 
 msgctxt "#30440"
 msgid "Color of an unaired episode name"
-msgstr ""
+msgstr "Color para nombre de episodio no emitido"
 
 msgctxt "#30441"
 msgid "Select userlist for movies"
-msgstr ""
+msgstr "Seleccionar lista de usuario para películas"
 
 msgctxt "#30442"
 msgid "Userlist for movies"
-msgstr ""
+msgstr "Lista de usuario para películas"
 
 msgctxt "#30443"
 msgid "Selected userlist for movies"
-msgstr ""
+msgstr "Lista de usuario seleccionada para películas"
 
 msgctxt "#30444"
 msgid "Select userlist for shows"
-msgstr ""
+msgstr "Seleccionar lista de usuario para series"
 
 msgctxt "#30445"
 msgid "Userlist for shows"
-msgstr ""
+msgstr "Lista de usuario para series"
 
 msgctxt "#30446"
 msgid "Selected userlist for shows"
-msgstr ""
+msgstr "Lista de usuario seleccionada para series"
 
 msgctxt "#30447"
 msgid "Add to Trakt, when movie is added to Kodi library"
-msgstr ""
+msgstr "Agregar a Trakt, cuando la película es añadida a la biblioteca Kodi"
 
 msgctxt "#30448"
 msgid "Add to Trakt, when show is added to Kodi library"
-msgstr ""
+msgstr "Agregar a Trakt, cuando la serie es añadida a la biblioteca Kodi"
 
 msgctxt "#30449"
 msgid "Remove from Trakt, when movie is deleted from Kodi library"
-msgstr ""
+msgstr "Borrar de Trakt, cuando la película es eliminada de la biblioteca Kodi"
 
 msgctxt "#30450"
 msgid "Remove from Trakt, when show is deleted from Kodi library"
-msgstr ""
+msgstr "Borrar de Trakt, cuando la serie es eliminada de la biblioteca Kodi"
 
 msgctxt "#30451"
 msgid "Torrent files path"
-msgstr ""
+msgstr "Ruta para archivos torrent"
 
 msgctxt "#30452"
 msgid "Reset all paths"
-msgstr ""
+msgstr "Restablecer todas las rutas"
 
 msgctxt "#30453"
 msgid "Upload /debug/bundle (with kodi.log) to pastebin"
-msgstr ""
+msgstr "Subir /debug/bundle (con kodi.log) a Pastebin"
 
 msgctxt "#30454"
 msgid "Paste url:[CR]%s"
-msgstr ""
+msgstr "Pegar url:[CR]%s"
 
 msgctxt "#30455"
 msgid "Logging"
-msgstr ""
+msgstr "Registro de depuración"
 
 msgctxt "#30456"
 msgid "Upload /debug/all (no kodi.log) to pastebin"
-msgstr ""
+msgstr "Subir /debug/all (sin kodi.log) a Pastebin"
 
 msgctxt "#30457"
 msgid "Uploading file to pastebin"
-msgstr ""
+msgstr "Subiendo archivo a Pastebin"
 
 msgctxt "#30458"
 msgid "Deleted movies"
-msgstr ""
+msgstr "Películas eliminadas"
 
 msgctxt "#30459"
 msgid "Deleted shows"
-msgstr ""
+msgstr "Series eliminadas"
 
 msgctxt "#30460"
 msgid "Database"
-msgstr ""
+msgstr "Base de datos"
 
 msgctxt "#30461"
 msgid "Show information"
-msgstr ""
+msgstr "Mostrar información"
 
 msgctxt "#30462"
 msgid "Clear deleted movies"
-msgstr ""
+msgstr "Limpiar películas eliminadas"
 
 msgctxt "#30463"
 msgid "Clear deleted shows"
-msgstr ""
+msgstr "Limpiar series eliminadas"
 
 msgctxt "#30464"
 msgid "Clear torrents history"
-msgstr ""
+msgstr "Limpiar historial torrent"
 
 msgctxt "#30465"
 msgid "Clear search history"
-msgstr ""
+msgstr "Limpiar historial de búsqueda"
 
 msgctxt "#30466"
 msgid "Clear the database"
-msgstr ""
+msgstr "Limpiar base de datos"
 
 msgctxt "#30467"
 msgid "Cache"
-msgstr ""
+msgstr "Caché"
 
 msgctxt "#30468"
 msgid "Clear TMDB cache"
-msgstr ""
+msgstr "Limpiar caché TMDB"
 
 msgctxt "#30469"
 msgid "Clear Trakt cache"
-msgstr ""
+msgstr "Limpiar caché Trakt"
 
 msgctxt "#30470"
 msgid "Clear the cache"
-msgstr ""
+msgstr "Limpiar caché"
 
 msgctxt "#30471"
 msgid "Are you sure you want to do it?"
-msgstr ""
+msgstr "¿Estás seguro de que quiere hacer esto?"
 
 msgctxt "#30472"
 msgid "Database cleared"
-msgstr ""
+msgstr "Base de datos borrada"
 
 msgctxt "#30473"
 msgid "Select network interface"
-msgstr ""
+msgstr "Seleccionar interfaz de red"
 
 msgctxt "#30474"
 msgid "Network interfaces"
-msgstr ""
+msgstr "Interfaces de red"
 
 msgctxt "#30475"
 msgid "Strm files language"
-msgstr ""
+msgstr "Idioma archivo strm"
 
 msgctxt "#30476"
 msgid "Select language"
-msgstr ""
+msgstr "Seleccionar idioma"
 
 msgctxt "#30477"
 msgid "Original language"
-msgstr ""
+msgstr "Original"
 
 msgctxt "#30478"
 msgid "Searching"
-msgstr ""
+msgstr "Búsqueda"
 
 msgctxt "#30480"
 msgid "Run Kodi library update after add/delete"
-msgstr ""
+msgstr "Actualizar biblioteca Kodi después de agregar/eliminar"
 
 msgctxt "#30481"
 msgid "Automatically"
-msgstr ""
+msgstr "Automáticamente"
 
 msgctxt "#30482"
 msgid "Ask"
-msgstr ""
+msgstr "Preguntar"
 
 msgctxt "#30483"
 msgid "Create NFO files for Movie scrapers"
-msgstr ""
+msgstr "Crear archivos NFO para los scrapers de películas"
 
 msgctxt "#30484"
 msgid "Create NFO files for TV Show scrapers"
-msgstr ""
+msgstr "Crear archivos NFO para los scrapers de series"
 
 msgctxt "#30485"
 msgid "Concurrent connections limit per second"
-msgstr ""
+msgstr "Límite de conexiones simultáneas por segundo"
 
 msgctxt "#30486"
 msgid "Automatic concurrent connections limit per second"
-msgstr ""
+msgstr "Limitar automáticamente el número de conexiones"
 
 msgctxt "#30487"
 msgid "Enable built-in HTTP proxy"
-msgstr ""
+msgstr "Activar proxy HTTP incorporado"
 
 msgctxt "#30488"
 msgid "Internal Proxy Port"
-msgstr ""
+msgstr "Puerto interno proxy"
 
 msgctxt "#30489"
 msgid "Log Internal proxy requests"
-msgstr ""
+msgstr "Registrar solicitudes proxy"
 
 msgctxt "#30490"
 msgid "Internal HTTP proxy"
-msgstr ""
+msgstr "Proxy HTTP"
 
 msgctxt "#30491"
 msgid "Use Fanart.tv for posters/images"
-msgstr ""
+msgstr "Usar Fanart.tv para posters/imágenes"
 
 msgctxt "#30492"
 msgid "Use Proxy for downloading .torrent files"
-msgstr ""
+msgstr "Usar proxy para descargar archivos .torrent"
 
 msgctxt "#30493"
 msgid "Use Proxy for trackers"
-msgstr ""
+msgstr "Usar proxy para trackers"
 
 msgctxt "#30494"
 msgid "Use Proxy for torrent downloading"
-msgstr ""
+msgstr "Usar proxy para la descarga torrent"
 
 msgctxt "#30495"
 msgid "Use built-in DNS resolver"
-msgstr ""
+msgstr "Usar resolución DNS integrada"
 
 msgctxt "#30496"
 msgid "Turn off if you use Tor addresses, or you want [CR]to use DNS settings from OS"
-msgstr ""
+msgstr "Desactivar si usas direcciones Tor, o deseas[CR]utilizar la configuración DNS del sistema operativo"
 
 msgctxt "#30497"
 msgid "Use Antizapret proxy (only for Russia)"
-msgstr ""
+msgstr "Usar proxy Antizapret (solo para Rusia)"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"
-msgstr ""
+msgstr "Restablecer esta ruta a '/'"
 
 msgctxt "#30499"
 msgid "Automatically adjust memory size[CR]for heavy torrents, if possible"
-msgstr ""
+msgstr "Ajustar automáticamente el tamaño de la memoria[CR]para torrents pesados"
 
 msgctxt "#30500"
 msgid "Automatically adjust buffer size[CR]for heavy torrents"
-msgstr ""
+msgstr "Ajustar automáticamente el tamaño del buffer[CR]para torrents pesados"
 
 msgctxt "#30502"
 msgid "Adjust buffer according to Kodi advancedsettings.xml, if set"
-msgstr ""
+msgstr "Ajustar buffer de acuerdo con advancedsettings.xml si está configurado"
 
 msgctxt "#30503"
 msgid "Use libtorrent.config to override torrent engine settings"
-msgstr ""
+msgstr "Usar libtorrent.config para anular la configuración del motor torrent"
 
 msgctxt "#30504"
 msgid "Located at USERDATA/plugin.video.elementum/libtorrent.config file[CR]Settings apply automatically. Visit https://libtorrent.org for info."
-msgstr ""
+msgstr "Localizado en USERDATA/plugin.video.elementum/libtorrent.config[CR]los ajustes se aplican automáticamente. Visita https://libtorrent.org para obtener información."
 
 msgctxt "#30505"
 msgid "Add episode number to the title"
-msgstr ""
+msgstr "Añadir número de episodio a título"
 
 msgctxt "#30506"
 msgid "Enable libtorrent logging"
-msgstr ""
+msgstr "Activar registro libtorrent"
 
 msgctxt "#30511"
 msgid "Libtorrent settings profile"
-msgstr ""
+msgstr "Perfil de ajuste libtorrent"
 
 msgctxt "#30512"
 msgid "Default"
-msgstr ""
+msgstr "Por defecto"
 
 msgctxt "#30513"
 msgid "Minimal memory"
-msgstr ""
+msgstr "Memoria mínima"
 
 msgctxt "#30514"
 msgid "High speed"
-msgstr ""
+msgstr "Alta velocidad"
 
 msgctxt "#30515"
 msgid "Load torrents from torrents folder paused"
-msgstr ""
+msgstr "Cargar torrents en pausa desde carpeta torrents"
 
 msgctxt "#30516"
 msgid "... resume N seconds earlier"
-msgstr ""
+msgstr "Tiempo a retroceder antes de reanudar (segundos)"
 
 msgctxt "#30517"
 msgid "In Kodi library"
-msgstr ""
+msgstr "En biblioteca Kodi"
 
 msgctxt "#30518"
 msgid "Use libtorrent deadlines"
-msgstr ""
+msgstr "Usar plazos libtorrent"
 
 msgctxt "#30519"
 msgid "Use libtorrent pause/resume trick for added torrents"
-msgstr ""
+msgstr "Usar truco libtorrent pausar/reanudar para añadir torrents"
 
 msgctxt "#30520"
 msgid "Add item to start menu"
-msgstr ""
+msgstr "Añadir elemento al menú de inicio"
 
 msgctxt "#30521"
 msgid "Delete item from start menu"
-msgstr ""
+msgstr "Eliminar elemento del menú de inicio"
 
 msgctxt "#30522"
 msgid "Minimum file size"
-msgstr ""
+msgstr "Tamaño mínimo de archivos"
 
 msgctxt "#30523"
 msgid "Minimum file size for Movies, MB"
-msgstr ""
+msgstr "Tamaño mín. de archivo para Películas (MB)"
 
 msgctxt "#30524"
 msgid "Minimum file size for Shows, MB per minute"
-msgstr ""
+msgstr "Tamaño mín. de archivo para Series TV (MB/min)"
 
 msgctxt "#30525"
 msgid "Automatically start downloading next episode"
-msgstr ""
+msgstr "Iniciar automáticamente descarga de siguiente episodio"
 
 msgctxt "#30527"
 msgid "Donate"
-msgstr ""
+msgstr "Donar"
 
 msgctxt "#30528"
 msgid "Automatically load first found subtitles"
-msgstr ""
+msgstr "Cargar automáticamente primer subtítulo encontrado"
 
 msgctxt "#30529"
 msgid "Number of subtitles to load automatically"
-msgstr ""
+msgstr "Número de subtítulos a cargar automáticamente"
 
 msgctxt "#30530"
 msgid "Delete autoloaded subtitles on player stop"
-msgstr ""
+msgstr "Eliminar subtítulos cargados automáticamente al detener reproducción"
 
 msgctxt "#30531"
 msgid "Download all files from torrent"
-msgstr ""
+msgstr "Descargar todos los archivos torrents"
 
 msgctxt "#30532"
 msgid "Stop Downloading all files"
-msgstr ""
+msgstr "Detener todos los archivos en descarga"
 
 msgctxt "#30535"
 msgid "Continue playback from [B]%s[/B]?"
-msgstr ""
+msgstr "¿Quieres continuar la reproducción desde [B]%s[/B]?"
 
 msgctxt "#30536"
 msgid "Skip IPv6 addresses resolving"
-msgstr ""
+msgstr "Omitir resolución de direcciones IPv6"
 
 msgctxt "#30537"
 msgid "Torrents history"
-msgstr ""
+msgstr "Historial torrents"
 
 msgctxt "#30538"
 msgid "Use torrents history?"
-msgstr ""
+msgstr "Usar historial torrents"
 
 msgctxt "#30539"
 msgid "Store N torrents in history"
-msgstr ""
+msgstr "Número de torrents en historial"
 
 msgctxt "#30540"
 msgid "Subtitles"
-msgstr ""
+msgstr "Subtítulos"
 
 msgctxt "#30541"
 msgid "Automatic Subtitles Search"
-msgstr ""
+msgstr "Búsqueda automática de subtítulos"
 
 msgctxt "#30542"
 msgid "Disable if subtitles are available in player"
-msgstr ""
+msgstr "Desactivar si los subtítulos están disponibles en el reproductor"
 
 msgctxt "#30543"
 msgid "Subtitles included in torrent"
-msgstr ""
+msgstr "Subtítulos incluidos en torrent"
 
 msgctxt "#30544"
 msgid "Automatic Scrape"
-msgstr ""
+msgstr "Raspado automático"
 
 msgctxt "#30545"
 msgid "Automatic scraping allows to scrape connected providers[CR]to find new movies, if there are results,"
-msgstr ""
+msgstr "El raspado automático permite raspar proveedores para encontrar[CR]nuevas películas. Si hay resultados y las películas pasan las"
 
 msgctxt "#30546"
 msgid "Strategy"
-msgstr ""
+msgstr "Estrategia"
 
 msgctxt "#30547"
 msgid "Find in each provider"
-msgstr ""
+msgstr "Encontrar en cada proveedor"
 
 msgctxt "#30548"
 msgid "Find in overall"
-msgstr ""
+msgstr "Encontrar en general"
 
 msgctxt "#30549"
 msgid "Search is successful when found N results"
-msgstr ""
+msgstr "Número de resultados a encontrar"
 
 msgctxt "#30550"
 msgid "What to search"
-msgstr ""
+msgstr "Que buscar"
 
 msgctxt "#30551"
 msgid "How to search"
-msgstr ""
+msgstr "Como buscar"
 
 msgctxt "#30552"
 msgid "Search each N hours"
-msgstr ""
+msgstr "Tiempo entre búsquedas (horas)"
 
 msgctxt "#30553"
 msgid "Find 4K resolution"
-msgstr ""
+msgstr "Encontrar resolución 4K"
 
 msgctxt "#30554"
 msgid "Find 1080p resolution"
-msgstr ""
+msgstr "Encontrar resolución 1080p"
 
 msgctxt "#30555"
 msgid "and movie passes checks for number of results[CR]movie can be added to the library."
-msgstr ""
+msgstr "comprobaciones de cantidad de resultados la película se puede[CR]agregar a la biblioteca."
 
 msgctxt "#30556"
 msgid "Add to the library"
-msgstr ""
+msgstr "Añadir a biblioteca"
 
 msgctxt "#30557"
 msgid "Number of popular movies to search"
-msgstr ""
+msgstr "Número de películas populares a buscar"
 
 msgctxt "#30558"
 msgid "Latest available movies"
-msgstr ""
+msgstr "Últimas películas disponibles"
 
 msgctxt "#30559"
 msgid "Skip searching for installed providers"
-msgstr ""
+msgstr "Omitir búsqueda para proveedores instalados"
 
 msgctxt "#30560"
 msgid "Files: %s"
-msgstr ""
+msgstr "Archivos: %s"
 
 msgctxt "#30561"
 msgid "Interval between requests, seconds"
-msgstr ""
+msgstr "Tiempo entre solicitudes (segundos)"
 
 msgctxt "#30562"
 msgid "Open directory with Kodi file browser"
-msgstr ""
+msgstr "Abrir directorio con explorador de archivos de Kodi"
 
 msgctxt "#30563"
 msgid "Synchronize frequency of Trakt, minutes"
-msgstr ""
+msgstr "Tiempo entre sincronizaciones con Trakt (minutos)"
 
 msgctxt "#30564"
 msgid "Sync hidden items"
-msgstr ""
+msgstr "Sincronizar elementos ocultos"
 
 msgctxt "#30565"
 msgid "Sync playback progress into Kodi library"
-msgstr ""
+msgstr "Sincronizar progreso de reproducción en la biblioteca Kodi"
 
 msgctxt "#30566"
 msgid "Lists"
-msgstr ""
+msgstr "Listas"
 
 msgctxt "#30567"
 msgid "Show \"All seasons\" in shows"
-msgstr ""
+msgstr "Mostrar \"Todas las temporadas\" en series"
 
 msgctxt "#30568"
 msgid "Seasons order"
-msgstr ""
+msgstr "Ordenación de temporadas"
 
 msgctxt "#30569"
 msgid "Ascending"
-msgstr ""
+msgstr "Ascendente"
 
 msgctxt "#30570"
 msgid "Descending"
-msgstr ""
+msgstr "Descendente"
 
 msgctxt "#30571"
 msgid "* All seasons"
-msgstr ""
+msgstr "* Todas las temporadas"
 
 msgctxt "#30572"
 msgid "Log server's response body"
-msgstr ""
+msgstr "Cuerpo registro de respuesta"
 
 msgctxt "#30573"
 msgid "Select file to play"
-msgstr ""
+msgstr "Seleccionar archivo a reproducir"
 
 msgctxt "#30574"
 msgid "Automatically answer Yes after timeout"
-msgstr ""
+msgstr "Responder SÍ automáticamente después de timeout"
 
 msgctxt "#30575"
 msgid "Timeout, seconds"
-msgstr ""
+msgstr "Timeout (segundos)"
 
 msgctxt "#30576"
 msgid "Trakt authentication needs to be updated!"
-msgstr ""
+msgstr "¡La autenticación para Trakt necesita ser actualizada!"
 
 msgctxt "#30577"
 msgid "End of file Buffer size, MB"
-msgstr ""
+msgstr "Tamaño de buffer para fin de archivo (MB)"
 
 msgctxt "#30578"
 msgid "Beginning of file Buffer size, MB"
-msgstr ""
+msgstr "Tamaño de buffer para comienzo de archivo (MB)"
 
 msgctxt "#30579"
 msgid "Settings"
-msgstr ""
+msgstr "Ajustes"
 
 msgctxt "#30580"
 msgid "Custom Trakt API Client ID"
-msgstr ""
+msgstr "ID Cliente personalizada para API Trakt"
 
 msgctxt "#30581"
 msgid "Custom Trakt API Client Secret"
-msgstr ""
+msgstr "ID Cliente Secreta personalizada para API Trakt"
 
 msgctxt "#30582"
 msgid "Settings for %s provider"
-msgstr ""
+msgstr "Ajustes para proveedor %s"
 
 msgctxt "#30583"
 msgid "Resolving magnet link"
-msgstr ""
+msgstr "Resolviendo enlace magnet"
 
 msgctxt "#30585"
 msgid "Enable library integration with Kodi"
-msgstr ""
+msgstr "Activar integración con biblioteca Kodi"
 
 msgctxt "#30586"
 msgid "If disabled - Elementum will not get/insert items to Kodi library [CR]and skip watched management with Kodi."
-msgstr ""
+msgstr "Si está deshabilitado, Elementum no obtendrá ni insertará elementos en la biblioteca de Kodi [CR]y omitirá la gestión de vistos con Kodi."
 
 msgctxt "#30587"
 msgid "Show welcome message on start"
-msgstr ""
+msgstr "Mostrar notificación durante el inicio"
 
 msgctxt "#30588"
 msgid "Pre-Play Buffering"
-msgstr ""
+msgstr "Almacenamiento previo a la reproducción"
 
 msgctxt "#30589"
 msgid "Speed limiting"
-msgstr ""
+msgstr "Limites de velocidad"
 
 msgctxt "#30590"
 msgid "Torrents autoload on addon startup"
-msgstr ""
+msgstr "Cargar automáticamente torrents al iniciar complemento"
 
 msgctxt "#30591"
 msgid "Limits for connections"
-msgstr ""
+msgstr "Límites de conexión"
 
 msgctxt "#30592"
 msgid "Seeding"
-msgstr ""
+msgstr "Siembra"
 
 msgctxt "#30593"
 msgid "Seed forever"
-msgstr ""
+msgstr "Sembrar constantemente"
 
 msgctxt "#30594"
 msgid "Network"
-msgstr ""
+msgstr "Red"
 
 msgctxt "#30595"
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Misceláneo"
 
 msgctxt "#30597"
 msgid "Cache size, MB"
-msgstr ""
+msgstr "Tamaño caché (MB)"
 
 msgctxt "#30598"
 msgid "Enable caching if using File storage and have speed problems.[CR]Will use more memory, but can improve the speed."
-msgstr ""
+msgstr "Habilita el almacenamiento en caché si usas almacenamiento en archivos y tienes problemas de velocidad.[CR]Usará más memoria, pero puede mejorar la velocidad."
 
 msgctxt "#30599"
 msgid "Enable Kodi library synchronization"
-msgstr ""
+msgstr "Activar sincronización con biblioteca Kodi"
 
 msgctxt "#30600"
 msgid "Enable Trakt synchronization"
-msgstr ""
+msgstr "Activar sincronización con Trakt"
 
 msgctxt "#30601"
 msgid "Enable synchronization while playback"
-msgstr ""
+msgstr "Activar sincronización durante la reproducción"
 
 msgctxt "#30602"
 msgid "Retry requests to addon after timeout, seconds"
-msgstr ""
+msgstr "Tiempo para reintentar solicitudes (segundos)"
 
 msgctxt "#30603"
 msgid "Addon Startup"
-msgstr ""
+msgstr "Arranque del complemento"
 
 msgctxt "#30604"
 msgid "Clean all history"
-msgstr ""
+msgstr "Limpiar todo el historial"
 
 msgctxt "#30605"
 msgid "Cache downloaded torrent files after search"
-msgstr ""
+msgstr "Almacenar en caché archivos torrents después de búsqueda"
 
 msgctxt "#30606"
 msgid "Show watched state for torrent's files"
-msgstr ""
+msgstr "Mostrar estado de visionado para archivos torrents"
 
 msgctxt "#30607"
 msgid "Use earliest release date as basic for searching"
-msgstr ""
+msgstr "Usar la fecha de lanzamiento más antigua como base para la búsqueda"
 
 msgctxt "#30608"
 msgid "Match found in your active torrents, play it?[CR]%s"
-msgstr ""
+msgstr "Se encontró una coincidencia en tus torrents activos, ¿reproducirla?[CR]%s"
 
 msgctxt "#30609"
 msgid "Automatically start next episode if available"
-msgstr ""
+msgstr "Reproducir automáticamente próximo episodio si está disponible"
 
 msgctxt "#30610"
 msgid "Magnet resolve timeout, seconds"
-msgstr ""
+msgstr "Tiempo para resolver enlaces Magnet (segundos)"
 
 msgctxt "#30611"
 msgid "Application platform type"
-msgstr ""
+msgstr "Tipo de plataforma"
 
 msgctxt "#30612"
 msgid "Select file to download"
-msgstr ""
+msgstr "Seleccionar archivo a descargar"
 
 msgctxt "#30613"
 msgid "... for movie"
-msgstr ""
+msgstr "... para película"
 
 msgctxt "#30614"
 msgid "... for tv show"
-msgstr ""
+msgstr "... series TV"
 
 msgctxt "#30615"
 msgid "... for search"
-msgstr ""
+msgstr "... para búsqueda"
 
 msgctxt "#30616"
 msgid "Elementum | Trakt Account"
-msgstr ""
+msgstr "Elementum | Cuenta Trakt"
 
 msgctxt "#30617"
 msgid "Your account is locked for API on Trakt.tv[CR]Please, contact Trakt Support at https://support.trakt.tv ."
-msgstr ""
+msgstr "Tu cuenta está bloqueada para la API en Trakt.tv[CR]Por favor, contacta al Soporte de Trakt en https://support.trakt.tv ."
 
 msgctxt "#30618"
 msgid "%s is downloaded"
-msgstr ""
+msgstr "%s descargado"
 
 msgctxt "#30619"
 msgid "Return to [B]%s[/B]"
-msgstr ""
+msgstr "Regresar a [B]%s[/B]"
 
 msgctxt "#30620"
 msgid "Restart Elementum addon"
-msgstr ""
+msgstr "Reiniciar complemento Elementum"
 
 msgctxt "#30621"
 msgid "Queued"
-msgstr ""
+msgstr "En cola"
 
 msgctxt "#30622"
 msgid "Checking"
-msgstr ""
+msgstr "Comprobando"
 
 msgctxt "#30623"
 msgid "Finding"
-msgstr ""
+msgstr "Buscando"
 
 msgctxt "#30624"
 msgid "Downloading"
-msgstr ""
+msgstr "Descargando"
 
 msgctxt "#30625"
 msgid "Finished"
-msgstr ""
+msgstr "Terminado"
 
 msgctxt "#30626"
 msgid "Seeding"
-msgstr ""
+msgstr "Siembra"
 
 msgctxt "#30627"
 msgid "Allocating"
-msgstr ""
+msgstr "Asignación"
 
 msgctxt "#30628"
 msgid "Stalled"
-msgstr ""
+msgstr "Atascado"
 
 msgctxt "#30629"
 msgid "Paused"
-msgstr ""
+msgstr "Pausado"
 
 msgctxt "#30630"
 msgid "Buffering"
-msgstr ""
+msgstr "Buffering"
 
 msgctxt "#30631"
 msgid "Playing"
-msgstr ""
+msgstr "Reproduciendo"
 
 msgctxt "#30632"
 msgid "Yes (%s seconds)"
-msgstr ""
+msgstr "Sí (%s segundos)"
 
 msgctxt "#30633"
 msgid "No (%s seconds)"
-msgstr ""
+msgstr "No (%s segundos)"
 
 msgctxt "#30634"
 msgid "Log level"
-msgstr ""
+msgstr "Nivel de registro"
 
 msgctxt "#30635"
 msgid "None"
-msgstr ""
+msgstr "Ninguno"
 
 msgctxt "#30636"
 msgid "Error"
-msgstr ""
+msgstr "Error"
 
 msgctxt "#30637"
 msgid "Info"
-msgstr ""
+msgstr "Información"
 
 msgctxt "#30638"
 msgid "Debug"
-msgstr ""
+msgstr "Depuración"
 
 msgctxt "#30639"
 msgid "Show Specials in season listings"
-msgstr ""
+msgstr "Mostrar Especiales en listados de temporadas"
 
 msgctxt "#30640"
 msgid "Bitrate"
-msgstr ""
+msgstr "Bitrate"
 
 msgctxt "#30641"
 msgid "Playback"
-msgstr ""
+msgstr "Reproducción"
 
 msgctxt "#30642"
 msgid "Force Resume options"
-msgstr ""
+msgstr "Forzar opciones de reanudación"
 
 msgctxt "#30643"
 msgid "by Kodi"
-msgstr ""
+msgstr "Kodi"
 
 msgctxt "#30644"
 msgid "by Elementum - Ask"
-msgstr ""
+msgstr "Solicitud - Elementum"
 
 msgctxt "#30645"
 msgid "by Elementum - Force"
-msgstr ""
+msgstr "Forzado - Elementum"
 
 msgctxt "#30646"
 msgid "Authorize Elementum on Trakt.tv"
-msgstr ""
+msgstr "Autorizar Elementum en Trakt.tv"
 
 msgctxt "#30647"
 msgid "Cancel Authorization for Elementum on Trakt.tv"
-msgstr ""
+msgstr "Cancelar autorización para Elementum en Trakt.tv"
 
 msgctxt "#30648"
 msgid "Authorization"
-msgstr ""
+msgstr "Autorización"
 
 msgctxt "#30649"
 msgid "To authorize addon for Trakt.tv you need to:[CR]1. Open [B]%s[/B][CR]2. Enter code: [B]%s[/B][CR]3. Wait for notification from Elementum."
-msgstr ""
+msgstr "Para autorizar el complemento en Trakt.tv debes:[CR]1. Abrir [B]%s[/B][CR]2. Ingresar el código: [B]%s[/B][CR]3. Esperar la notificación de Elementum."
 
 msgctxt "#30650"
 msgid "Successfully authorized for Trakt.tv"
-msgstr ""
+msgstr "Autorizado correctamente a Trakt.tv"
 
 msgctxt "#30651"
 msgid "Could not authorize for Trakt.tv"
-msgstr ""
+msgstr "No se pudo autorizar a Trakt.tv"
 
 msgctxt "#30652"
 msgid "Successfully deauthorized for Trakt.tv"
-msgstr ""
+msgstr "Desautorizado correctamente a Trakt.tv"
 
 msgctxt "#30653"
 msgid "Which files to download"
-msgstr ""
+msgstr "Que archivos descargar"
 
 msgctxt "#30654"
 msgid "Only playback file"
-msgstr ""
+msgstr "Sólo archivo de reproducción"
 
 msgctxt "#30655"
 msgid "Season files"
-msgstr ""
+msgstr "Archivos de temporada"
 
 msgctxt "#30656"
 msgid "All files"
-msgstr ""
+msgstr "Todos los archivos"
 
 msgctxt "#30657"
 msgid "Disable LSD"
-msgstr ""
+msgstr "Desactivar LSD"
 
 msgctxt "#30658"
 msgid "Add extra trackers"
-msgstr ""
+msgstr "Añadir trackers adicionales"
 
 msgctxt "#30659"
 msgid "All known trackers"
-msgstr ""
+msgstr "Todos los trackers conocidos"
 
 msgctxt "#30660"
 msgid "Best trackers"
-msgstr ""
+msgstr "Mejores trackers"
 
 msgctxt "#30661"
 msgid "Minimum set"
-msgstr ""
+msgstr "Mínimo"
 
 msgctxt "#30662"
 msgid "Remove original trackers from torrent"
-msgstr ""
+msgstr "Eliminar trackers originales del torrent"
 
 msgctxt "#30663"
 msgid "Show episodes on release day (w/o delay)"
-msgstr ""
+msgstr "Mostrar episodios el día del lanzamiento (sin demora)"
 
 msgctxt "#30664"
 msgid "Modify trackers in torrent"
-msgstr ""
+msgstr "Modificar trackers en torrent"
 
 msgctxt "#30665"
 msgid "At the time of adding"
-msgstr ""
+msgstr "Al momento de agregar"
 
 msgctxt "#30666"
 msgid "Every time"
-msgstr ""
+msgstr "Cada vez"
 
 msgctxt "#30667"
 msgid "Mark as watched in Trakt"
-msgstr ""
+msgstr "Marcar como visto en Trakt"
 
 msgctxt "#30668"
 msgid "Mark as unwatched in Trakt"
-msgstr ""
+msgstr "Marcar como no visto en Trakt"
 
 msgctxt "#30669"
 msgid "Delay addon startup, seconds"
-msgstr ""
+msgstr "Retrasar arranque del complemento (segundos)"
 
 msgctxt "#30670"
 msgid "Downloading required binary file for '%s'"
-msgstr ""
+msgstr "Descargando archivo binario requerido para '%s'"
 
 msgctxt "#30671"
 msgid "List of Opennic DNS IPs"
-msgstr ""
+msgstr "Lista de IP DNS de Opennic"
 
 msgctxt "#30672"
 msgid "Compact database"
-msgstr ""
+msgstr "Compactar base de datos"
 
 msgctxt "#30673"
 msgid "Compact cache database"
-msgstr ""
+msgstr "Compactar caché de base de datos"
 
 msgctxt "#30674"
 msgid "Database was compacted"
-msgstr ""
+msgstr "La base de datos fue compactada"
 
 msgctxt "#30675"
 msgid "Remote host login"
-msgstr ""
+msgstr "Inicio de sesión en host remoto"
 
 msgctxt "#30676"
 msgid "Remote host password"
-msgstr ""
+msgstr "Contraseña de host remoto"
 
 msgctxt "#30677"
 msgid "Force start as a library"
-msgstr ""
+msgstr "Forzar iniciar como biblioteca"
 
 msgctxt "#30678"
 msgid "Remove from Kodi library, when movie is deleted from Trakt"
-msgstr ""
+msgstr "Borrar película de la biblioteca cuando sea eliminada de Trakt"
 
 msgctxt "#30679"
 msgid "Remove from Kodi library, when show is deleted from Trakt"
-msgstr ""
+msgstr "Borrar serie de la biblioteca cuando sea eliminada de Trakt"
 
 msgctxt "#30680"
 msgid "Remove Elementum duplicates from library"
-msgstr ""
+msgstr "Borrar duplicados de Elementum de la biblioteca"
 
 msgctxt "#30681"
 msgid "[B]Found duplicates in Kodi library:[/B][CR]Movies: [B]%s[/B], Shows: [B]%s[/B], Episodes: [B]%s[/B][CR]Proceed?"
-msgstr ""
+msgstr "[B]Duplicados encontrados en la biblioteca de Kodi:[/B][CR]Películas: [B]%s[/B], Series: [B]%s[/B], Episodios: [B]%s[/B][CR]¿Continuar?"
 
 msgctxt "#30682"
 msgid "No duplicates were found in Kodi library"
-msgstr ""
+msgstr "No se encontraron duplicados en la biblioteca de Kodi"
 
 msgctxt "#30683"
 msgid "Starting library duplicates removal"
-msgstr ""
+msgstr "Eliminando duplicados de la biblioteca"
 
 msgctxt "#30684"
 msgid "Removed Movies: %s, Shows: %s, Episodes: %s"
-msgstr ""
+msgstr "Eliminados. Películas: %s, Series: %s, Episodios: %s"
 
 msgctxt "#30685"
 msgid "Remove movies from Elementum database"
-msgstr ""
+msgstr "Borrar películas de la base de datos"
 
 msgctxt "#30686"
 msgid "Remove shows from Elementum database"
-msgstr ""
+msgstr "Borrar series de la base de datos"
 
 msgctxt "#30687"
 msgid "In Elementum library"
-msgstr ""
+msgstr "En biblioteca Elementum"
 
 msgctxt "#30688"
 msgid "Skip searching for installed Elementum repository"
-msgstr ""
+msgstr "Omitir búsqueda de repositorio Elementum instalado"
 
 msgctxt "#30689"
 msgid "Internal DNS client"
-msgstr ""
+msgstr "Cliente DNS"
 
 msgctxt "#30691"
 msgid "Hide watched"
-msgstr ""
+msgstr "Ocultar vistos"
 
 msgctxt "#30692"
 msgid "TMDB images quality (affects Kodi performance)"
-msgstr ""
+msgstr "Calidad de las imágenes de TMDB (afecta al rendimiento de Kodi)"
 
 msgctxt "#30693"
 msgid "Original"
-msgstr ""
+msgstr "Original"
 
 msgctxt "#30694"
 msgid "High"
-msgstr ""
+msgstr "Alta"
 
 msgctxt "#30695"
 msgid "Medium"
-msgstr ""
+msgstr "Media"
 
 msgctxt "#30696"
 msgid "Low"
-msgstr ""
+msgstr "Baja"
 
 msgctxt "#30697"
 msgid "Interface language"
-msgstr ""
+msgstr "Idioma de interfaz"
 
 msgctxt "#30698"
 msgid "Kodi language"
-msgstr ""
+msgstr "Idioma de Kodi"
 
 msgctxt "#30699"
 msgid "Use earliest release date for progress and calendars"
-msgstr ""
+msgstr "Usar la fecha de lanzamiento más antigua para progreso y calendarios"
 
 msgctxt "#30700"
 msgid "Interface fallback language"
-msgstr ""
+msgstr "Idioma secundario de la interfaz"
 
 msgctxt "#30701"
 msgid "English | en"
-msgstr ""
+msgstr "Inglés | en"
 
 msgctxt "#30702"
 msgid "Reached daily limit for subtitles downloads"
-msgstr ""
+msgstr "Alcanzado límite diario de descargas de subtítulos"
 
 msgctxt "#30703"
 msgid "Can be used by search providers or [CR]for debugging"
-msgstr ""
+msgstr "Puede ser usado por los proveedores de búsqueda o [CR]para depuración"
 
 msgctxt "#30704"
 msgid "TMDB API Key check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Falló la comprobación de la clave de API de TMDB, no se puede usar el servicio TMDB"
 
 msgctxt "#30705"
 msgid "TMDB API accessibility check failed, cannot use TMDB service"
-msgstr ""
+msgstr "Falló la comprobación de accesibilidad de la API de TMDB, no se puede usar el servicio TMDB"
 
 msgctxt "#30706"
 msgid "Transmission 4.05"
-msgstr ""
+msgstr "Transmission 4.05"
 
 msgctxt "#30707"
 msgid "qBittorrent 3.3.9"
-msgstr ""
+msgstr "qBittorrent 3.3.9"
 
 msgctxt "#30708"
 msgid "qBittorrent 4.6.4"
-msgstr ""
+msgstr "qBittorrent 4.6.4"
 
 msgctxt "#30709"
 msgid "Open [B]%s[/B]"
-msgstr ""
+msgstr "Abrir [B]%s[/B]"
 
 msgctxt "#30710"
 msgid "BitTorrent ports"
-msgstr ""
+msgstr "Puertos BitTorrent"
 
 msgctxt "#30711"
 msgid "Delete torrent '%s'?"
-msgstr ""
+msgstr "¿Deseas eliminar el torrent '%s'?"
 
 msgctxt "#30712"
 msgid "Force to always use proxy, can break download in some cases"
-msgstr ""
+msgstr "Forzar el uso del proxy siempre, puede hacer que falle la descarga en algunos casos"
 
 msgctxt "#30713"
 msgid "Disable NATPMP"
-msgstr ""
+msgstr "Desactivar NATPMP"
 
 msgctxt "#30714"
 msgid "Re-check torrent's data"
-msgstr ""
+msgstr "Volver a verificar los datos del torrent"
 
 msgctxt "#30715"
 msgid "Antizapret PAC file URL"
-msgstr ""
+msgstr "URL del archivo PAC de Antizapret"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "Servidor DNS sobre HTTPS"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "Servidor DNS sobre HTTPS personalizado"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "Usar servidores DNS de OpenNIC"

--- a/resources/language/Ukrainian/strings.po
+++ b/resources/language/Ukrainian/strings.po
@@ -278,43 +278,43 @@ msgstr "За замовчуванням (прийнятне)"
 
 msgctxt "#30076"
 msgid "libtorrent (Rasterbar) 1.1.0"
-msgstr ""
+msgstr "libtorrent (Rasterbar) 1.1.0"
 
 msgctxt "#30077"
 msgid "BitTorrent 7.5.0"
-msgstr ""
+msgstr "BitTorrent 7.5.0"
 
 msgctxt "#30078"
 msgid "BitTorrent 7.9.9"
-msgstr ""
+msgstr "BitTorrent 7.9.9"
 
 msgctxt "#30079"
 msgid "µTorrent 3.5.5"
-msgstr ""
+msgstr "µTorrent 3.5.5"
 
 msgctxt "#30080"
 msgid "µTorrent 3.6.0"
-msgstr ""
+msgstr "µTorrent 3.6.0"
 
 msgctxt "#30081"
 msgid "µTorrent 2.2.1"
-msgstr ""
+msgstr "µTorrent 2.2.1"
 
 msgctxt "#30082"
 msgid "Transmission 2.92"
-msgstr ""
+msgstr "Transmission 2.92"
 
 msgctxt "#30083"
 msgid "Deluge 1.3.6"
-msgstr ""
+msgstr "Deluge 1.3.6"
 
 msgctxt "#30084"
 msgid "Deluge 2.1.1"
-msgstr ""
+msgstr "Deluge 2.1.1"
 
 msgctxt "#30085"
 msgid "Vuze 5.7.3.0"
-msgstr ""
+msgstr "Vuze 5.7.3.0"
 
 msgctxt "#30086"
 msgid "Enable tuned storage settings"
@@ -411,11 +411,11 @@ msgstr "Скануємо трекери..."
 
 msgctxt "#30119"
 msgid "ID of selected userlist for movies"
-msgstr ""
+msgstr "ID вибраного списку користувача для фільмів"
 
 msgctxt "#30120"
 msgid "ID of selected userlist for shows"
-msgstr ""
+msgstr "ID вибраного списку користувача для серіалів"
 
 msgctxt "#30141"
 msgid "Please support Elementum development by visiting[CR]https://elementum.surge.sh/donate/ or https://elementumorg.github.io/donate/"
@@ -1084,7 +1084,7 @@ msgstr "Порт"
 
 msgctxt "#30397"
 msgid "Web UI"
-msgstr ""
+msgstr "Вебінтерфейс"
 
 msgctxt "#30398"
 msgid "Debug information (with kodi.log)"
@@ -1160,7 +1160,7 @@ msgstr "Скільки переглянути для маркування як �
 
 msgctxt "#30417"
 msgid "Use name of production company as Studio for shows"
-msgstr ""
+msgstr "Використовувати назву виробничої компанії як студію для серіалів"
 
 msgctxt "#30418"
 msgid "Calculate number of unwatched episodes in Shows/Seasons"
@@ -1300,7 +1300,7 @@ msgstr "Журналювати"
 
 msgctxt "#30456"
 msgid "Upload /debug/all (no kodi.log) to pastebin"
-msgstr ""
+msgstr "Завантажити /debug/all (без kodi.log) на pastebin"
 
 msgctxt "#30457"
 msgid "Uploading file to pastebin"
@@ -1460,7 +1460,7 @@ msgstr "Вимкнути цє, якщо використовуєте Tor, або
 
 msgctxt "#30497"
 msgid "Use Antizapret proxy (only for Russia)"
-msgstr ""
+msgstr "Використовувати проксі Antizapret (лише для Росії)"
 
 msgctxt "#30498"
 msgid "Reset this path to '/'"
@@ -1484,7 +1484,7 @@ msgstr "Використовувати libtorrent.config для налаштув
 
 msgctxt "#30504"
 msgid "Located at USERDATA/plugin.video.elementum/libtorrent.config file[CR]Settings apply automatically. Visit https://libtorrent.org for info."
-msgstr ""
+msgstr "Розташовано у файлі USERDATA/plugin.video.elementum/libtorrent.config[CR]Налаштування застосовуються автоматично. Відвідайте https://libtorrent.org для інформації."
 
 msgctxt "#30505"
 msgid "Add episode number to the title"
@@ -1584,7 +1584,7 @@ msgstr "Продовжити відтворення від [B]%s[/B]?"
 
 msgctxt "#30536"
 msgid "Skip IPv6 addresses resolving"
-msgstr ""
+msgstr "Пропускати визначення адрес IPv6"
 
 msgctxt "#30537"
 msgid "Torrents history"
@@ -1760,11 +1760,11 @@ msgstr "Налаштування"
 
 msgctxt "#30580"
 msgid "Custom Trakt API Client ID"
-msgstr ""
+msgstr "Власний Client ID Trakt API"
 
 msgctxt "#30581"
 msgid "Custom Trakt API Client Secret"
-msgstr ""
+msgstr "Власний Client Secret Trakt API"
 
 msgctxt "#30582"
 msgid "Settings for %s provider"
@@ -1980,11 +1980,11 @@ msgstr "Помилка"
 
 msgctxt "#30637"
 msgid "Info"
-msgstr ""
+msgstr "Інформація"
 
 msgctxt "#30638"
 msgid "Debug"
-msgstr ""
+msgstr "Налагодження"
 
 msgctxt "#30639"
 msgid "Show Specials in season listings"
@@ -2156,7 +2156,7 @@ msgstr "Видалити дублікати Elementum з бібліотеки"
 
 msgctxt "#30681"
 msgid "[B]Found duplicates in Kodi library:[/B][CR]Movies: [B]%s[/B], Shows: [B]%s[/B], Episodes: [B]%s[/B][CR]Proceed?"
-msgstr ""
+msgstr "[B]Знайдено дублікати у медіатеці Kodi:[/B][CR]Фільми: [B]%s[/B], Серіали: [B]%s[/B], Епізоди: [B]%s[/B][CR]Продовжити?"
 
 msgctxt "#30682"
 msgid "No duplicates were found in Kodi library"
@@ -2164,19 +2164,19 @@ msgstr "Не знайдено дублікатів в бібліотеці Kodi"
 
 msgctxt "#30683"
 msgid "Starting library duplicates removal"
-msgstr ""
+msgstr "Початок видалення дублікатів з медіатеки"
 
 msgctxt "#30684"
 msgid "Removed Movies: %s, Shows: %s, Episodes: %s"
-msgstr ""
+msgstr "Видалено фільмів: %s, серіалів: %s, епізодів: %s"
 
 msgctxt "#30685"
 msgid "Remove movies from Elementum database"
-msgstr ""
+msgstr "Видалити фільми з бази даних Elementum"
 
 msgctxt "#30686"
 msgid "Remove shows from Elementum database"
-msgstr ""
+msgstr "Видалити серіали з бази даних Elementum"
 
 msgctxt "#30687"
 msgid "In Elementum library"
@@ -2224,11 +2224,11 @@ msgstr "Мова Kodi"
 
 msgctxt "#30699"
 msgid "Use earliest release date for progress and calendars"
-msgstr ""
+msgstr "Використовувати найранішу дату виходу для прогресу та календарів"
 
 msgctxt "#30700"
 msgid "Interface fallback language"
-msgstr ""
+msgstr "Резервна мова інтерфейсу"
 
 msgctxt "#30701"
 msgid "English | en"
@@ -2240,7 +2240,7 @@ msgstr "Достигнуто добовий ліміт на завантажен
 
 msgctxt "#30703"
 msgid "Can be used by search providers or [CR]for debugging"
-msgstr ""
+msgstr "Може використовуватися постачальниками пошуку або[CR]для налагодження"
 
 msgctxt "#30704"
 msgid "TMDB API Key check failed, cannot use TMDB service"
@@ -2252,15 +2252,15 @@ msgstr "Не вдалося перевірити доступність API TMDB
 
 msgctxt "#30706"
 msgid "Transmission 4.05"
-msgstr ""
+msgstr "Transmission 4.05"
 
 msgctxt "#30707"
 msgid "qBittorrent 3.3.9"
-msgstr ""
+msgstr "qBittorrent 3.3.9"
 
 msgctxt "#30708"
 msgid "qBittorrent 4.6.4"
-msgstr ""
+msgstr "qBittorrent 4.6.4"
 
 msgctxt "#30709"
 msgid "Open [B]%s[/B]"
@@ -2276,7 +2276,7 @@ msgstr "Видалити торент '%s'?"
 
 msgctxt "#30712"
 msgid "Force to always use proxy, can break download in some cases"
-msgstr ""
+msgstr "Завжди примусово використовувати проксі, у деяких випадках може порушити завантаження"
 
 msgctxt "#30713"
 msgid "Disable NATPMP"
@@ -2284,20 +2284,20 @@ msgstr "Вимкнути NATPMP"
 
 msgctxt "#30714"
 msgid "Re-check torrent's data"
-msgstr ""
+msgstr "Повторно перевірити дані торента"
 
 msgctxt "#30715"
 msgid "Antizapret PAC file URL"
-msgstr ""
+msgstr "URL файлу PAC Antizapret"
 
 msgctxt "#30716"
 msgid "DNS over HTTPS Server"
-msgstr ""
+msgstr "Сервер DNS over HTTPS"
 
 msgctxt "#30717"
 msgid "Custom DNS over HTTPS Server"
-msgstr ""
+msgstr "Власний сервер DNS over HTTPS"
 
 msgctxt "#30718"
 msgid "Use OpenNIC DNS Servers"
-msgstr ""
+msgstr "Використовувати DNS-сервери OpenNIC"


### PR DESCRIPTION
> **Please read this first: these translations were produced with Claude Opus, not by native speakers.**
>
> I am a Spanish speaker. I can vouch for the Spanish (Mexico) file and I checked the mechanics of every string, but I cannot vouch for the wording in the other fifteen languages. You may well want to reject this, take only some files, or wait for native speakers — that is a completely reasonable call and I will not be offended. I am opening it because the alternative is that these strings stay in English indefinitely, and a native speaker correcting a draft is easier than starting from an empty file.

Follow-up to #1194 (Spanish) and #1195 (Argentinian Spanish, Polish, Swedish). This fills every remaining empty `msgstr` in the other sixteen language files — **4748 strings**.

| Language | Strings | | Language | Strings |
|---|---|---|---|---|
| Slovak | 511 | | Portuguese (Brazil) | 401 |
| Spanish (Mexico) | 511 | | Dutch | 394 |
| German | 457 | | Hungarian | 391 |
| Portuguese | 424 | | Finnish | 386 |
| Romanian | 424 | | Hebrew | 332 |
| Greek | 233 | | Italian | 145 |
| Croatian | 48 | | Ukrainian | 39 |
| French | 36 | | Russian | 16 |

Every one of these files is now at 571/571.

## What was checked mechanically

Every string I wrote was verified against the English source for matching counts of `%s`, `[CR]`, `[B]`/`[/B]`, `[I]`/`[/I]` and `[COLOR]`/`[/COLOR]`. Zero mismatches. No existing translation was modified — only empty `msgstr` entries were filled, so the diff is exactly 4748 insertions and 4748 deletions.

Product and protocol names are left alone throughout (`libtorrent`, `Transmission`, `qBittorrent`, `µTorrent`, `Deluge`, `Vuze`, `Antizapret`, `OpenNIC`, `NATPMP`, `LSD`, `PAC`), following what the Russian file does.

## Two cases that needed real care

**Spanish (Mexico)** was derived from the Spanish file, since they are the same language, but not blindly. The Spanish file has five strings whose markup does not match the English source (`[I]` added in 30681 and 30684, an extra `[CR]` in 30349 and 30586, a missing `[CR]` in 30703) and two strings where "earliest" is translated as *más reciente*, the opposite meaning (30607 and 30699 — 30699 also calls a date a *versión*). I wrote all of those to follow the English rather than propagate them. #1194 fixes the two meaning errors in the Spanish file itself; the five markup ones I have left alone there.

**Brazilian Portuguese** is not European Portuguese with a few words swapped. After deriving a draft I went back over 46 strings that carried constructions only used in Portugal: the `A` + infinitive progressive (`A baixar` → `Baixando`), *tu* with enclitic pronouns (`Tens a certeza de que queres` → `Tem certeza de que deseja`), and vocabulary like *base de dados* → *banco de dados* and *fornecedor* → *provedor*. Substituting *transferência* with *download* also breaks gender agreement in five strings, which I caught and rewrote (`Caminho das downloads` → `Caminho dos downloads`).

## If you want a smaller bite

Happy to split this per language, drop any file, or close it entirely. The Spanish (Mexico) file is the one I would stand behind; the rest are offered as drafts for native speakers to correct.
